### PR TITLE
Modifications to address issue #95

### DIFF
--- a/uco-core/core.ttl
+++ b/uco-core/core.ttl
@@ -495,3 +495,44 @@ core:value
 	rdfs:domain core:ControlledVocabulary ;
 	rdfs:range xsd:string ;
 	.
+
+core:HashNameEnum
+  	a rdfs:Datatype ;
+  	rdfs:comment "An enumeration of common hashing algorithm names."@en ;
+  	owl:equivalentClass [
+  		a rdfs:Datatype ;
+  		owl:oneOf [
+  			a rdf:List ;
+  			rdf:first "MD5" ;
+  			rdf:rest [
+  				a rdf:List ;
+  				rdf:first "MD6" ;
+  				rdf:rest [
+  					a rdf:List ;
+  					rdf:first "SHA1" ;
+  					rdf:rest [
+  						a rdf:List ;
+  						rdf:first "SHA224" ;
+  						rdf:rest [
+  							a rdf:List ;
+  							rdf:first "SHA256" ;
+  							rdf:rest [
+  								a rdf:List ;
+  								rdf:first "SHA384" ;
+  								rdf:rest [
+  									a rdf:List ;
+  									rdf:first "SHA512" ;
+  									rdf:rest [
+  										a rdf:List ;
+  										rdf:first "SSDEEP" ;
+  										rdf:rest rdf:nil ;
+  									] ;
+  								] ;
+  							] ;
+  						] ;
+  					] ;
+  				] ;
+  			] ;
+  		] ;
+  	] ;
+  	.

--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -3840,47 +3840,6 @@
 	rdfs:comment "Specifies HTTP-specific network connection properties."@en ;
 	.
 
-:HashNameEnum
-	a rdfs:Datatype ;
-	rdfs:comment "An enumeration of common hashing algorithm names."@en ;
-	owl:equivalentClass [
-		a rdfs:Datatype ;
-		owl:oneOf [
-			a rdf:List ;
-			rdf:first "MD5" ;
-			rdf:rest [
-				a rdf:List ;
-				rdf:first "MD6" ;
-				rdf:rest [
-					a rdf:List ;
-					rdf:first "SHA1" ;
-					rdf:rest [
-						a rdf:List ;
-						rdf:first "SHA224" ;
-						rdf:rest [
-							a rdf:List ;
-							rdf:first "SHA256" ;
-							rdf:rest [
-								a rdf:List ;
-								rdf:first "SHA384" ;
-								rdf:rest [
-									a rdf:List ;
-									rdf:first "SHA512" ;
-									rdf:rest [
-										a rdf:List ;
-										rdf:first "SSDEEP" ;
-										rdf:rest rdf:nil ;
-									] ;
-								] ;
-							] ;
-						] ;
-					] ;
-				] ;
-			] ;
-		] ;
-	] ;
-	.
-
 :ICCID
 	a owl:DatatypeProperty ;
 	rdfs:label "ICCID"@en ;

--- a/uco-types/types.ttl
+++ b/uco-types/types.ttl
@@ -160,7 +160,7 @@ types:hashMethod
 	rdfs:label "hashMethod"@en ;
 	rdfs:comment "A particular cryptographic hashing method (e.g., MD5)."@en ;
 	rdfs:domain types:Hash ;
-	rdfs:range xsd:string ;
+	rdfs:range <http://unifiedcyberontology.org/core#HashNameEnum> ;
 	.
 
 types:hashValue
@@ -197,4 +197,3 @@ types:value
 		;
 	rdfs:range xsd:string ;
 	.
-


### PR DESCRIPTION
Moved the existing observable:HashNameEnum datatype definition to core.ttl as core:HashNameEnum to allow it to be used as a range within types.ttl without adding any more unecessary imports.

Removed observable:HashNameEnum.
Modified range of types:hashMethod to be core:HashNameEnum.