### PR TITLE
Modifications to address issue #63

### DIFF
--- a/uco-core/core.ttl
+++ b/uco-core/core.ttl
@@ -462,6 +462,7 @@ core:startTime
 	rdfs:label "startTime"@en ;
 	rdfs:comment "The initial time of a time range."@en ;
 	rdfs:domain core:Relationship ;
+  rdfs:range xsd:dateTime ;
 	.
 
 core:statement

--- a/uco-investigation/investigation.ttl
+++ b/uco-investigation/investigation.ttl
@@ -11,6 +11,14 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+<http://unifiedcyberontology.org/core#endTime>
+  rdfs:domain investigation:Authorization ;
+.
+
+<http://unifiedcyberontology.org/core#startTime>
+  rdfs:domain investigation:Authorization ;
+.
+
 <http://unifiedcyberontology.org/investigation>
 	a owl:Ontology ;
 	rdfs:label "uco-investigation"@en ;
@@ -43,6 +51,18 @@ investigation:Authorization
 			owl:onProperty investigation:authorizationIdentifier ;
 			owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
+		],
+    [
+			a owl:Restriction ;
+			owl:onProperty <http://unifiedcyberontology.org/core#endTime> ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:dateTime ;
+		],
+    [
+			a owl:Restriction ;
+			owl:onProperty <http://unifiedcyberontology.org/core#startTime> ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:dateTime ;
 		]
 		;
 	rdfs:label "Authorization"@en ;


### PR DESCRIPTION
Added the missing range definition of xsd:dateTime to core:startTime (this was fixing a bug)

Added core:endTime and core:startTime as optional properties on investigation:Authorization