### PR TITLE
Modifications to address issue #114

### DIFF
--- a/uco-action/action.ttl
+++ b/uco-action/action.ttl
@@ -244,7 +244,11 @@ action:ActionStatusTypeEnum
 
 action:ArrayOfAction
 	a owl:Class ;
-	rdfs:subClassOf <http://unifiedcyberontology.org/types#ArrayOfObject> ;
+  rdfs:subClassOf [
+		a owl:Restriction ;
+		owl:onProperty action:action ;
+		owl:minCardinality "1"^^xsd:nonNegativeInteger ;
+	] ;
 	rdfs:label "ArrayOfAction"@en ;
 	rdfs:comment "An ordered list of action object references."@en ;
 	.
@@ -259,6 +263,14 @@ action:TrendEnum
 		) ;
 	] ;
 	.
+
+action:action
+  	a owl:ObjectProperty ;
+  	rdfs:label "action"@en ;
+  	rdfs:comment "A characterization of a single action."@en ;
+  	rdfs:domain action:ArrayOfAction ;
+  	rdfs:range action:Action;
+  	.
 
 action:actionCount
 	a owl:DatatypeProperty ;
@@ -452,4 +464,3 @@ action:value
 	rdfs:domain action:ActionArgument ;
 	rdfs:range xsd:string ;
 	.
-

--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -4197,6 +4197,12 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 			owl:onProperty :visibility ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
+		],
+    [
+			a owl:Restriction ;
+			owl:onProperty :message ;
+			owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange :CyberItem;
 		]
 		;
 	rdfs:label "MessageThread"@en ;
@@ -9063,7 +9069,7 @@ How does this relate to Application?
 	rdfs:label "hashes"@en ;
 	rdfs:comment "Specifies any hashes computed over the section."@en ;
 	rdfs:domain :WindowsPESection ;
-	rdfs:range <http://unifiedcyberontology.org/types#ArrayOfHash> ;
+	rdfs:range <http://unifiedcyberontology.org/types#Hash>  ;
 	.
 
 :headerRaw
@@ -9668,7 +9674,7 @@ How does this relate to Application?
 	a owl:ObjectProperty ;
 	rdfs:label "message"@en ;
 	rdfs:domain :MessageThread ;
-	rdfs:range <http://unifiedcyberontology.org/types#ArrayOfObject> ;
+	rdfs:range :CyberItem ;
 	.
 
 :messageID

--- a/uco-types/types.ttl
+++ b/uco-types/types.ttl
@@ -14,35 +14,6 @@
 	owl:imports <http://unifiedcyberontology.org/core> ;
 	.
 
-types:ArrayOfHash
-	a owl:Class ;
-	rdfs:subClassOf [
-		a owl:Restriction ;
-		owl:onProperty types:hash ;
-		owl:onClass types:Hash ;
-		owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-	] ;
-	rdfs:label "ArrayOfHash"@en ;
-	rdfs:comment "An ordered list of hash values."@en ;
-	.
-
-types:ArrayOfObject
-	a owl:Class ;
-	rdfs:subClassOf [
-		a owl:Restriction ;
-		owl:onProperty types:object ;
-		owl:minCardinality "1"^^xsd:nonNegativeInteger ;
-	] ;
-	rdfs:label "ArrayOfObject"@en ;
-	rdfs:comment "An ordered list of object references."@en ;
-	.
-
-types:ArrayOfString
-	a owl:Class ;
-	rdfs:label "ArrayOfString"@en ;
-	rdfs:comment "An ordered list of string values."@en ;
-	.
-
 types:ControlledDictionary
 	a owl:Class ;
 	rdfs:subClassOf [
@@ -147,14 +118,6 @@ types:entry
 	rdfs:range types:DictionaryEntry ;
 	.
 
-types:hash
-	a owl:ObjectProperty ;
-	rdfs:label "hash"@en ;
-	rdfs:comment "A single calculated hash."@en ;
-	rdfs:domain types:ArrayOfHash ;
-	rdfs:range types:Hash ;
-	.
-
 types:hashMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "hashMethod"@en ;
@@ -179,21 +142,10 @@ types:key
 	rdfs:range xsd:string ;
 	.
 
-types:object
-	a owl:ObjectProperty ;
-	rdfs:label "object"@en ;
-	rdfs:comment "A single UCO object."@en ;
-	rdfs:domain types:ArrayOfObject ;
-	rdfs:range <http://unifiedcyberontology.org/core#UcoObject> ;
-	.
-
 types:value
 	a owl:DatatypeProperty ;
 	rdfs:label "value"@en ;
 	rdfs:comment "A specific property value."@en ;
-	rdfs:domain
-		types:ArrayOfString ,
-		types:ControlledDictionaryEntry
-		;
+	rdfs:domain types:ControlledDictionaryEntry;
 	rdfs:range xsd:string ;
 	.


### PR DESCRIPTION
observables.ttl
Removed ArrayOfHash, ArrayOfObject and ArrayOfString classes
Removed types:hash property
Removed types:object property
Removed ArrayOfString from domain of types:value property

action.ttl
Modified action:ArrayOfAction to locally define it as a list of action:action specifically rather than as a subclass of types:ArrayOfObject
Added action:action object to convey a single Action as part of an ArrayOfAction

observable.ttl
Modified range of observable:hashes to be types:Hash rather than types:ArrayOfHash
Modified range of observable:message to be observable:CyberIterm rather than ArrayOfObject
Modified owl:onDataRange of observable:message property restriction on the observable:MessageThread class to by observable:CyberItem