### PR TITLE
Fixes #85 The NeutralRole class was defined in role.ttl (which is cor…

### DIFF
--- a/uco-victim/victim.ttl
+++ b/uco-victim/victim.ttl
@@ -20,7 +20,7 @@
 
 victim:Victim
 	a owl:Class ;
-	rdfs:subClassOf <http://unifiedcyberontology.org/core/role#NeutralRole> ;
+	rdfs:subClassOf <http://unifiedcyberontology.org/role#NeutralRole> ;
 	rdfs:label "Victim"@en ;
 	rdfs:comment "Person or organization that is the target of some malicious action."@en ;
 	.


### PR DESCRIPTION
…rect). However, in victim.ttl it was referenced with an improper namespace.