### PR TITLE
Address Issue 135 - Put observable prefix back into observable.ttl

### DIFF
--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -6,7 +6,7 @@
 # imports: https://unifiedcyberontology.org/ontology/uco/types
 
 @base <https://unifiedcyberontology.org/ontology/uco/observable> .
-@prefix : <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -25,49 +25,49 @@
 		;
 	.
 
-:Account
+observable:Account
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accountIssuer ;
+			owl:onProperty observable:accountIssuer ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accountType ;
+			owl:onProperty observable:accountType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :expirationTime ;
+			owl:onProperty observable:expirationTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :modifiedTime ;
+			owl:onProperty observable:modifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :owner ;
+			owl:onProperty observable:owner ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isActive ;
+			owl:onProperty observable:isActive ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accountIdentifier ;
+			owl:onProperty observable:accountIdentifier ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -76,24 +76,24 @@
 	rdfs:comment "The fundamental properties of an account."@en ;
 	.
 
-:AccountAuthentication
+observable:AccountAuthentication
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :passwordLastChanged ;
+			owl:onProperty observable:passwordLastChanged ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :password ;
+			owl:onProperty observable:password ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :passwordType ;
+			owl:onProperty observable:passwordType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -101,7 +101,7 @@
 	rdfs:label "AccountAuthentication"@en ;
 	.
 
-:AccountType
+observable:AccountType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -141,7 +141,7 @@
 	] ;
 	.
 
-:ActionArgumentNameEnum
+observable:ActionArgumentNameEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of common arguments for cyber actions."@en ;
 	owl:equivalentClass [
@@ -354,7 +354,7 @@
 	] ;
 	.
 
-:ActionNameEnum
+observable:ActionNameEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of common specific cyber action names."@en ;
 	owl:equivalentClass [
@@ -1087,7 +1087,7 @@
 	] ;
 	.
 
-:ActionTypeEnum
+observable:ActionTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of common general action types."@en ;
 	owl:equivalentClass [
@@ -1540,17 +1540,17 @@
 	] ;
 	.
 
-:AlternateDataStream
+observable:AlternateDataStream
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :hashes ;
+			owl:onProperty observable:hashes ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :size ;
+			owl:onProperty observable:size ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
@@ -1564,31 +1564,31 @@
 	rdfs:label "AlternateDataStream"@en ;
 	.
 
-:Application
+observable:Application
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :operatingSystem ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:operatingSystem ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :numberOfLaunches ;
+			owl:onProperty observable:numberOfLaunches ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :applicationIdentifier ;
+			owl:onProperty observable:applicationIdentifier ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :version ;
+			owl:onProperty observable:version ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -1597,14 +1597,14 @@
 	rdfs:comment "Characteristics of a software application."@en ;
 	.
 
-:ApplicationAccount
+observable:ApplicationAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -1612,25 +1612,25 @@
 	rdfs:comment "Characteristics of an account within a particular application."@en ;
 	.
 
-:ArchiveFile
+observable:ArchiveFile
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :archiveType ;
+			owl:onProperty observable:archiveType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :comment ;
+			owl:onProperty observable:comment ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :version ;
+			owl:onProperty observable:version ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -1638,37 +1638,37 @@
 	rdfs:label "ArchiveFile"@en ;
 	.
 
-:Attachment
+observable:Attachment
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "Attachment"@en ;
 	.
 
-:Audio
+observable:Audio
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :bitRate ;
+			owl:onProperty observable:bitRate ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :duration ;
+			owl:onProperty observable:duration ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :audioType ;
+			owl:onProperty observable:audioType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :format ;
+			owl:onProperty observable:format ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -1677,24 +1677,24 @@
 	rdfs:comment "Characteristics of piece of digital audio."@en ;
 	.
 
-:AutonomousSystem
+observable:AutonomousSystem
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :regionalInternetRegistry ;
+			owl:onProperty observable:regionalInternetRegistry ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :asHandle ;
+			owl:onProperty observable:asHandle ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :number ;
+			owl:onProperty observable:number ;
 			owl:onDataRange xsd:integer ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -1703,7 +1703,7 @@
 	rdfs:comment "Basic characteristics of an Internet autonomous system."@en ;
 	.
 
-:BitnessEnum
+observable:BitnessEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of word sizes that define classes of operating systems."@en ;
 	owl:equivalentClass [
@@ -1720,13 +1720,13 @@
 	] ;
 	.
 
-:BluetoothAddress
+observable:BluetoothAddress
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :addressValue ;
+			owl:onProperty observable:addressValue ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -1735,40 +1735,40 @@
 	rdfs:comment "Properties of a Bluetooth address."@en ;
 	.
 
-:BrowserBookmark
+observable:BrowserBookmark
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accessedTime ;
+			owl:onProperty observable:accessedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :modifiedTime ;
+			owl:onProperty observable:modifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :visitCount ;
+			owl:onProperty observable:visitCount ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :bookmarkPath ;
+			owl:onProperty observable:bookmarkPath ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -1777,52 +1777,52 @@
 	rdfs:comment "A bookmark to a web pages or files using a web browser."@en ;
 	.
 
-:BrowserCookie
+observable:BrowserCookie
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accessedTime ;
+			owl:onProperty observable:accessedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :expirationTime ;
+			owl:onProperty observable:expirationTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :cookieDomain ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:cookieDomain ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isSecure ;
+			owl:onProperty observable:isSecure ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :cookieName ;
+			owl:onProperty observable:cookieName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :cookiePath ;
+			owl:onProperty observable:cookiePath ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -1831,20 +1831,20 @@
 	rdfs:comment "A piece of data used by a (remote) web page, stored on the local machine."@en ;
 	.
 
-:Calendar
+observable:Calendar
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :owner ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:owner ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -1852,84 +1852,84 @@
 	rdfs:comment "A collection of appointments and meetings."@en ;
 	.
 
-:CalendarEntry
+observable:CalendarEntry
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :endTime ;
+			owl:onProperty observable:endTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :location ;
+			owl:onProperty observable:location ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :modifiedTime ;
+			owl:onProperty observable:modifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :owner ;
+			owl:onProperty observable:owner ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :remindTime ;
+			owl:onProperty observable:remindTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :startTime ;
+			owl:onProperty observable:startTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isPrivate ;
+			owl:onProperty observable:isPrivate ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :duration ;
+			owl:onProperty observable:duration ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :eventStatus ;
+			owl:onProperty observable:eventStatus ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :eventType ;
+			owl:onProperty observable:eventType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :recurrence ;
+			owl:onProperty observable:recurrence ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subject ;
+			owl:onProperty observable:subject ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -1938,7 +1938,7 @@
 	rdfs:comment "Characteristics of an entry (appointment, meeting, event) within a calendar."@en ;
 	.
 
-:CharacterEncodingEnum
+observable:CharacterEncodingEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of character encodings."@en ;
 	owl:equivalentClass [
@@ -1999,19 +1999,19 @@
 	] ;
 	.
 
-:CompressedStream
+observable:CompressedStream
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :compressionRatio ;
+			owl:onProperty observable:compressionRatio ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:double ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :compressionMethod ;
+			owl:onProperty observable:compressionMethod ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -2020,117 +2020,117 @@
 	rdfs:comment "Characteristics of compression applied to a body of data content."@en ;
 	.
 
-:ComputerSpecification
+observable:ComputerSpecification
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :biosDate ;
+			owl:onProperty observable:biosDate ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :biosReleaseDate ;
+			owl:onProperty observable:biosReleaseDate ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :localTime ;
+			owl:onProperty observable:localTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :systemTime ;
+			owl:onProperty observable:systemTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :currentSystemDate ;
+			owl:onProperty observable:currentSystemDate ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:dateTime ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :availableRam ;
+			owl:onProperty observable:availableRam ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :totalRam ;
+			owl:onProperty observable:totalRam ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :biosManufacturer ;
+			owl:onProperty observable:biosManufacturer ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :biosSerialNumber ;
+			owl:onProperty observable:biosSerialNumber ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :biosVersion ;
+			owl:onProperty observable:biosVersion ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :cpu ;
+			owl:onProperty observable:cpu ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :cpuFamily ;
+			owl:onProperty observable:cpuFamily ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :gpu ;
+			owl:onProperty observable:gpu ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :gpuFamily ;
+			owl:onProperty observable:gpuFamily ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :hostname ;
+			owl:onProperty observable:hostname ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :processorArchitecture ;
+			owl:onProperty observable:processorArchitecture ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :timezoneDST ;
+			owl:onProperty observable:timezoneDST ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :timezoneStandard ;
+			owl:onProperty observable:timezoneStandard ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :uptime ;
+			owl:onProperty observable:uptime ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -2139,55 +2139,55 @@
 	rdfs:comment "Characterizes a computer system (as a combination of both software and hardware)."@en ;
 	.
 
-:Contact
+observable:Contact
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contactID ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:string ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :contactName ;
+			owl:onProperty observable:contactID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contactType ;
+			owl:onProperty observable:contactName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :firstName ;
+			owl:onProperty observable:contactType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :lastName ;
+			owl:onProperty observable:firstName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :middleName ;
+			owl:onProperty observable:lastName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :screenName ;
+			owl:onProperty observable:middleName ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:screenName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -2196,60 +2196,60 @@
 	rdfs:comment "Contact found in an application, for example an entry in an address book."@en ;
 	.
 
-:ContentData
+observable:ContentData
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :byteOrder ;
+			owl:onProperty observable:byteOrder ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :dataPayloadReferenceURL ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:dataPayloadReferenceURL ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isEncrypted ;
+			owl:onProperty observable:isEncrypted ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :entropy ;
+			owl:onProperty observable:entropy ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:double ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sizeInBytes ;
+			owl:onProperty observable:sizeInBytes ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :dataPayload ;
+			owl:onProperty observable:dataPayload ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :magicNumber ;
+			owl:onProperty observable:magicNumber ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mimeClass ;
+			owl:onProperty observable:mimeClass ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mimeType ;
+			owl:onProperty observable:mimeType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -2258,29 +2258,29 @@
 	rdfs:comment "Characteristics of a block of digital data."@en ;
 	.
 
-:CyberAction
+observable:CyberAction
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/action#Action> ,
-		:Observable
+		observable:Observable
 		;
 	rdfs:label "CyberAction"@en ;
 	rdfs:comment "Something that may be done or performed within the digital domain."@en ;
 	.
 
-:CyberItem
+observable:CyberItem
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Item> ,
-		:Observable ,
+		observable:Observable ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :state ;
+			owl:onProperty observable:state ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :hasChanged ;
+			owl:onProperty observable:hasChanged ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -2289,7 +2289,7 @@
 	rdfs:comment "A distinct article or unit within the digital domain."@en ;
 	.
 
-:CyberItemRelationshipEnum
+observable:CyberItemRelationshipEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of inter-cyberitem relationships."@en ;
 	owl:equivalentClass [
@@ -2842,7 +2842,7 @@
 	] ;
 	.
 
-:CyberItemStateEnum
+observable:CyberItemStateEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of cyberitem states."@en ;
 	owl:equivalentClass [
@@ -2891,42 +2891,42 @@
 	] ;
 	.
 
-:CyberObservablePattern
+observable:CyberObservablePattern
 	a owl:Class ;
-	rdfs:subClassOf :Observable ;
+	rdfs:subClassOf observable:Observable ;
 	rdfs:label "CyberObservablePattern"@en ;
 	rdfs:comment "A logical pattern composed of cyberitem and cyberaction properties."@en ;
 	.
 
-:CyberRelationship
+observable:CyberRelationship
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Relationship> ,
-		:Observable
+		observable:Observable
 		;
 	rdfs:label "CyberRelationship"@en ;
 	rdfs:comment "An association or link between two cyber observable objects."@en ;
 	.
 
-:DataRange
+observable:DataRange
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :rangeOffset ;
+			owl:onProperty observable:rangeOffset ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :rangeSize ;
+			owl:onProperty observable:rangeSize ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :rangeOffsetType ;
+			owl:onProperty observable:rangeOffsetType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -2935,37 +2935,37 @@
 	rdfs:comment "Bounding characteristics of a range within a block of digital data."@en ;
 	.
 
-:DefinedEffectFacet
+observable:DefinedEffectFacet
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "DefinedEffectFacet"@en ;
 	rdfs:comment "A set of properties characterizing some defined effect of a cyberaction in relation to one or more cyberitems."@en ;
 	.
 
-:Device
+observable:Device
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :deviceType ;
+			owl:onProperty observable:deviceType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :manufacturer ;
+			owl:onProperty observable:manufacturer ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :model ;
+			owl:onProperty observable:model ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :serialNumber ;
+			owl:onProperty observable:serialNumber ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -2974,29 +2974,29 @@
 	rdfs:comment "Characteristics of a piece of electronic equipment."@en ;
 	.
 
-:DigitalAccount
+observable:DigitalAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :firstLoginTime ;
+			owl:onProperty observable:firstLoginTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :lastLoginTime ;
+			owl:onProperty observable:lastLoginTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isDisabled ;
+			owl:onProperty observable:isDisabled ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :displayName ;
+			owl:onProperty observable:displayName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3005,35 +3005,35 @@
 	rdfs:comment "Characteristics of an account within the digital domain."@en ;
 	.
 
-:DigitalSignatureInfo
+observable:DigitalSignatureInfo
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :certificateIssuer ;
+			owl:onProperty observable:certificateIssuer ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :certificateSubject ;
+			owl:onProperty observable:certificateSubject ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :signatureDescription ;
+			owl:onProperty observable:signatureDescription ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :signatureExists ;
+			owl:onProperty observable:signatureExists ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :signatureVerified ;
+			owl:onProperty observable:signatureVerified ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -3042,24 +3042,24 @@
 	rdfs:comment "Characteristics of a value calculated via a mathematical scheme for demonstrating the authenticity of a digital message or documents."@en ;
 	.
 
-:Disk
+observable:Disk
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :diskType ;
+			owl:onProperty observable:diskType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :diskSize ;
+			owl:onProperty observable:diskSize ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :freeSpace ;
+			owl:onProperty observable:freeSpace ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		]
@@ -3067,59 +3067,59 @@
 	rdfs:label "Disk"@en ;
 	.
 
-:DiskPartition
+observable:DiskPartition
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :diskPartitionType ;
+			owl:onProperty observable:diskPartitionType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :partitionID ;
+			owl:onProperty observable:partitionID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :partitionLength ;
+			owl:onProperty observable:partitionLength ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :partitionOffset ;
+			owl:onProperty observable:partitionOffset ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :spaceLeft ;
+			owl:onProperty observable:spaceLeft ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :spaceUsed ;
+			owl:onProperty observable:spaceUsed ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :totalSpace ;
+			owl:onProperty observable:totalSpace ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mountPoint ;
+			owl:onProperty observable:mountPoint ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3128,7 +3128,7 @@
 	rdfs:comment "Characteristics of a region on a hard disk or other secondary storage."@en ;
 	.
 
-:DiskTypeEnum
+observable:DiskTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "A non-exhaustive enumeration of disk types."@en ;
 	owl:equivalentClass [
@@ -3157,19 +3157,19 @@
 	] ;
 	.
 
-:DomainName
+observable:DomainName
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isTLD ;
+			owl:onProperty observable:isTLD ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :value ;
+			owl:onProperty observable:value ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -3178,21 +3178,21 @@
 	rdfs:comment "Characteristics of an identification string that defines a realm of administrative autonomy, authority or control within the Internet."@en ;
 	.
 
-:ESN
+observable:ESN
 	a owl:DatatypeProperty ;
 	rdfs:label "ESN"@en ;
 	rdfs:comment "Electronic Serial Number ."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:string ;
 	.
 
-:EXIF
+observable:EXIF
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :exifData ;
+			owl:onProperty observable:exifData ;
 			owl:minCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3200,14 +3200,14 @@
 	rdfs:comment "Specifies exchangeable image file format (Exif) metadata tags for image and sound files recorded by digital cameras."@en ;
 	.
 
-:EmailAccount
+observable:EmailAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :emailAddress ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:emailAddress ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3215,19 +3215,19 @@
 	rdfs:comment "Characteristics of an account within an email domain."@en ;
 	.
 
-:EmailAddress
+observable:EmailAddress
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :displayName ;
+			owl:onProperty observable:displayName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :value ;
+			owl:onProperty observable:value ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -3236,129 +3236,129 @@
 	rdfs:comment "Characteristics of an identifier for an email box to which email messages are delivered."@en ;
 	.
 
-:EmailMessage
+observable:EmailMessage
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :modifiedTime ;
+			owl:onProperty observable:modifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :otherHeaders ;
+			owl:onProperty observable:otherHeaders ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :receivedTime ;
+			owl:onProperty observable:receivedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sentTime ;
+			owl:onProperty observable:sentTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :bodyRaw ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:bodyRaw ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :from ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:from ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :headerRaw ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:headerRaw ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :inReplyTo ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:inReplyTo ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sender ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:sender ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :xOriginatingIP ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:xOriginatingIP ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isRead ;
+			owl:onProperty observable:isRead ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :body ;
+			owl:onProperty observable:body ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contentDisposition ;
+			owl:onProperty observable:contentDisposition ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contentType ;
+			owl:onProperty observable:contentType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :messageID ;
+			owl:onProperty observable:messageID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :priority ;
+			owl:onProperty observable:priority ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subject ;
+			owl:onProperty observable:subject ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :xMailer ;
+			owl:onProperty observable:xMailer ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isMimeEncoded ;
+			owl:onProperty observable:isMimeEncoded ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isMultipart ;
+			owl:onProperty observable:isMultipart ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -3367,13 +3367,13 @@
 	rdfs:comment "An instance of an email message, corresponding to the internet message format described in RFC 5322 and related RFCs."@en ;
 	.
 
-:EncodedStream
+observable:EncodedStream
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :encodingMethod ;
+			owl:onProperty observable:encodingMethod ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3382,18 +3382,18 @@
 	rdfs:comment "Represents the encoding-related properties of some encoded thing."@en ;
 	.
 
-:EncryptedStream
+observable:EncryptedStream
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :encryptionMethod ;
+			owl:onProperty observable:encryptionMethod ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :encryptionMode ;
+			owl:onProperty observable:encryptionMode ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3401,7 +3401,7 @@
 	rdfs:comment "Represents the encryption-related properties of some encrypted thing."@en ;
 	.
 
-:EndiannessTypeEnum
+observable:EndiannessTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "A non-exhaustive eumeration of byte ordering methods."@en ;
 	owl:equivalentClass [
@@ -3422,12 +3422,12 @@
 	] ;
 	.
 
-:EnvironmentVariable
+observable:EnvironmentVariable
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :value ;
+			owl:onProperty observable:value ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
@@ -3442,49 +3442,49 @@
 	rdfs:comment "Represents the properties of an environment variable."@en ;
 	.
 
-:Event
+observable:Event
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :cyberAction ;
-			owl:onClass :CyberAction ;
+			owl:onProperty observable:cyberAction ;
+			owl:onClass observable:CyberAction ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :computerName ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:string ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :eventID ;
+			owl:onProperty observable:computerName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :eventText ;
+			owl:onProperty observable:eventID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :eventType ;
+			owl:onProperty observable:eventText ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:eventType ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3492,59 +3492,59 @@
 	rdfs:comment "An event, mainly used for operating system events."@en ;
 	.
 
-:ExtInode
+observable:ExtInode
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extDeletionTime ;
+			owl:onProperty observable:extDeletionTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extInodeChangeTime ;
+			owl:onProperty observable:extInodeChangeTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extFileType ;
+			owl:onProperty observable:extFileType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extFlags ;
+			owl:onProperty observable:extFlags ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extHardLinkCount ;
+			owl:onProperty observable:extHardLinkCount ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extInodeID ;
+			owl:onProperty observable:extInodeID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extPermissions ;
+			owl:onProperty observable:extPermissions ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extSGID ;
+			owl:onProperty observable:extSGID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extSUID ;
+			owl:onProperty observable:extSUID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		]
@@ -3553,44 +3553,44 @@
 	rdfs:comment "Characterizes the details of a single EXT file."@en ;
 	.
 
-:ExtractedString
+observable:ExtractedString
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :address ;
+			owl:onProperty observable:address ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :byteStringValue ;
+			owl:onProperty observable:byteStringValue ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :encoding ;
+			owl:onProperty observable:encoding ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :language ;
+			owl:onProperty observable:language ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :length ;
+			owl:onProperty observable:length ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :englishTranslation ;
+			owl:onProperty observable:englishTranslation ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :stringValue ;
+			owl:onProperty observable:stringValue ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3599,57 +3599,57 @@
 	rdfs:comment "A string extracted from a cyber item."@en ;
 	.
 
-:ExtractedStrings
+observable:ExtractedStrings
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "ExtractedStrings"@en ;
 	rdfs:comment "One or more strings extracted from a cyber item."@en ;
 	.
 
-:File
+observable:File
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accessedTime ;
+			owl:onProperty observable:accessedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :fileSystemType ;
+			owl:onProperty observable:fileSystemType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :metadataChangeTime ;
+			owl:onProperty observable:metadataChangeTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :modifiedTime ;
+			owl:onProperty observable:modifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sizeInBytes ;
+			owl:onProperty observable:sizeInBytes ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :allocationStatus ;
+			owl:onProperty observable:allocationStatus ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extension ;
+			owl:onProperty observable:extension ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3658,14 +3658,14 @@
 	rdfs:comment "The basic properties associated with the storage of a file on a file system."@en ;
 	.
 
-:FilePermissions
+observable:FilePermissions
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :owner ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:owner ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3673,18 +3673,18 @@
 	rdfs:comment "Characteristics of permissions or access rights for a file."@en ;
 	.
 
-:FileSystem
+observable:FileSystem
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :fileSystemType ;
+			owl:onProperty observable:fileSystemType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :clusterSize ;
+			owl:onProperty observable:clusterSize ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		]
@@ -3693,31 +3693,31 @@
 	rdfs:comment "Represents the properties of a file system."@en ;
 	.
 
-:Fragment
+observable:Fragment
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "Fragment"@en ;
 	rdfs:comment "Characteristics of an individual fragment of a file."@en ;
 	.
 
-:GeoLocationEntry
+observable:GeoLocationEntry
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :location ;
+			owl:onProperty observable:location ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3725,19 +3725,19 @@
 	rdfs:comment "Characteristics of a single application-specific geolocation entry."@en ;
 	.
 
-:GeoLocationLog
+observable:GeoLocationLog
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3745,24 +3745,24 @@
 	rdfs:comment "A log containing geolocation tracks and/or geolocation entries."@en ;
 	.
 
-:GeoLocationTrack
+observable:GeoLocationTrack
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :endTime ;
+			owl:onProperty observable:endTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :startTime ;
+			owl:onProperty observable:startTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -3770,24 +3770,24 @@
 	rdfs:comment "Characteristics of a set of contiguous geolocation entries representing a path/track taken."@en ;
 	.
 
-:GlobalFlagType
+observable:GlobalFlagType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :abbreviation ;
+			owl:onProperty observable:abbreviation ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :destination ;
+			owl:onProperty observable:destination ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :symbolicName ;
+			owl:onProperty observable:symbolicName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3796,42 +3796,42 @@
 	rdfs:comment "Characterizes Windows global flags."@en ;
 	.
 
-:HTTPConnection
+observable:HTTPConnection
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :httpRequestHeader ;
+			owl:onProperty observable:httpRequestHeader ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :httpMessageBodyData ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:httpMessageBodyData ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :httpMesageBodyLength ;
+			owl:onProperty observable:httpMesageBodyLength ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :requestVersion ;
+			owl:onProperty observable:requestVersion ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :requestMethod ;
+			owl:onProperty observable:requestMethod ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :requestValue ;
+			owl:onProperty observable:requestValue ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -3840,33 +3840,33 @@
 	rdfs:comment "Specifies HTTP-specific network connection properties."@en ;
 	.
 
-:ICCID
+observable:ICCID
 	a owl:DatatypeProperty ;
 	rdfs:label "ICCID"@en ;
 	rdfs:comment "Integrated circuit card identifier (http://www.itu.int/)."@en ;
-	rdfs:domain :SIMCard ;
+	rdfs:domain observable:SIMCard ;
 	rdfs:range xsd:string ;
 	.
 
-:ICMPConnection
+observable:ICMPConnection
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "ICMPConnection"@en ;
 	rdfs:comment "Specifies ICMP-specific network connection properties."@en ;
 	.
 
-:IComHandlerActionType
+observable:IComHandlerActionType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :comClassID ;
+			owl:onProperty observable:comClassID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :comData ;
+			owl:onProperty observable:comData ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3875,24 +3875,24 @@
 	rdfs:comment "Characterizes IComHandler actions."@en ;
 	.
 
-:IExecActionType
+observable:IExecActionType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :execArguments ;
+			owl:onProperty observable:execArguments ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :execProgramPath ;
+			owl:onProperty observable:execProgramPath ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :execWorkingDirectory ;
+			owl:onProperty observable:execWorkingDirectory ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3901,32 +3901,32 @@
 	rdfs:comment "Characterizes IExec actions."@en ;
 	.
 
-:IMEI
+observable:IMEI
 	a owl:DatatypeProperty ;
 	rdfs:label "IMEI"@en ;
 	rdfs:comment "International Mobile Equipment Identity (IMEI)."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:string ;
 	.
 
-:IMSI
+observable:IMSI
 	a owl:DatatypeProperty ;
 	rdfs:label "IMSI"@en ;
 	rdfs:comment "An International Mobile Subscriber Identity (IMSI) is a unique identification associated with all GSM and UMTS network mobile phone users. It is stored as a 64-bit field in the SIM inside the phone and is sent by the phone to the network."@en ;
 	rdfs:domain
-		:MobileAccount ,
-		:SIMCard
+		observable:MobileAccount ,
+		observable:SIMCard
 		;
 	rdfs:range xsd:string ;
 	.
 
-:IPv4Address
+observable:IPv4Address
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :value ;
+			owl:onProperty observable:value ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -3935,13 +3935,13 @@
 	rdfs:comment "Characteristics of an IPv4 internet protocol address."@en ;
 	.
 
-:IPv6Address
+observable:IPv6Address
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :value ;
+			owl:onProperty observable:value ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -3950,18 +3950,18 @@
 	rdfs:comment "Characteristics of an IPv6 internet protocol address."@en ;
 	.
 
-:IShowMessageActionType
+observable:IShowMessageActionType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :showMessageBody ;
+			owl:onProperty observable:showMessageBody ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :showMessageTitle ;
+			owl:onProperty observable:showMessageTitle ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3970,13 +3970,13 @@
 	rdfs:comment "Characterizes IShowMessage actions."@en ;
 	.
 
-:Image
+observable:Image
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :imageType ;
+			owl:onProperty observable:imageType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -3985,13 +3985,13 @@
 	rdfs:comment "Characteristics of a complete copy of a hard disk, memory or other digital media."@en ;
 	.
 
-:Library
+observable:Library
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :libraryType ;
+			owl:onProperty observable:libraryType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -4002,7 +4002,7 @@
 What about Android Package and iOS Package and Windows MSI?"""@en ;
 	.
 
-:LibraryTypeEnum
+observable:LibraryTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of library types."@en ;
 	owl:equivalentClass [
@@ -4031,13 +4031,13 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:MACAddress
+observable:MACAddress
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :value ;
+			owl:onProperty observable:value ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -4046,61 +4046,61 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of a media access control (MAC) address identifier assigned to network interfaces for communications at the data link layer of a network segment."@en ;
 	.
 
-:MSISDN
+observable:MSISDN
 	a owl:DatatypeProperty ;
 	rdfs:label "MSISDN"@en ;
 	rdfs:comment "Mobile Station International Subscriber Directory Number (MSISDN) is a number used to identify a mobile phone number internationally. MSISDN is defined by the E.164 numbering plan. This number includes a country code and a National Destination Code which identifies the subscriber's operator."@en ;
 	rdfs:domain
-		:MobileAccount ,
-		:MobileDevice
+		observable:MobileAccount ,
+		observable:MobileDevice
 		;
 	rdfs:range xsd:string ;
 	.
 
-:MSISDNType
+observable:MSISDNType
 	a owl:DatatypeProperty ;
 	rdfs:label "MSISDNType"@en ;
 	rdfs:comment "???."@en ;
-	rdfs:domain :MobileAccount ;
+	rdfs:domain observable:MobileAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:Memory
+observable:Memory
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :regionSize ;
+			owl:onProperty observable:regionSize ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :blockType ;
+			owl:onProperty observable:blockType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :MemoryBlockTypeEnum ;
+			owl:onDataRange observable:MemoryBlockTypeEnum ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isInjected ;
+			owl:onProperty observable:isInjected ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isMapped ;
+			owl:onProperty observable:isMapped ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isProtected ;
+			owl:onProperty observable:isProtected ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isVolatile ;
+			owl:onProperty observable:isVolatile ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -4109,7 +4109,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of a region of computer memory."@en ;
 	.
 
-:MemoryBlockTypeEnum
+observable:MemoryBlockTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "Types of memory blocks."@en ;
 	owl:equivalentClass [
@@ -4138,48 +4138,48 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:Message
+observable:Message
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sentTime ;
+			owl:onProperty observable:sentTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :from ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:from ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :messageID ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:string ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :messageText ;
+			owl:onProperty observable:messageID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :messageType ;
+			owl:onProperty observable:messageText ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sessionID ;
+			owl:onProperty observable:messageType ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:sessionID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4188,20 +4188,20 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of an electronic message."@en ;
 	.
 
-:MessageThread
+observable:MessageThread
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :visibility ;
+			owl:onProperty observable:visibility ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :message ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:message ;
+			owl:onClass observable:CyberItem ;
 			owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -4209,74 +4209,74 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of a running commentary of electronic messages pertaining to one topic or question."@en ;
 	.
 
-:MftRecord
+observable:MftRecord
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftFileNameAccessedTime ;
+			owl:onProperty observable:mftFileNameAccessedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftFileNameCreatedTime ;
+			owl:onProperty observable:mftFileNameCreatedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftFileNameModifiedTime ;
+			owl:onProperty observable:mftFileNameModifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftFileNameRecordChangeTime ;
+			owl:onProperty observable:mftFileNameRecordChangeTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftRecordChangeTime ;
+			owl:onProperty observable:mftRecordChangeTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftFileID ;
+			owl:onProperty observable:mftFileID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftFileNameLength ;
+			owl:onProperty observable:mftFileNameLength ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftFlags ;
+			owl:onProperty observable:mftFlags ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mftParentID ;
+			owl:onProperty observable:mftParentID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ntfsHardLinkCount ;
+			owl:onProperty observable:ntfsHardLinkCount ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ntfsOwnerID ;
+			owl:onProperty observable:ntfsOwnerID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ntfsOwnerSID ;
+			owl:onProperty observable:ntfsOwnerSID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4285,30 +4285,30 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characterizes the details of a single NTFS file."@en ;
 	.
 
-:MimePartType
+observable:MimePartType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :bodyRaw ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:bodyRaw ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :body ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:string ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :contentDisposition ;
+			owl:onProperty observable:body ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contentType ;
+			owl:onProperty observable:contentDisposition ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:contentType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4318,25 +4318,25 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 """@en ;
 	.
 
-:MobileAccount
+observable:MobileAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :IMSI ;
+			owl:onProperty observable:IMSI ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :MSISDN ;
+			owl:onProperty observable:MSISDN ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :MSISDNType ;
+			owl:onProperty observable:MSISDNType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4345,61 +4345,61 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Properties of a Mobile Account."@en ;
 	.
 
-:MobileDevice
+observable:MobileDevice
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :storageCapacityInBytes ;
+			owl:onProperty observable:storageCapacityInBytes ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ESN ;
+			owl:onProperty observable:ESN ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :IMEI ;
+			owl:onProperty observable:IMEI ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :bluetoothDeviceName ;
+			owl:onProperty observable:bluetoothDeviceName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :clockSetting ;
+			owl:onProperty observable:clockSetting ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :keypadUnlockCode ;
+			owl:onProperty observable:keypadUnlockCode ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mockLocationsAllowed ;
+			owl:onProperty observable:mockLocationsAllowed ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :network ;
+			owl:onProperty observable:network ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :phoneActivationTime ;
+			owl:onProperty observable:phoneActivationTime ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4408,13 +4408,13 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Properties of a Mobile Device."@en ;
 	.
 
-:Mutex
+observable:Mutex
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isNamed ;
+			owl:onProperty observable:isNamed ;
 			owl:onDataRange xsd:boolean ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -4422,26 +4422,26 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:label "Mutex"@en ;
 	.
 
-:NTFSFilePermissions
+observable:NTFSFilePermissions
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "NTFSFilePermissions"@en ;
 	rdfs:comment "Characteristics of permissions or access rights for an NTFS file."@en ;
 	.
 
-:NTFSFileSystem
+observable:NTFSFileSystem
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :entryID ;
+			owl:onProperty observable:entryID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sid ;
+			owl:onProperty observable:sid ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4449,40 +4449,40 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:label "NTFSFileSystem"@en ;
 	.
 
-:NetworkConnection
+observable:NetworkConnection
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :endTime ;
+			owl:onProperty observable:endTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :protocols ;
+			owl:onProperty observable:protocols ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :startTime ;
+			owl:onProperty observable:startTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isActive ;
+			owl:onProperty observable:isActive ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :destinationPort ;
+			owl:onProperty observable:destinationPort ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sourcePort ;
+			owl:onProperty observable:sourcePort ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		]
@@ -4491,48 +4491,48 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of connection (completed or attempted) across a digital network."@en ;
 	.
 
-:NetworkFlow
+observable:NetworkFlow
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ipfix ;
+			owl:onProperty observable:ipfix ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :dstPayload ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:dstPayload ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :srcPayload ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:srcPayload ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :dstBytes ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:integer ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :dstPackets ;
+			owl:onProperty observable:dstBytes ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :srcBytes ;
+			owl:onProperty observable:dstPackets ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :srcPackets ;
+			owl:onProperty observable:srcBytes ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:integer ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:srcPackets ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		]
@@ -4541,29 +4541,29 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of a sequence of data transiting a one or more digital network connections."@en ;
 	.
 
-:NetworkInterface
+observable:NetworkInterface
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :dhcpLeaseExpires ;
+			owl:onProperty observable:dhcpLeaseExpires ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :dhcpLeaseObtained ;
+			owl:onProperty observable:dhcpLeaseObtained ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :macAddress ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:macAddress ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :adapterName ;
+			owl:onProperty observable:adapterName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4571,7 +4571,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:label "NetworkInterface"@en ;
 	.
 
-:NetworkSocketAddressFamily
+observable:NetworkSocketAddressFamily
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -4611,7 +4611,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:NetworkSocketProtocolFamily
+observable:NetworkSocketProtocolFamily
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -4719,7 +4719,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:NetworkSocketType
+observable:NetworkSocketType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -4747,30 +4747,30 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:Note
+observable:Note
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :modifiedTime ;
+			owl:onProperty observable:modifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :text ;
+			owl:onProperty observable:text ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -4778,7 +4778,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of digital textual note."@en ;
 	.
 
-:Observable
+observable:Observable
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#UcoObject> ;
 	rdfs:label "Observable"@en ;
@@ -4786,34 +4786,34 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 """@en ;
 	.
 
-:OperatingSystem
+observable:OperatingSystem
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :bitness ;
+			owl:onProperty observable:bitness ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :environmentVariables ;
+			owl:onProperty observable:environmentVariables ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :installDate ;
+			owl:onProperty observable:installDate ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :manufacturer ;
+			owl:onProperty observable:manufacturer ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :version ;
+			owl:onProperty observable:version ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4822,30 +4822,30 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Specifies information about an operating system."@en ;
 	.
 
-:PDFFIle
+observable:PDFFIle
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :documentInformationDictionary ;
+			owl:onProperty observable:documentInformationDictionary ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isOptimized ;
+			owl:onProperty observable:isOptimized ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :pdfId1 ;
+			owl:onProperty observable:pdfId1 ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :version ;
+			owl:onProperty observable:version ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -4853,23 +4853,23 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:label "PDFFIle"@en ;
 	.
 
-:PIN
+observable:PIN
 	a owl:DatatypeProperty ;
 	rdfs:label "PIN"@en ;
 	rdfs:comment "Personal Identification Number (PIN)."@en ;
-	rdfs:domain :SIMCard ;
+	rdfs:domain observable:SIMCard ;
 	rdfs:range xsd:string ;
 	.
 
-:PUK
+observable:PUK
 	a owl:DatatypeProperty ;
 	rdfs:label "PUK"@en ;
 	rdfs:comment "Personal Unlocking Key (PUK) to unlock the SIM card."@en ;
-	rdfs:domain :SIMCard ;
+	rdfs:domain observable:SIMCard ;
 	rdfs:range xsd:string ;
 	.
 
-:PartitionTypeEnum
+observable:PartitionTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "A non-exhaustive enumeration of partition types. See http://www.win.tue.nl/~aeb/partitions/partition_types-1.html for more information about the various partition types."@en ;
 	owl:equivalentClass [
@@ -4954,20 +4954,20 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:PathRelation
+observable:PathRelation
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "PathRelation"@en ;
 	rdfs:comment "Specifies the location of one object within another containing object."@en ;
 	.
 
-:PhoneAccount
+observable:PhoneAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :phoneNumber ;
+			owl:onProperty observable:phoneNumber ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -4976,48 +4976,48 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of a telephone service account."@en ;
 	.
 
-:PhoneCall
+observable:PhoneCall
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :endTime ;
+			owl:onProperty observable:endTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :startTime ;
+			owl:onProperty observable:startTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :from ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:from ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :to ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:to ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :duration ;
+			owl:onProperty observable:duration ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :callType ;
+			owl:onProperty observable:callType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -5025,70 +5025,70 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of a specific phone call."@en ;
 	.
 
-:Process
+observable:Process
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :environmentVariables ;
+			owl:onProperty observable:environmentVariables ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :exitTime ;
+			owl:onProperty observable:exitTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :binary ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:binary ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :creatorUser ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:creatorUser ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :parent ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:parent ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isHidden ;
+			owl:onProperty observable:isHidden ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :pid ;
+			owl:onProperty observable:pid ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :exitStatus ;
+			owl:onProperty observable:exitStatus ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :currentWorkingDirectory ;
+			owl:onProperty observable:currentWorkingDirectory ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :status ;
+			owl:onProperty observable:status ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -5097,7 +5097,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of an instance of a computer program as executed on an operating system."@en ;
 	.
 
-:ProcessorArchEnum
+observable:ProcessorArchEnum
 	a rdfs:Datatype ;
 	rdfs:comment "A (non-exhaustive) enumeration of computer processor architectures."@en ;
 	owl:equivalentClass [
@@ -5154,14 +5154,14 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:PropertiesEnumeratedEffect
+observable:PropertiesEnumeratedEffect
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		:DefinedEffectFacet ,
+		observable:DefinedEffectFacet ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :properties ;
+			owl:onProperty observable:properties ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -5170,20 +5170,20 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characterizes the effects of actions upon cyberitems where some properties of the cyberitem are enumerated, such as the startup parameters for a process."@en ;
 	.
 
-:PropertyReadEffect
+observable:PropertyReadEffect
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		:DefinedEffectFacet ,
+		observable:DefinedEffectFacet ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :propertyName ;
+			owl:onProperty observable:propertyName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :value ;
+			owl:onProperty observable:value ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -5192,43 +5192,43 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characterize the effects of actions upon cyberitems where some specific property is read from an cyberitem, such as the current running state of a process."@en ;
 	.
 
-:RasterPicture
+observable:RasterPicture
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :camera ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:camera ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :bitsPerPixel ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:integer ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :pictureHeight ;
+			owl:onProperty observable:bitsPerPixel ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :pictureWidth ;
+			owl:onProperty observable:pictureHeight ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :imageCompressionMethod ;
+			owl:onProperty observable:pictureWidth ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:integer ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:imageCompressionMethod ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :picturetype ;
+			owl:onProperty observable:picturetype ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -5236,7 +5236,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:label "RasterPicture"@en ;
 	.
 
-:RegionalRegistryTypeEnum
+observable:RegionalRegistryTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of Regional Internet Registries (RIRs) names, represented via their respective acronyms."@en ;
 	owl:equivalentClass [
@@ -5265,7 +5265,7 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:RegistryDatatype
+observable:RegistryDatatype
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -5325,55 +5325,55 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:SIMCard
+observable:SIMCard
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :carrier ;
+			owl:onProperty observable:carrier ;
 			owl:onClass <https://unifiedcyberontology.org/ontology/uco/identity#Identity> ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :storageCapacityInBytes ;
+			owl:onProperty observable:storageCapacityInBytes ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ICCID ;
+			owl:onProperty observable:ICCID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :IMSI ;
+			owl:onProperty observable:IMSI ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :PIN ;
+			owl:onProperty observable:PIN ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :PUK ;
+			owl:onProperty observable:PUK ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :SIMForm ;
+			owl:onProperty observable:SIMForm ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :SIMType ;
+			owl:onProperty observable:SIMType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -5382,15 +5382,15 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Properties of a Mobile SIM card."@en ;
 	.
 
-:SIMForm
+observable:SIMForm
 	a owl:DatatypeProperty ;
 	rdfs:label "SIMForm"@en ;
 	rdfs:comment "The form of SIM card such as SIM, Micro SIM, Nano SIM."@en ;
-	rdfs:domain :SIMCard ;
+	rdfs:domain observable:SIMCard ;
 	rdfs:range xsd:string ;
 	.
 
-:SIMFormEnum
+observable:SIMFormEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of common SIM card form factors."@en ;
 	owl:equivalentClass [
@@ -5411,15 +5411,15 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:SIMType
+observable:SIMType
 	a owl:DatatypeProperty ;
 	rdfs:label "SIMType"@en ;
 	rdfs:comment "The type of SIM card such as SIM, USIM, UICC."@en ;
-	rdfs:domain :SIMCard ;
+	rdfs:domain observable:SIMCard ;
 	rdfs:range xsd:string ;
 	.
 
-:SIMTypeEnum
+observable:SIMTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of common SIM card types."@en ;
 	owl:equivalentClass [
@@ -5440,13 +5440,13 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	] ;
 	.
 
-:SMSMessage
+observable:SMSMessage
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isRead ;
+			owl:onProperty observable:isRead ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		]
@@ -5455,25 +5455,25 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment 'Characteristics of a Short Message Service (SMS) "text" message.'@en ;
 	.
 
-:SQLiteBlob
+observable:SQLiteBlob
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :columnName ;
+			owl:onProperty observable:columnName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :rowCondition ;
+			owl:onProperty observable:rowCondition ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :tableName ;
+			owl:onProperty observable:tableName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -5482,14 +5482,14 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characteristics of blob of data within a SQLite database."@en ;
 	.
 
-:SendControlCodeEffect
+observable:SendControlCodeEffect
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		:DefinedEffectFacet ,
+		observable:DefinedEffectFacet ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :controlCode ;
+			owl:onProperty observable:controlCode ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -5498,37 +5498,37 @@ What about Android Package and iOS Package and Windows MSI?"""@en ;
 	rdfs:comment "Characterizes the effects of actions upon cyberitems where some control code, or other control-oriented communication signal, is sent to the cyberitem. For example, an action may send a control code to change the running state of a process."@en ;
 	.
 
-:Software
+observable:Software
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :cpeid ;
+			owl:onProperty observable:cpeid ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :language ;
+			owl:onProperty observable:language ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :manufacturer ;
+			owl:onProperty observable:manufacturer ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :swid ;
+			owl:onProperty observable:swid ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :version ;
+			owl:onProperty observable:version ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -5541,21 +5541,21 @@ How does this relate to Application?
 """@en ;
 	.
 
-:StateChangeEffect
+observable:StateChangeEffect
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		:DefinedEffectFacet ,
+		observable:DefinedEffectFacet ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :oldObject ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:oldObject ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :newObject ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:newObject ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -5563,14 +5563,14 @@ How does this relate to Application?
 	rdfs:comment "Characterizes the effects of actions upon cyberitems where the some state of the cyberitem is changed."@en ;
 	.
 
-:SymbolicLink
+observable:SymbolicLink
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :targetFile ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:targetFile ;
+			owl:onClass observable:CyberItem ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;
@@ -5578,58 +5578,58 @@ How does this relate to Application?
 	rdfs:comment "Characteristics of a file that contains a reference to another file or directory in the form of an absolute or relative path and that affects pathname resolution."@en ;
 	.
 
-:TCPConnection
+observable:TCPConnection
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "TCPConnection"@en ;
 	rdfs:comment "Specifies TCP-specific network connection properties."@en ;
 	.
 
-:TaskActionType
+observable:TaskActionType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :iEmailAction ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:iEmailAction ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :iComHandlerAction ;
-			owl:onClass :IComHandlerActionType ;
+			owl:onProperty observable:iComHandlerAction ;
+			owl:onClass observable:IComHandlerActionType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :iExecAction ;
-			owl:onClass :IExecActionType ;
+			owl:onProperty observable:iExecAction ;
+			owl:onClass observable:IExecActionType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :iShowMessageAction ;
-			owl:onClass :IShowMessageActionType ;
+			owl:onProperty observable:iShowMessageAction ;
+			owl:onClass observable:IShowMessageActionType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :actionID ;
+			owl:onProperty observable:actionID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :actionType ;
+			owl:onProperty observable:actionType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :TaskActionTypeEnum ;
+			owl:onDataRange observable:TaskActionTypeEnum ;
 		]
 		;
 	rdfs:label "TaskActionType"@en ;
 	rdfs:comment "Characterizes scheduled task actions."@en ;
 	.
 
-:TaskActionTypeEnum
+observable:TaskActionTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of tas action types. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380596(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
@@ -5654,7 +5654,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:TaskFlagEnum
+observable:TaskFlagEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of the run flags for a task scheduler task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx See Also: http://msdn.microsoft.com/en-us/library/microsoft.office.excel.server.addins.computecluster.taskscheduler.taskflags(v=office.12).aspx."@en ;
 	owl:equivalentClass [
@@ -5715,7 +5715,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:TaskPriorityEnum
+observable:TaskPriorityEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of the priority levels of task scheduler tasks. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383512(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
@@ -5748,7 +5748,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:TaskStatusEnum
+observable:TaskStatusEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of the possible statuses of a scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383604(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381263(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381833(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383617(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
@@ -5853,7 +5853,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:ThreadRunningStatusEnum
+observable:ThreadRunningStatusEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of the various states that a thread may be in before, during, or after execution. See http://msdn.microsoft.com/en-us/library/system.diagnostics.threadstate(v=vs.110).aspx."@en ;
 	owl:equivalentClass [
@@ -5894,7 +5894,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:TriggerFrequencyEnum
+observable:TriggerFrequencyEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of the frequency types that a trigger may use. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383620(v=vs.85).aspx and http://msdn.microsoft.com/en-us/library/windows/desktop/aa383987(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
@@ -5935,61 +5935,61 @@ How does this relate to Application?
 	] ;
 	.
 
-:TriggerType
+observable:TriggerType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :triggerBeginTime ;
+			owl:onProperty observable:triggerBeginTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :triggerEndTime ;
+			owl:onProperty observable:triggerEndTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isEnabled ;
+			owl:onProperty observable:isEnabled ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :triggerDelay ;
+			owl:onProperty observable:triggerDelay ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :triggerMaxRunTime ;
+			owl:onProperty observable:triggerMaxRunTime ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :triggerSessionChangeType ;
+			owl:onProperty observable:triggerSessionChangeType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :triggerFrequency ;
+			owl:onProperty observable:triggerFrequency ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :TriggerFrequencyEnum ;
+			owl:onDataRange observable:TriggerFrequencyEnum ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :triggerType ;
+			owl:onProperty observable:triggerType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :TriggerTypeEnum ;
+			owl:onDataRange observable:TriggerTypeEnum ;
 		]
 		;
 	rdfs:label "TriggerType"@en ;
 	rdfs:comment "Characterizes task triggers. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383868(v=vs.85).aspx."@en ;
 	.
 
-:TriggerTypeEnum
+observable:TriggerTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of the types of triggers associated with a task."@en ;
 	owl:equivalentClass [
@@ -6026,19 +6026,19 @@ How does this relate to Application?
 	] ;
 	.
 
-:UNIXAccount
+observable:UNIXAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :gid ;
+			owl:onProperty observable:gid ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :shell ;
+			owl:onProperty observable:shell ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6046,33 +6046,33 @@ How does this relate to Application?
 	rdfs:label "UNIXAccount"@en ;
 	.
 
-:UNIXFilePermissions
+observable:UNIXFilePermissions
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "UNIXFilePermissions"@en ;
 	rdfs:comment "Characteristics of permissions or access rights for a UNIX file."@en ;
 	.
 
-:UNIXProcess
+observable:UNIXProcess
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "UNIXProcess"@en ;
 	rdfs:comment "Characterization of a UNIX process."@en ;
 	.
 
-:UNIXVolume
+observable:UNIXVolume
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mountPoint ;
+			owl:onProperty observable:mountPoint ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :options ;
+			owl:onProperty observable:options ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6081,61 +6081,61 @@ How does this relate to Application?
 	rdfs:comment "Characterizes a Unix disk volume."@en ;
 	.
 
-:URL
+observable:URL
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :host ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:host ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :userName ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:userName ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :port ;
+			owl:onProperty observable:port ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :fragment ;
+			owl:onProperty observable:fragment ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :password ;
+			owl:onProperty observable:password ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :path ;
+			owl:onProperty observable:path ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :query ;
+			owl:onProperty observable:query ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :scheme ;
+			owl:onProperty observable:scheme ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :fullValue ;
+			owl:onProperty observable:fullValue ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -6144,7 +6144,7 @@ How does this relate to Application?
 	rdfs:comment "Characteristics of a uniform resource locator (URL)."@en ;
 	.
 
-:UnixProcessStateEnum
+observable:UnixProcessStateEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of Unix process states"@en ;
 	owl:equivalentClass [
@@ -6181,31 +6181,31 @@ How does this relate to Application?
 	] ;
 	.
 
-:UserAccount
+observable:UserAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :canEscalatePrivs ;
+			owl:onProperty observable:canEscalatePrivs ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isPrivileged ;
+			owl:onProperty observable:isPrivileged ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isServiceAccount ;
+			owl:onProperty observable:isServiceAccount ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :homeDirectory ;
+			owl:onProperty observable:homeDirectory ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6213,35 +6213,35 @@ How does this relate to Application?
 	rdfs:label "UserAccount"@en ;
 	.
 
-:UserSession
+observable:UserSession
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :loginTime ;
+			owl:onProperty observable:loginTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :logoutTime ;
+			owl:onProperty observable:logoutTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :effectiveUser ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:effectiveUser ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :effectiveGroup ;
+			owl:onProperty observable:effectiveGroup ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :effectiveGroupID ;
+			owl:onProperty observable:effectiveGroupID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6250,14 +6250,14 @@ How does this relate to Application?
 	rdfs:comment "Characterizes a user session."@en ;
 	.
 
-:ValuesEnumeratedEffect
+observable:ValuesEnumeratedEffect
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		:DefinedEffectFacet ,
+		observable:DefinedEffectFacet ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :values ;
+			owl:onProperty observable:values ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -6266,19 +6266,19 @@ How does this relate to Application?
 	rdfs:comment "Characterizes the effects of actions upon cyberitems where some values of the cyberitem are enumerated, such as the values of a registry key."@en ;
 	.
 
-:Volume
+observable:Volume
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sectorSize ;
+			owl:onProperty observable:sectorSize ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :volumeID ;
+			owl:onProperty observable:volumeID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6287,150 +6287,150 @@ How does this relate to Application?
 	rdfs:comment "Characteristics of a single accessible storage area (Volume) with a single file system."@en ;
 	.
 
-:WhoIs
+observable:WhoIs
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :creationDate ;
+			owl:onProperty observable:creationDate ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :expirationDate ;
+			owl:onProperty observable:expirationDate ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :lookupDate ;
+			owl:onProperty observable:lookupDate ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :updatedDate ;
+			owl:onProperty observable:updatedDate ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :domainName ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:domainName ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ipAddress ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:ipAddress ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :serverName ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:serverName ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :registrarInfo ;
-			owl:onClass :WhoisRegistrarInfoType ;
+			owl:onProperty observable:registrarInfo ;
+			owl:onClass observable:WhoisRegistrarInfoType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :domainID ;
+			owl:onProperty observable:domainID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :remarks ;
+			owl:onProperty observable:remarks ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sponsoringRegistrar ;
+			owl:onProperty observable:sponsoringRegistrar ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :regionalInternetRegistry ;
+			owl:onProperty observable:regionalInternetRegistry ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :RegionalRegistryTypeEnum ;
+			owl:onDataRange observable:RegionalRegistryTypeEnum ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :dnssec ;
+			owl:onProperty observable:dnssec ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :WhoisDNSSECTypeEnum ;
+			owl:onDataRange observable:WhoisDNSSECTypeEnum ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :status ;
+			owl:onProperty observable:status ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :WhoisStatusTypeEnum ;
+			owl:onDataRange observable:WhoisStatusTypeEnum ;
 		]
 		;
 	rdfs:label "WhoIs"@en ;
 	rdfs:comment "Characterizes Whois information for a domain."@en ;
 	.
 
-:WhoisContactType
+observable:WhoisContactType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :address ;
+			owl:onProperty observable:address ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contactOrganization ;
+			owl:onProperty observable:contactOrganization ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :emailAddress ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:emailAddress ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :faxNumber ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:faxNumber ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :phone ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:phone ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contactID ;
+			owl:onProperty observable:contactID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contactName ;
+			owl:onProperty observable:contactName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :contactType ;
+			owl:onProperty observable:contactType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :WhoisContactTypeEnum ;
+			owl:onDataRange observable:WhoisContactTypeEnum ;
 		]
 		;
 	rdfs:label "WhoisContactType"@en ;
 	rdfs:comment "Contact-related properties from a Whois record."@en ;
 	.
 
-:WhoisContactTypeEnum
+observable:WhoisContactTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of types of registrar contacts listed in a whois entry."@en ;
 	owl:equivalentClass [
@@ -6451,7 +6451,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:WhoisDNSSECTypeEnum
+observable:WhoisDNSSECTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of acceptable values for the DNSSEC field in a Whois entry."@en ;
 	owl:equivalentClass [
@@ -6468,53 +6468,53 @@ How does this relate to Application?
 	] ;
 	.
 
-:WhoisRegistrarInfoType
+observable:WhoisRegistrarInfoType
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :address ;
+			owl:onProperty observable:address ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :emailAddress ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:emailAddress ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :phone ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:phone ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :referralURL ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:referralURL ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :whoisServer ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:whoisServer ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :registrarGUID ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:string ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :registrarID ;
+			owl:onProperty observable:registrarGUID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :registrarName ;
+			owl:onProperty observable:registrarID ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:registrarName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6523,7 +6523,7 @@ How does this relate to Application?
 	rdfs:comment "Registrar-related properties from a Whois record."@en ;
 	.
 
-:WhoisStatusTypeEnum
+observable:WhoisStatusTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of all valid statuses for a domain within a whois entry."@en ;
 	owl:equivalentClass [
@@ -6608,13 +6608,13 @@ How does this relate to Application?
 	] ;
 	.
 
-:WifiAddress
+observable:WifiAddress
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :addressValue ;
+			owl:onProperty observable:addressValue ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6623,19 +6623,19 @@ How does this relate to Application?
 	rdfs:comment "Properties of a WiFI address."@en ;
 	.
 
-:WindowsAccount
+observable:WindowsAccount
 	a owl:Class ;
 	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
 	rdfs:label "WindowsAccount"@en ;
 	.
 
-:WindowsActiveDirectoryAccount
+observable:WindowsActiveDirectoryAccount
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :objectGUID ;
+			owl:onProperty observable:objectGUID ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -6643,53 +6643,53 @@ How does this relate to Application?
 	rdfs:label "WindowsActiveDirectoryAccount"@en ;
 	.
 
-:WindowsComputerSpecification
+observable:WindowsComputerSpecification
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :registeredOrganization ;
+			owl:onProperty observable:registeredOrganization ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :registeredOwner ;
+			owl:onProperty observable:registeredOwner ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :windowsDirectory ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:windowsDirectory ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :windowsSystemDirectory ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:windowsSystemDirectory ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :windowsTempDirectory ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:windowsTempDirectory ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :msProductID ;
+			owl:onProperty observable:msProductID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :msProductName ;
+			owl:onProperty observable:msProductName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :netBIOSName ;
+			owl:onProperty observable:netBIOSName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6698,7 +6698,7 @@ How does this relate to Application?
 	rdfs:comment "Specifies Windows-specific system properties."@en ;
 	.
 
-:WindowsDriveTypeEnum
+observable:WindowsDriveTypeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of possible drive types, as enumerated by the WINAPI GetDriveType function: http://msdn.microsoft.com/en-us/library/windows/desktop/aa364939(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
@@ -6735,47 +6735,47 @@ How does this relate to Application?
 	] ;
 	.
 
-:WindowsPEBinaryFile
+observable:WindowsPEBinaryFile
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :peType ;
+			owl:onProperty observable:peType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :timeDateStamp ;
+			owl:onProperty observable:timeDateStamp ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :optionalHeader ;
-			owl:onClass :WindowsPEOptionalHeader ;
+			owl:onProperty observable:optionalHeader ;
+			owl:onClass observable:WindowsPEOptionalHeader ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :numberOfSections ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:integer ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty :numberOfSymbols ;
+			owl:onProperty observable:numberOfSections ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :sizeOfOptionalHeader ;
+			owl:onProperty observable:numberOfSymbols ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :impHash ;
+			owl:onProperty observable:sizeOfOptionalHeader ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:integer ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:impHash ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6784,7 +6784,7 @@ How does this relate to Application?
 	rdfs:comment "Properties specific to Windows portable executable (PE) files."@en ;
 	.
 
-:WindowsPEBinaryType
+observable:WindowsPEBinaryType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -6804,33 +6804,33 @@ How does this relate to Application?
 	] ;
 	.
 
-:WindowsPEFileHeader
+observable:WindowsPEFileHeader
 	a owl:Class ;
 	rdfs:subClassOf [
 		a owl:Restriction ;
-		owl:onProperty :timeDateStamp ;
+		owl:onProperty observable:timeDateStamp ;
 		owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 	] ;
 	rdfs:label "WindowsPEFileHeader"@en ;
 	.
 
-:WindowsPEOptionalHeader
+observable:WindowsPEOptionalHeader
 	a owl:Class ;
 	rdfs:label "WindowsPEOptionalHeader"@en ;
 	.
 
-:WindowsPESection
+observable:WindowsPESection
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :entropy ;
+			owl:onProperty observable:entropy ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:float ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :size ;
+			owl:onProperty observable:size ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
@@ -6844,41 +6844,41 @@ How does this relate to Application?
 	rdfs:label "WindowsPESection"@en ;
 	.
 
-:WindowsPrefetch
+observable:WindowsPrefetch
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :firstRun ;
+			owl:onProperty observable:firstRun ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :lastRun ;
+			owl:onProperty observable:lastRun ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :volume ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:volume ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :timesExecuted ;
+			owl:onProperty observable:timesExecuted ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :applicationFileName ;
+			owl:onProperty observable:applicationFileName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :prefetchHash ;
+			owl:onProperty observable:prefetchHash ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6887,42 +6887,42 @@ How does this relate to Application?
 	rdfs:comment "Characterizes entries in the Windows prefetch files. Starting with Windows XP, prefetching was introduced to speed up application startup."@en ;
 	.
 
-:WindowsProcess
+observable:WindowsProcess
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :startupInfo ;
+			owl:onProperty observable:startupInfo ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :aslrEnabled ;
+			owl:onProperty observable:aslrEnabled ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :depEnabled ;
+			owl:onProperty observable:depEnabled ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ownerSID ;
+			owl:onProperty observable:ownerSID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :priority ;
+			owl:onProperty observable:priority ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :windowTitle ;
+			owl:onProperty observable:windowTitle ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6930,13 +6930,13 @@ How does this relate to Application?
 	rdfs:label "WindowsProcess"@en ;
 	.
 
-:WindowsRegistryHive
+observable:WindowsRegistryHive
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :hiveType ;
+			owl:onProperty observable:hiveType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -6945,30 +6945,30 @@ How does this relate to Application?
 	rdfs:comment "Characteristics of a particular logical group of keys, subkeys, and values in a Windows registry."@en ;
 	.
 
-:WindowsRegistryKey
+observable:WindowsRegistryKey
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :modifiedTime ;
+			owl:onProperty observable:modifiedTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :creator ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:creator ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :numberOfSubkeys ;
+			owl:onProperty observable:numberOfSubkeys ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :key ;
+			owl:onProperty observable:key ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -6977,17 +6977,17 @@ How does this relate to Application?
 	rdfs:comment "Characteristics of a particular key within a Windows registry."@en ;
 	.
 
-:WindowsRegistryValue
+observable:WindowsRegistryValue
 	a owl:Class ;
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty :dataType ;
+			owl:onProperty observable:dataType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :data ;
+			owl:onProperty observable:data ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
@@ -7002,46 +7002,46 @@ How does this relate to Application?
 	rdfs:comment "Properties of a particular value within a Windows registry."@en ;
 	.
 
-:WindowsService
+observable:WindowsService
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :serviceStatus ;
+			owl:onProperty observable:serviceStatus ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :serviceType ;
+			owl:onProperty observable:serviceType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :startType ;
+			owl:onProperty observable:startType ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :displayName ;
+			owl:onProperty observable:displayName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :groupName ;
+			owl:onProperty observable:groupName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :startCommandLine ;
+			owl:onProperty observable:startCommandLine ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :serviceName ;
+			owl:onProperty observable:serviceName ;
 			owl:onDataRange xsd:string ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
@@ -7050,7 +7050,7 @@ How does this relate to Application?
 	rdfs:comment "Properties specific to Windows services."@en ;
 	.
 
-:WindowsServiceStartType
+observable:WindowsServiceStartType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -7078,7 +7078,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:WindowsServiceStatus
+observable:WindowsServiceStatus
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -7114,7 +7114,7 @@ How does this relate to Application?
 	] ;
 	.
 
-:WindowsServiceType
+observable:WindowsServiceType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -7138,143 +7138,143 @@ How does this relate to Application?
 	] ;
 	.
 
-:WindowsTask
+observable:WindowsTask
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :createdTime ;
+			owl:onProperty observable:createdTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :mostRecentRunTime ;
+			owl:onProperty observable:mostRecentRunTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :nextRunTime ;
+			owl:onProperty observable:nextRunTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :account ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:account ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :application ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :workItemData ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:workItemData ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :workingDirectory ;
-			owl:onClass :CyberItem ;
+			owl:onProperty observable:workingDirectory ;
+			owl:onClass observable:CyberItem ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :exitCode ;
+			owl:onProperty observable:exitCode ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :maxRunTime ;
+			owl:onProperty observable:maxRunTime ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:long ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accountLogonType ;
+			owl:onProperty observable:accountLogonType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :accountRunLevel ;
+			owl:onProperty observable:accountRunLevel ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :imageName ;
+			owl:onProperty observable:imageName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :omment ;
+			owl:onProperty observable:omment ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :parameters ;
+			owl:onProperty observable:parameters ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :taskCreator ;
+			owl:onProperty observable:taskCreator ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :priority ;
+			owl:onProperty observable:priority ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :TaskPriorityEnum ;
+			owl:onDataRange observable:TaskPriorityEnum ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :status ;
+			owl:onProperty observable:status ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :TaskStatusEnum ;
+			owl:onDataRange observable:TaskStatusEnum ;
 		]
 		;
 	rdfs:label "WindowsTask"@en ;
 	rdfs:comment "Characterize Windows task scheduler tasks. See Also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381311(v=vs.85).aspx."@en ;
 	.
 
-:WindowsThread
+observable:WindowsThread
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :creationTime ;
+			owl:onProperty observable:creationTime ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :runningStatus ;
+			owl:onProperty observable:runningStatus ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :priority ;
+			owl:onProperty observable:priority ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :context ;
+			owl:onProperty observable:context ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :securityAttributes ;
+			owl:onProperty observable:securityAttributes ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -7283,34 +7283,34 @@ How does this relate to Application?
 	rdfs:comment "Characteristics of a single thread of execution within a Windows process."@en ;
 	.
 
-:WindowsVolume
+observable:WindowsVolume
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :driveLetter ;
+			owl:onProperty observable:driveLetter ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :driveType ;
+			owl:onProperty observable:driveType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :WindowsDriveTypeEnum ;
+			owl:onDataRange observable:WindowsDriveTypeEnum ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :windowsVolumeAttributes ;
+			owl:onProperty observable:windowsVolumeAttributes ;
 			owl:maxQualifiedCardinality "4"^^xsd:nonNegativeInteger ;
-			owl:onDataRange :WindowsVolumeAttributeEnum ;
+			owl:onDataRange observable:WindowsVolumeAttributeEnum ;
 		]
 		;
 	rdfs:label "WindowsVolume"@en ;
 	rdfs:comment "Characterizes a Windows disk volume."@en ;
 	.
 
-:WindowsVolumeAttributeEnum
+observable:WindowsVolumeAttributeEnum
 	a rdfs:Datatype ;
 	rdfs:comment "An enumeration of attributes that may be returned by the diskpart attributes command: http://technet.microsoft.com/en-us/library/cc766465(v=ws.10).aspx."@en ;
 	owl:equivalentClass [
@@ -7335,19 +7335,19 @@ How does this relate to Application?
 	] ;
 	.
 
-:WirelessNetworkConnection
+observable:WirelessNetworkConnection
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :baseStation ;
+			owl:onProperty observable:baseStation ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :ssid ;
+			owl:onProperty observable:ssid ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -7356,98 +7356,98 @@ How does this relate to Application?
 	rdfs:comment "Connection to a wireless network."@en ;
 	.
 
-:X509Certificate
+observable:X509Certificate
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :issuerHash ;
+			owl:onProperty observable:issuerHash ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subjectHash ;
+			owl:onProperty observable:subjectHash ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :thumbprintHash ;
+			owl:onProperty observable:thumbprintHash ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :validityNotAfter ;
+			owl:onProperty observable:validityNotAfter ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :validityNotBefore ;
+			owl:onProperty observable:validityNotBefore ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :x509v3extensions ;
-			owl:onClass :X509V3Extensions ;
+			owl:onProperty observable:x509v3extensions ;
+			owl:onClass observable:X509V3Extensions ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :isSelfSigned ;
+			owl:onProperty observable:isSelfSigned ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:boolean ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subjectPublicKeyExponent ;
+			owl:onProperty observable:subjectPublicKeyExponent ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :issuer ;
+			owl:onProperty observable:issuer ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :serialNumber ;
+			owl:onProperty observable:serialNumber ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :signature ;
+			owl:onProperty observable:signature ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :signatureAlgorithm ;
+			owl:onProperty observable:signatureAlgorithm ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subject ;
+			owl:onProperty observable:subject ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subjectPublicKeyAlgorithm ;
+			owl:onProperty observable:subjectPublicKeyAlgorithm ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subjectPublicKeyModulus ;
+			owl:onProperty observable:subjectPublicKeyModulus ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :version ;
+			owl:onProperty observable:version ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -7455,101 +7455,101 @@ How does this relate to Application?
 	rdfs:label "X509Certificate"@en ;
 	.
 
-:X509V3Extensions
+observable:X509V3Extensions
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :privateKeyUsagePeriodNotAfter ;
+			owl:onProperty observable:privateKeyUsagePeriodNotAfter ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :privateKeyUsagePeriodNotBefore ;
+			owl:onProperty observable:privateKeyUsagePeriodNotBefore ;
 			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :authorityKeyIdentifier ;
+			owl:onProperty observable:authorityKeyIdentifier ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :basicConstraints ;
+			owl:onProperty observable:basicConstraints ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :certificatePolicies ;
+			owl:onProperty observable:certificatePolicies ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :crlDistributionPoints ;
+			owl:onProperty observable:crlDistributionPoints ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :extendedKeyUsage ;
+			owl:onProperty observable:extendedKeyUsage ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :inhibitAnyPolicy ;
+			owl:onProperty observable:inhibitAnyPolicy ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :issuerAlternativeName ;
+			owl:onProperty observable:issuerAlternativeName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :keyUsage ;
+			owl:onProperty observable:keyUsage ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :nameConstraints ;
+			owl:onProperty observable:nameConstraints ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :policyConstraints ;
+			owl:onProperty observable:policyConstraints ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :policyMappings ;
+			owl:onProperty observable:policyMappings ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subjectAlternativeName ;
+			owl:onProperty observable:subjectAlternativeName ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subjectDirectoryAttributes ;
+			owl:onProperty observable:subjectDirectoryAttributes ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty :subjectKeyIdentifier ;
+			owl:onProperty observable:subjectKeyIdentifier ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]
@@ -7558,2517 +7558,2517 @@ How does this relate to Application?
 	rdfs:comment "Extended properties of X.509 v3 digital certificates."@en ;
 	.
 
-:abbreviation
+observable:abbreviation
 	a owl:DatatypeProperty ;
 	rdfs:label "abbreviation"@en ;
 	rdfs:comment "The abbreviation of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
-	rdfs:domain :GlobalFlagType ;
+	rdfs:domain observable:GlobalFlagType ;
 	rdfs:range xsd:string ;
 	.
 
-:accessedDirectory
+observable:accessedDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "accessedDirectory"@en ;
 	rdfs:comment "Directories accessed by the prefetch application during startup."@en ;
-	rdfs:domain :WindowsPrefetch ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsPrefetch ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:accessedFile
+observable:accessedFile
 	a owl:ObjectProperty ;
 	rdfs:label "accessedFile"@en ;
 	rdfs:comment "Files (e.g., DLLs and other support files) used by the application during startup."@en ;
-	rdfs:domain :WindowsPrefetch ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsPrefetch ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:accessedTime
+observable:accessedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "accessedTime"@en ;
 	rdfs:comment "The date and time at which the Object was accessed."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:account
+observable:account
 	a owl:ObjectProperty ;
 	rdfs:label "account"@en ;
 	rdfs:comment "Specifies the account used to run the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381228(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsTask ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:accountIdentifier
+observable:accountIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "accountIdentifier"@en ;
 	rdfs:comment "The unique identifier for the account."@en ;
-	rdfs:domain :Account ;
+	rdfs:domain observable:Account ;
 	rdfs:range xsd:string ;
 	.
 
-:accountIssuer
+observable:accountIssuer
 	a owl:ObjectProperty ;
 	rdfs:label "accountIssuer"@en ;
 	rdfs:comment "The issuer of this account."@en ;
-	rdfs:domain :Account ;
+	rdfs:domain observable:Account ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/core#UcoObject> ;
 	.
 
-:accountLogin
+observable:accountLogin
 	a owl:DatatypeProperty ;
 	rdfs:label "accountLogin"@en ;
 	rdfs:comment "The login identifier for the digital account."@en ;
-	rdfs:domain :DigitalAccount ;
+	rdfs:domain observable:DigitalAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:accountLogonType
+observable:accountLogonType
 	a owl:DatatypeProperty ;
 	rdfs:label "accountLogonType"@en ;
 	rdfs:comment "Specifies the security logon method required to run the tasks associated with the account. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383013(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:string ;
 	.
 
-:accountRunLevel
+observable:accountRunLevel
 	a owl:DatatypeProperty ;
 	rdfs:label "accountRunLevel"@en ;
 	rdfs:comment "Specifies the permission level of the account that the task will be run at."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:string ;
 	.
 
-:accountType
+observable:accountType
 	a owl:DatatypeProperty ;
 	rdfs:label "accountType"@en ;
 	rdfs:comment "The type of account, for instance bank, phone, application, service, etc."@en ;
-	rdfs:domain :Account ;
+	rdfs:domain observable:Account ;
 	rdfs:range xsd:string ;
 	.
 
-:actionID
+observable:actionID
 	a owl:DatatypeProperty ;
 	rdfs:label "actionID"@en ;
 	rdfs:comment "Specifies the user-defined identifier for the action. This identifier is used by the Task Scheduler for logging purposes. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380590(v=vs.85).aspx."@en ;
-	rdfs:domain :TaskActionType ;
+	rdfs:domain observable:TaskActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:actionList
+observable:actionList
 	a owl:ObjectProperty ;
 	rdfs:label "actionList"@en ;
 	rdfs:comment "Specifies a list of actions to be performed by the scheduled task."@en ;
-	rdfs:domain :WindowsTask ;
-	rdfs:range :TaskActionType ;
+	rdfs:domain observable:WindowsTask ;
+	rdfs:range observable:TaskActionType ;
 	.
 
-:actionType
+observable:actionType
 	a owl:DatatypeProperty ;
 	rdfs:label "actionType"@en ;
 	rdfs:comment "Specifies the type of the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380596(v=vs.85).aspx."@en ;
-	rdfs:domain :TaskActionType ;
-	rdfs:range :TaskActionTypeEnum ;
+	rdfs:domain observable:TaskActionType ;
+	rdfs:range observable:TaskActionTypeEnum ;
 	.
 
-:activeDirectoryGroups
+observable:activeDirectoryGroups
 	a owl:DatatypeProperty ;
 	rdfs:label "activeDirectoryGroups"@en ;
-	rdfs:domain :WindowsActiveDirectoryAccount ;
+	rdfs:domain observable:WindowsActiveDirectoryAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:adapterName
+observable:adapterName
 	a owl:DatatypeProperty ;
 	rdfs:label "adapterName"@en ;
 	rdfs:comment "Specifies the name of the network adapter used by the network interface."@en ;
-	rdfs:domain :NetworkInterface ;
+	rdfs:domain observable:NetworkInterface ;
 	rdfs:range xsd:string ;
 	.
 
-:address
+observable:address
 	a owl:ObjectProperty ;
 	rdfs:label "address"@en ;
 	rdfs:comment "An address"@en ;
-	rdfs:domain :WhoisContactType ;
+	rdfs:domain observable:WhoisContactType ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/location#Location> ;
 	.
 
-:addressOfEntryPoint
+observable:addressOfEntryPoint
 	a owl:DatatypeProperty ;
 	rdfs:label "addressOfEntryPoint"@en ;
 	rdfs:comment "Specifies the address of the entry point relative to the image base when the executable is loaded into memory."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:addressValue
+observable:addressValue
 	a owl:DatatypeProperty ;
 	rdfs:label "addressValue"@en ;
 	rdfs:comment "The value of an address."@en ;
 	rdfs:domain
-		:BluetoothAddress ,
-		:WifiAddress
+		observable:BluetoothAddress ,
+		observable:WifiAddress
 		;
 	rdfs:range xsd:string ;
 	.
 
-:allocationStatus
+observable:allocationStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "allocationStatus"@en ;
 	rdfs:comment "The allocation status of a file."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:string ;
 	.
 
-:alternateDataStreams
+observable:alternateDataStreams
 	a owl:ObjectProperty ;
 	rdfs:label "alternateDataStreams"@en ;
-	rdfs:domain :NTFSFileSystem ;
-	rdfs:range :AlternateDataStream ;
+	rdfs:domain observable:NTFSFileSystem ;
+	rdfs:range observable:AlternateDataStream ;
 	.
 
-:application
+observable:application
 	a owl:ObjectProperty ;
 	rdfs:label "application"@en ;
 	rdfs:comment "The application associated with this object."@en ;
-	rdfs:domain :PhoneCall ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:PhoneCall ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:applicationFileName
+observable:applicationFileName
 	a owl:DatatypeProperty ;
 	rdfs:label "applicationFileName"@en ;
 	rdfs:comment "Name of the executable of the prefetch file."@en ;
-	rdfs:domain :WindowsPrefetch ;
+	rdfs:domain observable:WindowsPrefetch ;
 	rdfs:range xsd:string ;
 	.
 
-:applicationIdentifier
+observable:applicationIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "applicationIdentifier"@en ;
-	rdfs:domain :Application ;
+	rdfs:domain observable:Application ;
 	rdfs:range xsd:string ;
 	.
 
-:archiveType
+observable:archiveType
 	a owl:DatatypeProperty ;
 	rdfs:label "archiveType"@en ;
 	rdfs:comment "The type of a file archive, e.g. ZIP, GZIP or RAR."@en ;
-	rdfs:domain :ArchiveFile ;
+	rdfs:domain observable:ArchiveFile ;
 	rdfs:range xsd:string ;
 	.
 
-:arguments
+observable:arguments
 	a owl:DatatypeProperty ;
 	rdfs:label "arguments"@en ;
 	rdfs:comment "A list of arguments utilized in initiating the process."@en ;
-	rdfs:domain :Process ;
+	rdfs:domain observable:Process ;
 	rdfs:range xsd:string ;
 	.
 
-:asHandle
+observable:asHandle
 	a owl:DatatypeProperty ;
 	rdfs:label "asHandle"@en ;
-	rdfs:domain :AutonomousSystem ;
+	rdfs:domain observable:AutonomousSystem ;
 	rdfs:range xsd:string ;
 	.
 
-:aslrEnabled
+observable:aslrEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "aslrEnabled"@en ;
-	rdfs:domain :WindowsProcess ;
+	rdfs:domain observable:WindowsProcess ;
 	rdfs:range xsd:boolean ;
 	.
 
-:attendant
+observable:attendant
 	a owl:ObjectProperty ;
 	rdfs:label "attendant"@en ;
 	rdfs:comment "The attendants of the event."@en ;
-	rdfs:domain :CalendarEntry ;
+	rdfs:domain observable:CalendarEntry ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/identity#Identity> ;
 	.
 
-:audioType
+observable:audioType
 	a owl:DatatypeProperty ;
 	rdfs:label "audioType"@en ;
 	rdfs:comment "The type of a audio. For example: music or speech."@en ;
-	rdfs:domain :Audio ;
+	rdfs:domain observable:Audio ;
 	rdfs:range xsd:string ;
 	.
 
-:authorityKeyIdentifier
+observable:authorityKeyIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "authorityKeyIdentifier"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:availableRam
+observable:availableRam
 	a owl:DatatypeProperty ;
 	rdfs:label "availableRam"@en ;
 	rdfs:comment "Specifies the amount of physical memory available on the system, in bytes."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:long ;
 	.
 
-:baseOfCode
+observable:baseOfCode
 	a owl:DatatypeProperty ;
 	rdfs:label "baseOfCode"@en ;
 	rdfs:comment "Specifies the address that is relative to the image base of the beginning-of-code section when it is loaded into memory."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:baseStation
+observable:baseStation
 	a owl:DatatypeProperty ;
 	rdfs:label "baseStation"@en ;
 	rdfs:comment "The base station."@en ;
-	rdfs:domain :WirelessNetworkConnection ;
+	rdfs:domain observable:WirelessNetworkConnection ;
 	rdfs:range xsd:string ;
 	.
 
-:basicConstraints
+observable:basicConstraints
 	a owl:DatatypeProperty ;
 	rdfs:label "basicConstraints"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:bcc
+observable:bcc
 	a owl:ObjectProperty ;
 	rdfs:label "bcc"@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:binary
+observable:binary
 	a owl:ObjectProperty ;
 	rdfs:label "binary"@en ;
-	rdfs:domain :Process ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:Process ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:biosDate
+observable:biosDate
 	a owl:DatatypeProperty ;
 	rdfs:label "biosDate"@en ;
 	rdfs:comment "Specifies the date of the BIOS (e.g. the datestamp of the BIOS revision)."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:biosManufacturer
+observable:biosManufacturer
 	a owl:DatatypeProperty ;
 	rdfs:label "biosManufacturer"@en ;
 	rdfs:comment "Specifies the manufacturer of the BIOS."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:biosReleaseDate
+observable:biosReleaseDate
 	a owl:DatatypeProperty ;
 	rdfs:label "biosReleaseDate"@en ;
 	rdfs:comment "Specifies the date the BIOS was released."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:biosSerialNumber
+observable:biosSerialNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "biosSerialNumber"@en ;
 	rdfs:comment "Specifies the serial number of the BIOS."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:biosVersion
+observable:biosVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "biosVersion"@en ;
 	rdfs:comment "Specifies the version of the BIOS."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:bitRate
+observable:bitRate
 	a owl:DatatypeProperty ;
 	rdfs:label "bitRate"@en ;
 	rdfs:comment "The bitrate of the audio in bits per second."@en ;
-	rdfs:domain :Audio ;
+	rdfs:domain observable:Audio ;
 	rdfs:range xsd:long ;
 	.
 
-:bitness
+observable:bitness
 	a owl:DatatypeProperty ;
 	rdfs:label "bitness"@en ;
 	rdfs:comment "Specifies the bitness of the operating system (i.e. 32 or 64). Note that this is potentially different from the word size of the underlying hardware or CPU. A 32-bit operating system can be installed on a machine running a 64-bit processor."@en ;
-	rdfs:domain :OperatingSystem ;
+	rdfs:domain observable:OperatingSystem ;
 	rdfs:range xsd:string ;
 	.
 
-:bitsPerPixel
+observable:bitsPerPixel
 	a owl:DatatypeProperty ;
 	rdfs:label "bitsPerPixel"@en ;
-	rdfs:domain :RasterPicture ;
+	rdfs:domain observable:RasterPicture ;
 	rdfs:range xsd:integer ;
 	.
 
-:blockType
+observable:blockType
 	a owl:DatatypeProperty ;
 	rdfs:label "blockType"@en ;
 	rdfs:comment "The blockType property specifies the block type of a particular memory object."@en ;
-	rdfs:domain :Memory ;
-	rdfs:range :MemoryBlockTypeEnum ;
+	rdfs:domain observable:Memory ;
+	rdfs:range observable:MemoryBlockTypeEnum ;
 	.
 
-:bluetoothDeviceName
+observable:bluetoothDeviceName
 	a owl:DatatypeProperty ;
 	rdfs:label "bluetoothDeviceName"@en ;
 	rdfs:comment "Name configured withing Bluetooth settings on a device."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:string ;
 	.
 
-:body
+observable:body
 	a owl:DatatypeProperty ;
 	rdfs:label "body"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:bodyMultipart
+observable:bodyMultipart
 	a owl:ObjectProperty ;
 	rdfs:label "bodyMultipart"@en ;
 	rdfs:comment "A list of the MIME parts that make up the email body. This field MAY only be used if isMultipart is true."@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :MimePartType ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:MimePartType ;
 	.
 
-:bodyRaw
+observable:bodyRaw
 	a owl:ObjectProperty ;
 	rdfs:label "bodyRaw"@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:bookmarkPath
+observable:bookmarkPath
 	a owl:DatatypeProperty ;
 	rdfs:label "bookmarkPath"@en ;
 	rdfs:comment "The folder containing the bookmark."@en ;
-	rdfs:domain :BrowserBookmark ;
+	rdfs:domain observable:BrowserBookmark ;
 	rdfs:range xsd:string ;
 	.
 
-:byteOrder
+observable:byteOrder
 	a owl:DatatypeProperty ;
 	rdfs:label "byteOrder"@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:string ;
 	.
 
-:byteStringValue
+observable:byteStringValue
 	a owl:DatatypeProperty ;
 	rdfs:label "byteStringValue"@en ;
 	rdfs:comment "Specifies the raw, byte-string representation of the extracted string."@en ;
-	rdfs:domain :ExtractedString ;
+	rdfs:domain observable:ExtractedString ;
 	.
 
-:callType
+observable:callType
 	a owl:DatatypeProperty ;
 	rdfs:label "callType"@en ;
 	rdfs:comment "The type of a phone call,for example incoming, outgoing, missed."@en ;
-	rdfs:domain :PhoneCall ;
+	rdfs:domain observable:PhoneCall ;
 	rdfs:range xsd:string ;
 	.
 
-:camera
+observable:camera
 	a owl:ObjectProperty ;
 	rdfs:label "camera"@en ;
 	rdfs:comment "The name/make of the camera that was used for taking the picture."@en ;
-	rdfs:domain :RasterPicture ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:RasterPicture ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:canEscalatePrivs
+observable:canEscalatePrivs
 	a owl:DatatypeProperty ;
 	rdfs:label "canEscalatePrivs"@en ;
-	rdfs:domain :UserAccount ;
+	rdfs:domain observable:UserAccount ;
 	rdfs:range xsd:boolean ;
 	.
 
-:carrier
+observable:carrier
 	a owl:ObjectProperty ;
 	rdfs:label "carrier"@en ;
 	rdfs:comment "Telecommunications service provider that sold the SIM card."@en ;
-	rdfs:domain :SIMCard ;
+	rdfs:domain observable:SIMCard ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/identity#Identity> ;
 	.
 
-:categories
+observable:categories
 	a owl:DatatypeProperty ;
 	rdfs:label "categories"@en ;
 	rdfs:comment "Categories applied to the object."@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:cc
+observable:cc
 	a owl:ObjectProperty ;
 	rdfs:label "cc"@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:certificateIssuer
+observable:certificateIssuer
 	a owl:ObjectProperty ;
 	rdfs:label "certificateIssuer"@en ;
-	rdfs:domain :DigitalSignatureInfo ;
+	rdfs:domain observable:DigitalSignatureInfo ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/identity#Identity> ;
 	.
 
-:certificatePolicies
+observable:certificatePolicies
 	a owl:DatatypeProperty ;
 	rdfs:label "certificatePolicies"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:certificateSubject
+observable:certificateSubject
 	a owl:ObjectProperty ;
 	rdfs:label "certificateSubject"@en ;
-	rdfs:domain :DigitalSignatureInfo ;
+	rdfs:domain observable:DigitalSignatureInfo ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/core#UcoObject> ;
 	.
 
-:characteristics
+observable:characteristics
 	a owl:DatatypeProperty ;
 	rdfs:label "characteristics"@en ;
 	rdfs:comment "Specifies the flags that indicate the file’s characteristics."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:checksum
+observable:checksum
 	a owl:DatatypeProperty ;
 	rdfs:label "checksum"@en ;
 	rdfs:comment "Specifies the checksum of the PE binary."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:clockSetting
+observable:clockSetting
 	a owl:DatatypeProperty ;
 	rdfs:label "clockSetting"@en ;
 	rdfs:comment "The generalizedTime value on the mobile device when it was processes."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:string ;
 	.
 
-:clusterSize
+observable:clusterSize
 	a owl:DatatypeProperty ;
 	rdfs:label "clusterSize"@en ;
 	rdfs:comment "The size of cluster allocation units in a file system."@en ;
-	rdfs:domain :FileSystem ;
+	rdfs:domain observable:FileSystem ;
 	rdfs:range xsd:integer ;
 	.
 
-:columnName
+observable:columnName
 	a owl:DatatypeProperty ;
 	rdfs:label "columnName"@en ;
-	rdfs:domain :SQLiteBlob ;
+	rdfs:domain observable:SQLiteBlob ;
 	rdfs:range xsd:string ;
 	.
 
-:comClassID
+observable:comClassID
 	a owl:DatatypeProperty ;
 	rdfs:label "comClassID"@en ;
 	rdfs:comment "Specifies the ID of the COM action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380613(v=vs.85).aspx."@en ;
-	rdfs:domain :IComHandlerActionType ;
+	rdfs:domain observable:IComHandlerActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:comData
+observable:comData
 	a owl:DatatypeProperty ;
 	rdfs:label "comData"@en ;
 	rdfs:comment "Specifies the data associated with the COM handler. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380613(v=vs.85).aspx."@en ;
-	rdfs:domain :IComHandlerActionType ;
+	rdfs:domain observable:IComHandlerActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:comment
+observable:comment
 	a owl:DatatypeProperty ;
 	rdfs:label "comment"@en ;
-	rdfs:domain :ArchiveFile ;
+	rdfs:domain observable:ArchiveFile ;
 	rdfs:range xsd:string ;
 	.
 
-:compressionMethod
+observable:compressionMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "compressionMethod"@en ;
 	rdfs:comment "The algorithm used to compress the data."@en ;
-	rdfs:domain :CompressedStream ;
+	rdfs:domain observable:CompressedStream ;
 	rdfs:range xsd:string ;
 	.
 
-:compressionRatio
+observable:compressionRatio
 	a owl:DatatypeProperty ;
 	rdfs:label "compressionRatio"@en ;
 	rdfs:comment "The compression ratio of the compressed data."@en ;
-	rdfs:domain :CompressedStream ;
+	rdfs:domain observable:CompressedStream ;
 	rdfs:range xsd:double ;
 	.
 
-:computerName
+observable:computerName
 	a owl:DatatypeProperty ;
 	rdfs:label "computerName"@en ;
 	rdfs:comment "A name of the computer on which the log entry was created."@en ;
-	rdfs:domain :Event ;
+	rdfs:domain observable:Event ;
 	rdfs:range xsd:string ;
 	.
 
-:contactID
+observable:contactID
 	a owl:DatatypeProperty ;
 	rdfs:label "contactID"@en ;
 	rdfs:comment "Specifies an ID for the contact. This can be presented as Contact ID, Billing ID, Admin ID, Tech ID, etc."@en ;
-	rdfs:domain :WhoisContactType ;
+	rdfs:domain observable:WhoisContactType ;
 	rdfs:range xsd:string ;
 	.
 
-:contactInfo
+observable:contactInfo
 	a owl:ObjectProperty ;
 	rdfs:label "contactInfo"@en ;
 	rdfs:comment "Specifies contact info that would be returned from a contact lookup."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :WhoisContactType ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:WhoisContactType ;
 	.
 
-:contactName
+observable:contactName
 	a owl:DatatypeProperty ;
 	rdfs:label "contactName"@en ;
 	rdfs:comment "The name of a contact."@en ;
-	rdfs:domain :WhoisContactType ;
+	rdfs:domain observable:WhoisContactType ;
 	rdfs:range xsd:string ;
 	.
 
-:contactOrganization
+observable:contactOrganization
 	a owl:ObjectProperty ;
 	rdfs:label "contactOrganization"@en ;
 	rdfs:comment "The name of the organization a contact works for or is assoicated with."@en ;
-	rdfs:domain :WhoisContactType ;
+	rdfs:domain observable:WhoisContactType ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/identity#Identity> ;
 	.
 
-:contactType
+observable:contactType
 	a owl:DatatypeProperty ;
 	rdfs:label "contactType"@en ;
 	rdfs:comment "Specifies what type of contact this is."@en ;
-	rdfs:domain :WhoisContactType ;
-	rdfs:range :WhoisContactTypeEnum ;
+	rdfs:domain observable:WhoisContactType ;
+	rdfs:range observable:WhoisContactTypeEnum ;
 	.
 
-:contentDisposition
+observable:contentDisposition
 	a owl:DatatypeProperty ;
 	rdfs:label "contentDisposition"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:contentType
+observable:contentType
 	a owl:DatatypeProperty ;
 	rdfs:label "contentType"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:context
+observable:context
 	a owl:DatatypeProperty ;
 	rdfs:label "context"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:string ;
 	.
 
-:controlCode
+observable:controlCode
 	a owl:DatatypeProperty ;
 	rdfs:label "controlCode"@en ;
 	rdfs:comment "Specifies the actual control code that was sent to the cyberitem."@en ;
-	rdfs:domain :SendControlCodeEffect ;
+	rdfs:domain observable:SendControlCodeEffect ;
 	rdfs:range xsd:string ;
 	.
 
-:cookieDomain
+observable:cookieDomain
 	a owl:ObjectProperty ;
 	rdfs:label "cookieDomain"@en ;
 	rdfs:comment "The domain for which the cookie is stored, for example nfi.minjus.nl."@en ;
-	rdfs:domain :BrowserCookie ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:BrowserCookie ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:cookieName
+observable:cookieName
 	a owl:DatatypeProperty ;
 	rdfs:label "cookieName"@en ;
 	rdfs:comment "The name of the cookie."@en ;
-	rdfs:domain :BrowserCookie ;
+	rdfs:domain observable:BrowserCookie ;
 	rdfs:range xsd:string ;
 	.
 
-:cookiePath
+observable:cookiePath
 	a owl:DatatypeProperty ;
 	rdfs:label "cookiePath"@en ;
 	rdfs:comment "String representation of the path of the cookie."@en ;
-	rdfs:domain :BrowserCookie ;
+	rdfs:domain observable:BrowserCookie ;
 	rdfs:range xsd:string ;
 	.
 
-:cpeid
+observable:cpeid
 	a owl:DatatypeProperty ;
 	rdfs:label "cpeid"@en ;
 	rdfs:comment "Specifies the Common Platform Enumeration identifier for the software."@en ;
-	rdfs:domain :Software ;
+	rdfs:domain observable:Software ;
 	rdfs:range xsd:string ;
 	.
 
-:cpu
+observable:cpu
 	a owl:DatatypeProperty ;
 	rdfs:label "cpu"@en ;
 	rdfs:comment "Specifies the name of the CPU used by the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:cpuFamily
+observable:cpuFamily
 	a owl:DatatypeProperty ;
 	rdfs:label "cpuFamily"@en ;
 	rdfs:comment "Specifies the name of the CPU family used by the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:createdTime
+observable:createdTime
 	a owl:DatatypeProperty ;
 	rdfs:label "createdTime"@en ;
 	rdfs:comment "The date and time at which the Object was created."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:creationDate
+observable:creationDate
 	a owl:DatatypeProperty ;
 	rdfs:label "creationDate"@en ;
 	rdfs:comment "Specifies the date in which the registered domain was created."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:creationFlags
+observable:creationFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "creationFlags"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:creationTime
+observable:creationTime
 	a owl:DatatypeProperty ;
 	rdfs:label "creationTime"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:creator
+observable:creator
 	a owl:ObjectProperty ;
 	rdfs:label "creator"@en ;
 	rdfs:comment "Specifies the name of the creator of the registry key."@en ;
-	rdfs:domain :WindowsRegistryKey ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsRegistryKey ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:creatorUser
+observable:creatorUser
 	a owl:ObjectProperty ;
 	rdfs:label "creatorUser"@en ;
 	rdfs:comment "The user that created/owns the process."@en ;
-	rdfs:domain :Process ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:Process ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:crlDistributionPoints
+observable:crlDistributionPoints
 	a owl:DatatypeProperty ;
 	rdfs:label "crlDistributionPoints"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:currentSystemDate
+observable:currentSystemDate
 	a owl:DatatypeProperty ;
 	rdfs:label "currentSystemDate"@en ;
 	rdfs:comment "Specifies the current date on the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:currentWorkingDirectory
+observable:currentWorkingDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "currentWorkingDirectory"@en ;
-	rdfs:domain :Process ;
+	rdfs:domain observable:Process ;
 	rdfs:range xsd:string ;
 	.
 
-:cyberAction
+observable:cyberAction
 	a owl:ObjectProperty ;
 	rdfs:label "cyberAction"@en ;
 	rdfs:comment "The action taken in response to the event."@en ;
-	rdfs:domain :Event ;
-	rdfs:range :CyberAction ;
+	rdfs:domain observable:Event ;
+	rdfs:range observable:CyberAction ;
 	.
 
-:data
+observable:data
 	a owl:DatatypeProperty ;
 	rdfs:label "data"@en ;
-	rdfs:domain :WindowsRegistryValue ;
+	rdfs:domain observable:WindowsRegistryValue ;
 	rdfs:range xsd:string ;
 	.
 
-:dataPayload
+observable:dataPayload
 	a owl:DatatypeProperty ;
 	rdfs:label "dataPayload"@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:string ;
 	.
 
-:dataPayloadReferenceURL
+observable:dataPayloadReferenceURL
 	a owl:ObjectProperty ;
 	rdfs:label "dataPayloadReferenceURL"@en ;
-	rdfs:domain :ContentData ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:ContentData ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:dataType
+observable:dataType
 	a owl:DatatypeProperty ;
 	rdfs:label "dataType"@en ;
-	rdfs:domain :WindowsRegistryValue ;
+	rdfs:domain observable:WindowsRegistryValue ;
 	rdfs:range xsd:string ;
 	.
 
-:depEnabled
+observable:depEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "depEnabled"@en ;
-	rdfs:domain :WindowsProcess ;
+	rdfs:domain observable:WindowsProcess ;
 	rdfs:range xsd:boolean ;
 	.
 
-:descriptions
+observable:descriptions
 	a owl:DatatypeProperty ;
 	rdfs:label "descriptions"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:destination
+observable:destination
 	a owl:DatatypeProperty ;
 	rdfs:label "destination"@en ;
 	rdfs:comment "The destination of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
-	rdfs:domain :GlobalFlagType ;
+	rdfs:domain observable:GlobalFlagType ;
 	rdfs:range xsd:string ;
 	.
 
-:destinationFlags
+observable:destinationFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "destinationFlags"@en ;
 	rdfs:comment """Specifies the destination TCP flags.
           """@en ;
-	rdfs:domain :TCPConnection ;
+	rdfs:domain observable:TCPConnection ;
 	.
 
-:destinationPort
+observable:destinationPort
 	a owl:DatatypeProperty ;
 	rdfs:label "destinationPort"@en ;
 	rdfs:comment "Specifies the destination port used in the connection, as an integer in the range of 0 - 65535."@en ;
-	rdfs:domain :NetworkConnection ;
+	rdfs:domain observable:NetworkConnection ;
 	rdfs:range xsd:integer ;
 	.
 
-:deviceType
+observable:deviceType
 	a owl:DatatypeProperty ;
 	rdfs:label "deviceType"@en ;
-	rdfs:domain :Device ;
+	rdfs:domain observable:Device ;
 	rdfs:range xsd:string ;
 	.
 
-:dhcpLeaseExpires
+observable:dhcpLeaseExpires
 	a owl:DatatypeProperty ;
 	rdfs:label "dhcpLeaseExpires"@en ;
 	rdfs:comment "Specifies the date/time that the DHCP lease obtained on the network interface expires."@en ;
-	rdfs:domain :NetworkInterface ;
+	rdfs:domain observable:NetworkInterface ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:dhcpLeaseObtained
+observable:dhcpLeaseObtained
 	a owl:DatatypeProperty ;
 	rdfs:label "dhcpLeaseObtained"@en ;
 	rdfs:comment "Specifies the date/time that the DHCP lease was obtained on the network interface."@en ;
-	rdfs:domain :NetworkInterface ;
+	rdfs:domain observable:NetworkInterface ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:dhcpServer
+observable:dhcpServer
 	a owl:ObjectProperty ;
 	rdfs:label "dhcpServer"@en ;
 	rdfs:comment "Specifies the list of DHCP server IP Addresses used by the network interface."@en ;
-	rdfs:domain :NetworkInterface ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:NetworkInterface ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:diskPartitionType
+observable:diskPartitionType
 	a owl:DatatypeProperty ;
 	rdfs:label "diskPartitionType"@en ;
 	rdfs:comment "Specifies the type of partition being characterized."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:string ;
 	.
 
-:diskSize
+observable:diskSize
 	a owl:DatatypeProperty ;
 	rdfs:label "diskSize"@en ;
 	rdfs:comment "The size of the disk, in bytes."@en ;
-	rdfs:domain :Disk ;
+	rdfs:domain observable:Disk ;
 	rdfs:range xsd:long ;
 	.
 
-:diskType
+observable:diskType
 	a owl:DatatypeProperty ;
 	rdfs:label "diskType"@en ;
 	rdfs:comment "The type of disk being characterized, e.g., removable."@en ;
-	rdfs:domain :Disk ;
+	rdfs:domain observable:Disk ;
 	rdfs:range xsd:string ;
 	.
 
-:displayName
+observable:displayName
 	a owl:DatatypeProperty ;
 	rdfs:label "displayName"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:dllCharacteristics
+observable:dllCharacteristics
 	a owl:DatatypeProperty ;
 	rdfs:label "dllCharacteristics"@en ;
 	rdfs:comment "Specifies the flags that characterize the PE binary."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:dnssec
+observable:dnssec
 	a owl:DatatypeProperty ;
 	rdfs:label "dnssec"@en ;
 	rdfs:comment 'Specifies the DNSSEC property associated with a Whois entry. Acceptable values are: "Signed" or "Unsigned".'@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :WhoisDNSSECTypeEnum ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:WhoisDNSSECTypeEnum ;
 	.
 
-:documentInformationDictionary
+observable:documentInformationDictionary
 	a owl:ObjectProperty ;
 	rdfs:label "documentInformationDictionary"@en ;
-	rdfs:domain :PDFFIle ;
+	rdfs:domain observable:PDFFIle ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#ControlledDictionary> ;
 	.
 
-:domain
+observable:domain
 	a owl:DatatypeProperty ;
 	rdfs:label "domain"@en ;
 	rdfs:comment "The domain(s) that the system belongs to."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
+	rdfs:domain observable:WindowsComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:domainID
+observable:domainID
 	a owl:DatatypeProperty ;
 	rdfs:label "domainID"@en ;
 	rdfs:comment "Specifies the domain id for the domain associated with a Whois entry."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:string ;
 	.
 
-:domainName
+observable:domainName
 	a owl:ObjectProperty ;
 	rdfs:label "domainName"@en ;
 	rdfs:comment "Specifies the corresponding domain name for a whois entry."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:driveLetter
+observable:driveLetter
 	a owl:DatatypeProperty ;
 	rdfs:label "driveLetter"@en ;
 	rdfs:comment "Specifies the drive letter of a windows volume."@en ;
-	rdfs:domain :WindowsVolume ;
+	rdfs:domain observable:WindowsVolume ;
 	rdfs:range xsd:string ;
 	.
 
-:driveType
+observable:driveType
 	a owl:DatatypeProperty ;
 	rdfs:label "driveType"@en ;
 	rdfs:comment "Specifies the drive type of a windows volume."@en ;
-	rdfs:domain :WindowsVolume ;
-	rdfs:range :WindowsDriveTypeEnum ;
+	rdfs:domain observable:WindowsVolume ;
+	rdfs:range observable:WindowsDriveTypeEnum ;
 	.
 
-:dst
+observable:dst
 	a owl:ObjectProperty ;
 	rdfs:label "dst"@en ;
 	rdfs:comment "Specifies the destination(s) of the network connection."@en ;
-	rdfs:domain :NetworkConnection ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:NetworkConnection ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:dstBytes
+observable:dstBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "dstBytes"@en ;
-	rdfs:domain :NetworkFlow ;
+	rdfs:domain observable:NetworkFlow ;
 	rdfs:range xsd:integer ;
 	.
 
-:dstPackets
+observable:dstPackets
 	a owl:DatatypeProperty ;
 	rdfs:label "dstPackets"@en ;
-	rdfs:domain :NetworkFlow ;
+	rdfs:domain observable:NetworkFlow ;
 	rdfs:range xsd:integer ;
 	.
 
-:dstPayload
+observable:dstPayload
 	a owl:ObjectProperty ;
 	rdfs:label "dstPayload"@en ;
-	rdfs:domain :NetworkFlow ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:NetworkFlow ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:duration
+observable:duration
 	a owl:DatatypeProperty ;
 	rdfs:label "duration"@en ;
 	rdfs:comment "The duration of the phone call in seconds."@en ;
-	rdfs:domain :PhoneCall ;
+	rdfs:domain observable:PhoneCall ;
 	rdfs:range xsd:long ;
 	.
 
-:effectiveGroup
+observable:effectiveGroup
 	a owl:DatatypeProperty ;
 	rdfs:label "effectiveGroup"@en ;
 	rdfs:comment "Specifies the name of the effective group used in the user session."@en ;
-	rdfs:domain :UserSession ;
+	rdfs:domain observable:UserSession ;
 	rdfs:range xsd:string ;
 	.
 
-:effectiveGroupID
+observable:effectiveGroupID
 	a owl:DatatypeProperty ;
 	rdfs:label "effectiveGroupID"@en ;
 	rdfs:comment "Specifies the effective group ID of the group used in the user session."@en ;
-	rdfs:domain :UserSession ;
+	rdfs:domain observable:UserSession ;
 	rdfs:range xsd:string ;
 	.
 
-:effectiveUser
+observable:effectiveUser
 	a owl:ObjectProperty ;
 	rdfs:label "effectiveUser"@en ;
 	rdfs:comment "Specifies the effective user details used in the user session."@en ;
-	rdfs:domain :UserSession ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:UserSession ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:emailAddress
+observable:emailAddress
 	a owl:ObjectProperty ;
 	rdfs:label "emailAddress"@en ;
 	rdfs:comment "An email address."@en ;
-	rdfs:domain :WhoisContactType ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoisContactType ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:encoding
+observable:encoding
 	a owl:DatatypeProperty ;
 	rdfs:label "Encoding"@en ;
 	rdfs:comment "The encoding method used for the extracted string."@en ;
-	rdfs:domain :ExtractedString ;
+	rdfs:domain observable:ExtractedString ;
 	rdfs:range xsd:string ;
 	.
 
-:encodingMethod
+observable:encodingMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "encodingMethod"@en ;
-	rdfs:domain :EncodedStream ;
+	rdfs:domain observable:EncodedStream ;
 	rdfs:range xsd:string ;
 	.
 
-:encryptionIV
+observable:encryptionIV
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionIV"@en ;
-	rdfs:domain :EncryptedStream ;
+	rdfs:domain observable:EncryptedStream ;
 	rdfs:range xsd:string ;
 	.
 
-:encryptionKey
+observable:encryptionKey
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionKey"@en ;
-	rdfs:domain :EncryptedStream ;
+	rdfs:domain observable:EncryptedStream ;
 	rdfs:range xsd:string ;
 	.
 
-:encryptionMethod
+observable:encryptionMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionMethod"@en ;
-	rdfs:domain :EncryptedStream ;
+	rdfs:domain observable:EncryptedStream ;
 	rdfs:range xsd:string ;
 	.
 
-:encryptionMode
+observable:encryptionMode
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionMode"@en ;
-	rdfs:domain :EncryptedStream ;
+	rdfs:domain observable:EncryptedStream ;
 	rdfs:range xsd:string ;
 	.
 
-:endTime
+observable:endTime
 	a owl:DatatypeProperty ;
 	rdfs:label "endTime"@en ;
-	rdfs:domain :PhoneCall ;
+	rdfs:domain observable:PhoneCall ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:englishTranslation
+observable:englishTranslation
 	a owl:DatatypeProperty ;
 	rdfs:label "englishTranslation"@en ;
 	rdfs:comment "Specifies the English translation of the string, if it is not written in English."@en ;
-	rdfs:domain :ExtractedString ;
+	rdfs:domain observable:ExtractedString ;
 	rdfs:range xsd:string ;
 	.
 
-:entropy
+observable:entropy
 	a owl:DatatypeProperty ;
 	rdfs:label "entropy"@en ;
 	rdfs:comment "Shannon entropy (a measure of randomness) of the data."@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:double ;
 	.
 
-:entryID
+observable:entryID
 	a owl:DatatypeProperty ;
 	rdfs:label "entryID"@en ;
 	rdfs:comment "A unique identifier for the file within the filesystem."@en ;
-	rdfs:domain :NTFSFileSystem ;
+	rdfs:domain observable:NTFSFileSystem ;
 	rdfs:range xsd:long ;
 	.
 
-:environmentVariables
+observable:environmentVariables
 	a owl:ObjectProperty ;
 	rdfs:label "environmentVariables"@en ;
 	rdfs:comment "A list of environment variables associated with the process. "@en ;
-	rdfs:domain :Process ;
+	rdfs:domain observable:Process ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Dictionary> ;
 	.
 
-:eventID
+observable:eventID
 	a owl:DatatypeProperty ;
 	rdfs:label "eventID"@en ;
 	rdfs:comment "The identifier of the event."@en ;
-	rdfs:domain :Event ;
+	rdfs:domain observable:Event ;
 	rdfs:range xsd:string ;
 	.
 
-:eventStatus
+observable:eventStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "eventStatus"@en ;
 	rdfs:comment "The status of the event, for instance accepted, pending or cancelled."@en ;
-	rdfs:domain :CalendarEntry ;
+	rdfs:domain observable:CalendarEntry ;
 	rdfs:range xsd:string ;
 	.
 
-:eventText
+observable:eventText
 	a owl:DatatypeProperty ;
 	rdfs:label "eventText"@en ;
 	rdfs:comment "The textual representation of the event."@en ;
-	rdfs:domain :Event ;
+	rdfs:domain observable:Event ;
 	rdfs:range xsd:string ;
 	.
 
-:eventType
+observable:eventType
 	a owl:DatatypeProperty ;
 	rdfs:label "eventType"@en ;
 	rdfs:comment 'The type of the event, for example \\"information\\", \\"warning\\" or \\"error\\".'@en ;
-	rdfs:domain :Event ;
+	rdfs:domain observable:Event ;
 	rdfs:range xsd:string ;
 	.
 
-:execArguments
+observable:execArguments
 	a owl:DatatypeProperty ;
 	rdfs:label "execArguments"@en ;
 	rdfs:comment "Specifies the arguments associated with the command-line operation launched by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
-	rdfs:domain :IExecActionType ;
+	rdfs:domain observable:IExecActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:execProgramHashes
+observable:execProgramHashes
 	a owl:ObjectProperty ;
 	rdfs:label "execProgramHashes"@en ;
 	rdfs:comment "Specifies the hashes of the executable file launched by the action."@en ;
-	rdfs:domain :IExecActionType ;
+	rdfs:domain observable:IExecActionType ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Hash> ;
 	.
 
-:execProgramPath
+observable:execProgramPath
 	a owl:DatatypeProperty ;
 	rdfs:label "execProgramPath"@en ;
 	rdfs:comment "Specifies the path to the executable file launched by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
-	rdfs:domain :IExecActionType ;
+	rdfs:domain observable:IExecActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:execWorkingDirectory
+observable:execWorkingDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "execWorkingDirectory"@en ;
 	rdfs:comment "Specifies the directory that contains either the executable file or the files that are used by the executable file launched by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
-	rdfs:domain :IExecActionType ;
+	rdfs:domain observable:IExecActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:exifData
+observable:exifData
 	a owl:ObjectProperty ;
 	rdfs:label "exifData"@en ;
-	rdfs:domain :EXIF ;
+	rdfs:domain observable:EXIF ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#ControlledDictionary> ;
 	.
 
-:exitCode
+observable:exitCode
 	a owl:DatatypeProperty ;
 	rdfs:label "exitCode"@en ;
 	rdfs:comment "Specifies the last exit code of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381245(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:long ;
 	.
 
-:exitStatus
+observable:exitStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "exitStatus"@en ;
 	rdfs:comment "A small number passed from the process to the parent process when it has finished executing. In general, 0 indicates successful termination, any other number indicates a failure."@en ;
-	rdfs:domain :Process ;
+	rdfs:domain observable:Process ;
 	rdfs:range xsd:long ;
 	.
 
-:exitTime
+observable:exitTime
 	a owl:DatatypeProperty ;
 	rdfs:label "exitTime"@en ;
 	rdfs:comment "The time at which the process exited."@en ;
-	rdfs:domain :Process ;
+	rdfs:domain observable:Process ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:expirationDate
+observable:expirationDate
 	a owl:DatatypeProperty ;
 	rdfs:label "expirationDate"@en ;
 	rdfs:comment "Specifies the date in which the registered domain will expire."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:expirationTime
+observable:expirationTime
 	a owl:DatatypeProperty ;
 	rdfs:label "expirationTime"@en ;
 	rdfs:comment "The date and time at which the validity of the object expires."@en ;
-	rdfs:domain :BrowserCookie ;
+	rdfs:domain observable:BrowserCookie ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:extDeletionTime
+observable:extDeletionTime
 	a owl:DatatypeProperty ;
 	rdfs:label "extDeletionTime"@en ;
 	rdfs:comment 'Specifies the time at which the file represented by an Inode was "deleted".'@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:extFileType
+observable:extFileType
 	a owl:DatatypeProperty ;
 	rdfs:label "extFileType"@en ;
 	rdfs:comment "Specifies the EXT file type (FIFO, Directory, Regular file, Symbolic link, etc) for the Inode."@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:integer ;
 	.
 
-:extFlags
+observable:extFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "extFlags"@en ;
 	rdfs:comment "Specifies user flags to further protect (limit its use and modification) the file represented by an Inode."@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:integer ;
 	.
 
-:extHardLinkCount
+observable:extHardLinkCount
 	a owl:DatatypeProperty ;
 	rdfs:label "extHardLinkCount"@en ;
 	rdfs:comment "Specifies a count of how many hard links point to an Inode."@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:integer ;
 	.
 
-:extInodeChangeTime
+observable:extInodeChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "extInodeChangeTime"@en ;
 	rdfs:comment "The date and time at which the file Inode metadata was last modified."@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:extInodeID
+observable:extInodeID
 	a owl:DatatypeProperty ;
 	rdfs:label "extInodeID"@en ;
 	rdfs:comment "Specifies a single Inode identifier."@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:integer ;
 	.
 
-:extPermissions
+observable:extPermissions
 	a owl:DatatypeProperty ;
 	rdfs:label "extPermissions"@en ;
 	rdfs:comment "Specifies the read/write/execute permissions for the file represented by an EXT Inode."@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:integer ;
 	.
 
-:extSGID
+observable:extSGID
 	a owl:DatatypeProperty ;
 	rdfs:label "extSGID"@en ;
 	rdfs:comment "Specifies the group ID for the file represented by an Inode."@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:integer ;
 	.
 
-:extSUID
+observable:extSUID
 	a owl:DatatypeProperty ;
 	rdfs:label "extSUID"@en ;
 	rdfs:comment 'Specifies the user ID that "owns" the file represented by an Inode.'@en ;
-	rdfs:domain :ExtInode ;
+	rdfs:domain observable:ExtInode ;
 	rdfs:range xsd:integer ;
 	.
 
-:extendedKeyUsage
+observable:extendedKeyUsage
 	a owl:DatatypeProperty ;
 	rdfs:label "extendedKeyUsage"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:extension
+observable:extension
 	a owl:DatatypeProperty ;
 	rdfs:label "extension"@en ;
 	rdfs:comment "The file name extension: everything after the last dot. Not present if the file has no dot in its name."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:string ;
 	.
 
-:faxNumber
+observable:faxNumber
 	a owl:ObjectProperty ;
 	rdfs:label "faxNumber"@en ;
 	rdfs:comment "A phone number(account) of a fax."@en ;
-	rdfs:domain :WhoisContactType ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoisContactType ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:fileAlignment
+observable:fileAlignment
 	a owl:DatatypeProperty ;
 	rdfs:label "fileAlignment"@en ;
 	rdfs:comment "Specifies the factor (in bytes) that is used to align the raw data of sections in the image file."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:fileHeaderHashes
+observable:fileHeaderHashes
 	a owl:ObjectProperty ;
 	rdfs:label "fileHeaderHashes"@en ;
 	rdfs:comment "Specifies any hashes that were computed for the file header."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Hash> ;
 	.
 
-:fileName
+observable:fileName
 	a owl:DatatypeProperty ;
 	rdfs:label "fileName"@en ;
 	rdfs:comment "Specifies the name associated with a file in a file system."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:string ;
 	.
 
-:filePath
+observable:filePath
 	a owl:DatatypeProperty ;
 	rdfs:label "filePath"@en ;
 	rdfs:comment "Specifies the file path for the location of a file within a filesystem."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:string ;
 	.
 
-:fileSystemType
+observable:fileSystemType
 	a owl:DatatypeProperty ;
 	rdfs:label "fileSystemType"@en ;
 	rdfs:comment "The specific type of a file system."@en ;
-	rdfs:domain :FileSystem ;
+	rdfs:domain observable:FileSystem ;
 	rdfs:range xsd:string ;
 	.
 
-:firstLoginTime
+observable:firstLoginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "firstLoginTime"@en ;
 	rdfs:comment "The date and time of the first login of the account."@en ;
-	rdfs:domain :DigitalAccount ;
+	rdfs:domain observable:DigitalAccount ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:firstName
+observable:firstName
 	a owl:DatatypeProperty ;
 	rdfs:label "firstName"@en ;
 	rdfs:comment "The first name of the contact."@en ;
-	rdfs:domain :Contact ;
+	rdfs:domain observable:Contact ;
 	rdfs:range xsd:string ;
 	.
 
-:firstRun
+observable:firstRun
 	a owl:DatatypeProperty ;
 	rdfs:label "firstRun"@en ;
 	rdfs:comment "Timestamp of when the prefetch application was first run."@en ;
-	rdfs:domain :WindowsPrefetch ;
+	rdfs:domain observable:WindowsPrefetch ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:flags
+observable:flags
 	a owl:DatatypeProperty ;
 	rdfs:label "flags"@en ;
 	rdfs:comment "Specifies any flags that modify the behavior of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381248(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
-	rdfs:range :TaskFlagEnum ;
+	rdfs:domain observable:WindowsTask ;
+	rdfs:range observable:TaskFlagEnum ;
 	.
 
-:format
+observable:format
 	a owl:DatatypeProperty ;
 	rdfs:label "format"@en ;
 	rdfs:comment "The format of the audio. For example: mp3 or flac."@en ;
-	rdfs:domain :Audio ;
+	rdfs:domain observable:Audio ;
 	rdfs:range xsd:string ;
 	.
 
-:fragment
+observable:fragment
 	a owl:DatatypeProperty ;
 	rdfs:label "fragment"@en ;
 	rdfs:comment "Fragment pointing to a specific part in the resource."@en ;
-	rdfs:domain :URL ;
+	rdfs:domain observable:URL ;
 	rdfs:range xsd:string ;
 	.
 
-:fragmentIndex
+observable:fragmentIndex
 	a owl:DatatypeProperty ;
 	rdfs:label "fragmentIndex"@en ;
-	rdfs:domain :Fragment ;
+	rdfs:domain observable:Fragment ;
 	rdfs:range xsd:integer ;
 	.
 
-:freeSpace
+observable:freeSpace
 	a owl:DatatypeProperty ;
 	rdfs:label "freeSpace"@en ;
 	rdfs:comment "The amount of free space on the disk, in bytes."@en ;
-	rdfs:domain :Disk ;
+	rdfs:domain observable:Disk ;
 	rdfs:range xsd:long ;
 	.
 
-:from
+observable:from
 	a owl:ObjectProperty ;
 	rdfs:label "from"@en ;
 	rdfs:comment "The phone number of the initiating party."@en ;
-	rdfs:domain :PhoneCall ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:PhoneCall ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:fullValue
+observable:fullValue
 	a owl:DatatypeProperty ;
 	rdfs:label "fullValue"@en ;
 	rdfs:comment "The full string value of the URL."@en ;
-	rdfs:domain :URL ;
+	rdfs:domain observable:URL ;
 	rdfs:range xsd:string ;
 	.
 
-:geoLocationEntry
+observable:geoLocationEntry
 	a owl:ObjectProperty ;
 	rdfs:label "geoLocationEntry"@en ;
-	rdfs:domain :GeoLocationTrack ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:GeoLocationTrack ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:gid
+observable:gid
 	a owl:DatatypeProperty ;
 	rdfs:label "gid"@en ;
-	rdfs:domain :UNIXAccount ;
+	rdfs:domain observable:UNIXAccount ;
 	rdfs:range xsd:integer ;
 	.
 
-:globalFlagList
+observable:globalFlagList
 	a owl:ObjectProperty ;
 	rdfs:label "globalFlagList"@en ;
 	rdfs:comment "A list of global flags. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549557(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
-	rdfs:range :GlobalFlagType ;
+	rdfs:domain observable:WindowsComputerSpecification ;
+	rdfs:range observable:GlobalFlagType ;
 	.
 
-:gpu
+observable:gpu
 	a owl:DatatypeProperty ;
 	rdfs:label "gpu"@en ;
 	rdfs:comment "Specifies the name of the GPU used by the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:gpuFamily
+observable:gpuFamily
 	a owl:DatatypeProperty ;
 	rdfs:label "gpuFamily"@en ;
 	rdfs:comment "Specifies the name of the GPU family used by the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:groupName
+observable:groupName
 	a owl:DatatypeProperty ;
 	rdfs:label "groupName"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:groups
+observable:groups
 	a owl:DatatypeProperty ;
 	rdfs:label "groups"@en ;
-	rdfs:domain :WindowsAccount ;
+	rdfs:domain observable:WindowsAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:hasChanged
+observable:hasChanged
 	a owl:DatatypeProperty ;
 	rdfs:label "hasChanged"@en ;
-	rdfs:domain :CyberItem ;
+	rdfs:domain observable:CyberItem ;
 	rdfs:range xsd:boolean ;
 	.
 
-:hash
+observable:hash
 	a owl:ObjectProperty ;
 	rdfs:label "hash"@en ;
 	rdfs:comment "Hash values of the data."@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Hash> ;
 	.
 
-:hashes
+observable:hashes
 	a owl:ObjectProperty ;
 	rdfs:label "hashes"@en ;
 	rdfs:comment "Specifies any hashes computed over the section."@en ;
-	rdfs:domain :WindowsPESection ;
+	rdfs:domain observable:WindowsPESection ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Hash> ;
 	.
 
-:headerRaw
+observable:headerRaw
 	a owl:ObjectProperty ;
 	rdfs:label "headerRaw"@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:hexadecimalValue
+observable:hexadecimalValue
 	a owl:DatatypeProperty ;
 	rdfs:label "hexadecimalValue"@en ;
 	rdfs:comment "The hexadecimal value of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
-	rdfs:domain :GlobalFlagType ;
+	rdfs:domain observable:GlobalFlagType ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:hiveType
+observable:hiveType
 	a owl:DatatypeProperty ;
 	rdfs:label "hiveType"@en ;
 	rdfs:comment "The type of a registry hive."@en ;
-	rdfs:domain :WindowsRegistryHive ;
+	rdfs:domain observable:WindowsRegistryHive ;
 	rdfs:range xsd:string ;
 	.
 
-:homeDirectory
+observable:homeDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "homeDirectory"@en ;
-	rdfs:domain :UserAccount ;
+	rdfs:domain observable:UserAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:host
+observable:host
 	a owl:ObjectProperty ;
 	rdfs:label "host"@en ;
 	rdfs:comment "Domain name or IP address where the resource is located."@en ;
-	rdfs:domain :URL ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:URL ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:hostname
+observable:hostname
 	a owl:DatatypeProperty ;
 	rdfs:label "hostname"@en ;
 	rdfs:comment "Specifies the hostname of the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:httpMesageBodyLength
+observable:httpMesageBodyLength
 	a owl:DatatypeProperty ;
 	rdfs:label "httpMesageBodyLength"@en ;
 	rdfs:comment "Specifies the length of an HTTP message body in bytes."@en ;
-	rdfs:domain :HTTPConnection ;
+	rdfs:domain observable:HTTPConnection ;
 	rdfs:range xsd:integer ;
 	.
 
-:httpMessageBodyData
+observable:httpMessageBodyData
 	a owl:ObjectProperty ;
 	rdfs:label "httpMessageBodyData"@en ;
 	rdfs:comment "Specifies the data contained in an HTTP message body."@en ;
-	rdfs:domain :HTTPConnection ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:HTTPConnection ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:httpRequestHeader
+observable:httpRequestHeader
 	a owl:ObjectProperty ;
 	rdfs:label "httpRequestHeader"@en ;
 	rdfs:comment "Specifies all of the HTTP header fields that may be found in the HTTP client request"@en ;
-	rdfs:domain :HTTPConnection ;
+	rdfs:domain observable:HTTPConnection ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Dictionary> ;
 	.
 
-:iComHandlerAction
+observable:iComHandlerAction
 	a owl:ObjectProperty ;
 	rdfs:label "iComHandlerAction"@en ;
 	rdfs:comment "Specifies the data associated with the task action-fired COM handler."@en ;
-	rdfs:domain :TaskActionType ;
-	rdfs:range :IComHandlerActionType ;
+	rdfs:domain observable:TaskActionType ;
+	rdfs:range observable:IComHandlerActionType ;
 	.
 
-:iEmailAction
+observable:iEmailAction
 	a owl:ObjectProperty ;
 	rdfs:label "iEmailAction"@en ;
 	rdfs:comment "Specifies an action that sends an e-mail, which in this context refers to actual email message sent. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380693(v=vs.85).aspx."@en ;
-	rdfs:domain :TaskActionType ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:TaskActionType ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:iExecAction
+observable:iExecAction
 	a owl:ObjectProperty ;
 	rdfs:label "iExecAction"@en ;
 	rdfs:comment "Specifies an action that executes a command-line operation. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
-	rdfs:domain :TaskActionType ;
-	rdfs:range :IExecActionType ;
+	rdfs:domain observable:TaskActionType ;
+	rdfs:range observable:IExecActionType ;
 	.
 
-:iShowMessageAction
+observable:iShowMessageAction
 	a owl:ObjectProperty ;
 	rdfs:label "iShowMessageAction"@en ;
 	rdfs:comment "Specifies an action that shows a message box when a task is activated. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381302(v=vs.85).aspx."@en ;
-	rdfs:domain :TaskActionType ;
-	rdfs:range :IShowMessageActionType ;
+	rdfs:domain observable:TaskActionType ;
+	rdfs:range observable:IShowMessageActionType ;
 	.
 
-:icmpCode
+observable:icmpCode
 	a owl:DatatypeProperty ;
 	rdfs:label "icmpCode"@en ;
 	rdfs:comment "Specifies the ICMP code byte."@en ;
-	rdfs:domain :ICMPConnection ;
+	rdfs:domain observable:ICMPConnection ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:icmpType
+observable:icmpType
 	a owl:DatatypeProperty ;
 	rdfs:label "icmpType"@en ;
 	rdfs:comment "Specifies the ICMP type byte."@en ;
-	rdfs:domain :ICMPConnection ;
+	rdfs:domain observable:ICMPConnection ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:imageBase
+observable:imageBase
 	a owl:DatatypeProperty ;
 	rdfs:label "imageBase"@en ;
 	rdfs:comment "Specifies the address that is relative to the image base of the beginning-of-data section when it is loaded into memory."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:imageCompressionMethod
+observable:imageCompressionMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "imageCompressionMethod"@en ;
-	rdfs:domain :RasterPicture ;
+	rdfs:domain observable:RasterPicture ;
 	rdfs:range xsd:string ;
 	.
 
-:imageName
+observable:imageName
 	a owl:DatatypeProperty ;
 	rdfs:label "imageName"@en ;
 	rdfs:comment "Specifies the image name for the task."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:string ;
 	.
 
-:imageType
+observable:imageType
 	a owl:DatatypeProperty ;
 	rdfs:label "imageType"@en ;
 	rdfs:comment "The type of the image, e.g. EnCase, RAW or LocalFolder."@en ;
-	rdfs:domain :Image ;
+	rdfs:domain observable:Image ;
 	rdfs:range xsd:string ;
 	.
 
-:impHash
+observable:impHash
 	a owl:DatatypeProperty ;
 	rdfs:label "impHash"@en ;
 	rdfs:comment "Specifies the special import hash, or ‘imphash’, calculated for the PE Binary based on its imported libraries and functions. "@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:string ;
 	.
 
-:inReplyTo
+observable:inReplyTo
 	a owl:ObjectProperty ;
 	rdfs:label "inReplyTo"@en ;
 	rdfs:comment "One of more unique identifiers for identifying the email(s) this email is a reply to."@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:inhibitAnyPolicy
+observable:inhibitAnyPolicy
 	a owl:DatatypeProperty ;
 	rdfs:label "inhibitAnyPolicy"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:installDate
+observable:installDate
 	a owl:DatatypeProperty ;
 	rdfs:label "installDate"@en ;
 	rdfs:comment "Specifies the date the operating system was installed."@en ;
-	rdfs:domain :OperatingSystem ;
+	rdfs:domain observable:OperatingSystem ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:ip
+observable:ip
 	a owl:ObjectProperty ;
 	rdfs:label "ip"@en ;
 	rdfs:comment "Specifies the list of IP addresses used by the network interface."@en ;
-	rdfs:domain :NetworkInterface ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:NetworkInterface ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:ipAddress
+observable:ipAddress
 	a owl:ObjectProperty ;
 	rdfs:label "ipAddress"@en ;
 	rdfs:comment "Specifies the corresponding ip address for a whois entry. Usually corresponds to a nameserver lookup."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:ipGateway
+observable:ipGateway
 	a owl:ObjectProperty ;
 	rdfs:label "ipGateway"@en ;
 	rdfs:comment "Specifies the list of IP Gateway IP Addresses used by the network interface."@en ;
-	rdfs:domain :NetworkInterface ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:NetworkInterface ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:ipfix
+observable:ipfix
 	a owl:ObjectProperty ;
 	rdfs:label "ipfix"@en ;
 	rdfs:comment "Specifies any IP Flow Information Export (IPFIX) data for the network traffic flow."@en ;
-	rdfs:domain :NetworkFlow ;
+	rdfs:domain observable:NetworkFlow ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Dictionary> ;
 	.
 
-:isActive
+observable:isActive
 	a owl:DatatypeProperty ;
 	rdfs:label "isActive"@en ;
 	rdfs:comment "Indicates whether the network connection is still active."@en ;
-	rdfs:domain :NetworkConnection ;
+	rdfs:domain observable:NetworkConnection ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isDirectory
+observable:isDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "isDirectory"@en ;
 	rdfs:comment "Specifies whether a file entry represents a directory."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isDisabled
+observable:isDisabled
 	a owl:DatatypeProperty ;
 	rdfs:label "isDisabled"@en ;
 	rdfs:comment "Is the digital account disabled?"@en ;
-	rdfs:domain :DigitalAccount ;
+	rdfs:domain observable:DigitalAccount ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isEnabled
+observable:isEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "isEnabled"@en ;
 	rdfs:comment "Specifies whether the trigger is enabled."@en ;
-	rdfs:domain :TriggerType ;
+	rdfs:domain observable:TriggerType ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isEncrypted
+observable:isEncrypted
 	a owl:DatatypeProperty ;
 	rdfs:label "isEncrypted"@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isHidden
+observable:isHidden
 	a owl:DatatypeProperty ;
 	rdfs:label "isHidden"@en ;
 	rdfs:comment """The isHidden property specifies whether the process is hidden or not.
           """@en ;
-	rdfs:domain :Process ;
+	rdfs:domain observable:Process ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isInjected
+observable:isInjected
 	a owl:DatatypeProperty ;
 	rdfs:label "isInjected"@en ;
 	rdfs:comment "The isInjected property specifies whether or not the particular memory object has had data/code injected into it by another process."@en ;
-	rdfs:domain :Memory ;
+	rdfs:domain observable:Memory ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isMapped
+observable:isMapped
 	a owl:DatatypeProperty ;
 	rdfs:label "isMapped"@en ;
 	rdfs:comment "The isMapped property specifies whether or not the particular memory object has been assigned a byte-for-byte correlation with some portion of a file or file-like resource."@en ;
-	rdfs:domain :Memory ;
+	rdfs:domain observable:Memory ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isMimeEncoded
+observable:isMimeEncoded
 	a owl:DatatypeProperty ;
 	rdfs:label "isMimeEncoded"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isMultipart
+observable:isMultipart
 	a owl:DatatypeProperty ;
 	rdfs:label "isMultipart"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isNamed
+observable:isNamed
 	a owl:DatatypeProperty ;
 	rdfs:label "isNamed"@en ;
-	rdfs:domain :Mutex ;
+	rdfs:domain observable:Mutex ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isOptimized
+observable:isOptimized
 	a owl:DatatypeProperty ;
 	rdfs:label "isOptimized"@en ;
-	rdfs:domain :PDFFIle ;
+	rdfs:domain observable:PDFFIle ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isPrivate
+observable:isPrivate
 	a owl:DatatypeProperty ;
 	rdfs:label "isPrivate"@en ;
 	rdfs:comment "Is the event marked as private?"@en ;
-	rdfs:domain :CalendarEntry ;
+	rdfs:domain observable:CalendarEntry ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isPrivileged
+observable:isPrivileged
 	a owl:DatatypeProperty ;
 	rdfs:label "isPrivileged"@en ;
-	rdfs:domain :UserAccount ;
+	rdfs:domain observable:UserAccount ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isProtected
+observable:isProtected
 	a owl:DatatypeProperty ;
 	rdfs:label "isProtected"@en ;
 	rdfs:comment "The isProtected property specifies whether or not the particular memory object is protected (read/write only from the process that allocated it)."@en ;
-	rdfs:domain :Memory ;
+	rdfs:domain observable:Memory ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isRead
+observable:isRead
 	a owl:DatatypeProperty ;
 	rdfs:label "isRead"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isSecure
+observable:isSecure
 	a owl:DatatypeProperty ;
 	rdfs:label "isSecure"@en ;
 	rdfs:comment "Is the cookie secure? If the cookie is secure it cannot be delivered over an unencrypted session such as http."@en ;
-	rdfs:domain :BrowserCookie ;
+	rdfs:domain observable:BrowserCookie ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isSelfSigned
+observable:isSelfSigned
 	a owl:DatatypeProperty ;
 	rdfs:label "isSelfSigned"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isServiceAccount
+observable:isServiceAccount
 	a owl:DatatypeProperty ;
 	rdfs:label "isServiceAccount"@en ;
-	rdfs:domain :UserAccount ;
+	rdfs:domain observable:UserAccount ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isTLD
+observable:isTLD
 	a owl:DatatypeProperty ;
 	rdfs:label "isTLD"@en ;
-	rdfs:domain :DomainName ;
+	rdfs:domain observable:DomainName ;
 	rdfs:range xsd:boolean ;
 	.
 
-:isVolatile
+observable:isVolatile
 	a owl:DatatypeProperty ;
 	rdfs:label "isVolatile"@en ;
 	rdfs:comment "The isVolatile property specifies whether or not the particular memory object is volatile."@en ;
-	rdfs:domain :Memory ;
+	rdfs:domain observable:Memory ;
 	rdfs:range xsd:boolean ;
 	.
 
-:issuer
+observable:issuer
 	a owl:DatatypeProperty ;
 	rdfs:label "issuer"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:string ;
 	.
 
-:issuerAlternativeName
+observable:issuerAlternativeName
 	a owl:DatatypeProperty ;
 	rdfs:label "issuerAlternativeName"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:issuerHash
+observable:issuerHash
 	a owl:ObjectProperty ;
 	rdfs:label "issuerHash"@en ;
 	rdfs:comment "A hash calculated on the certificate issuer name."@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Hash> ;
 	.
 
-:key
+observable:key
 	a owl:DatatypeProperty ;
 	rdfs:label "key"@en ;
-	rdfs:domain :WindowsRegistryKey ;
+	rdfs:domain observable:WindowsRegistryKey ;
 	rdfs:range xsd:string ;
 	.
 
-:keyUsage
+observable:keyUsage
 	a owl:DatatypeProperty ;
 	rdfs:label "keyUsage"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:keypadUnlockCode
+observable:keypadUnlockCode
 	a owl:DatatypeProperty ;
 	rdfs:label "keypadUnlockCode"@en ;
 	rdfs:comment "A code or password set on a device for security that must be entered to gain access to the device."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:string ;
 	.
 
-:labels
+observable:labels
 	a owl:DatatypeProperty ;
 	rdfs:label "labels"@en ;
 	rdfs:comment "Named and colored label."@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:language
+observable:language
 	a owl:DatatypeProperty ;
 	rdfs:label "language"@en ;
 	rdfs:comment """Specifies the language the string is written in, e.g. English.
           For consistency, it is strongly recommended to use the ISO 639-2 language code, if available. Please see http://www.loc.gov/standards/iso639-2/php/code_list.php for a list of ISO 639-2 codes."""@en ;
-	rdfs:domain :ExtractedString ;
+	rdfs:domain observable:ExtractedString ;
 	rdfs:range xsd:string ;
 	.
 
-:lastLoginTime
+observable:lastLoginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "lastLoginTime"@en ;
 	rdfs:comment "The date and time of the last login of the account."@en ;
-	rdfs:domain :DigitalAccount ;
+	rdfs:domain observable:DigitalAccount ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:lastName
+observable:lastName
 	a owl:DatatypeProperty ;
 	rdfs:label "lastName"@en ;
 	rdfs:comment "The last name of the contact."@en ;
-	rdfs:domain :Contact ;
+	rdfs:domain observable:Contact ;
 	rdfs:range xsd:string ;
 	.
 
-:lastRun
+observable:lastRun
 	a owl:DatatypeProperty ;
 	rdfs:label "lastRun"@en ;
 	rdfs:comment "Timestamp of when the prefetch application was last run."@en ;
-	rdfs:domain :WindowsPrefetch ;
+	rdfs:domain observable:WindowsPrefetch ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:length
+observable:length
 	a owl:DatatypeProperty ;
 	rdfs:label "length"@en ;
 	rdfs:comment "Specifies the length, in characters, of the extracted string."@en ;
-	rdfs:domain :ExtractedString ;
+	rdfs:domain observable:ExtractedString ;
 	rdfs:range xsd:integer ;
 	.
 
-:libraryType
+observable:libraryType
 	a owl:DatatypeProperty ;
 	rdfs:label "libraryType"@en ;
 	rdfs:comment "Specifies the type of library being characterized."@en ;
-	rdfs:domain :Library ;
+	rdfs:domain observable:Library ;
 	rdfs:range xsd:string ;
 	.
 
-:loaderFlags
+observable:loaderFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "loaderFlags"@en ;
 	rdfs:comment "Specifies the reserved loader flags"@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:localTime
+observable:localTime
 	a owl:DatatypeProperty ;
 	rdfs:label "localTime"@en ;
 	rdfs:comment "Specifies the local time on the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:location
+observable:location
 	a owl:ObjectProperty ;
 	rdfs:label "location"@en ;
 	rdfs:comment "An associated location."@en ;
-	rdfs:domain :GeoLocationEntry ;
+	rdfs:domain observable:GeoLocationEntry ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/location#Location> ;
 	.
 
-:loginTime
+observable:loginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "loginTime"@en ;
 	rdfs:comment "Specifies the date/time of the login for the user session."@en ;
-	rdfs:domain :UserSession ;
+	rdfs:domain observable:UserSession ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:logoutTime
+observable:logoutTime
 	a owl:DatatypeProperty ;
 	rdfs:label "logoutTime"@en ;
 	rdfs:comment "Specifies the date/time of the logout for the user session."@en ;
-	rdfs:domain :UserSession ;
+	rdfs:domain observable:UserSession ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:lookupDate
+observable:lookupDate
 	a owl:DatatypeProperty ;
 	rdfs:label "lookupDate"@en ;
 	rdfs:comment "Specifies the date and time that the Whois record was queried."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:macAddress
+observable:macAddress
 	a owl:ObjectProperty ;
 	rdfs:label "macAddress"@en ;
 	rdfs:comment "Specifies the MAC or hardware address of the physical network card. "@en ;
-	rdfs:domain :NetworkInterface ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:NetworkInterface ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:machine
+observable:machine
 	a owl:DatatypeProperty ;
 	rdfs:label "machine"@en ;
 	rdfs:comment "Specifies the type of target machine."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:string ;
 	.
 
-:magic
+observable:magic
 	a owl:DatatypeProperty ;
 	rdfs:label "magic"@en ;
 	rdfs:comment "Specifies the value that indicates the type of the PE binary."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:magicNumber
+observable:magicNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "magicNumber"@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:string ;
 	.
 
-:majorImageVersion
+observable:majorImageVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorImageVersion"@en ;
 	rdfs:comment "Specifies the major version number of the image."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:majorLinkerVersion
+observable:majorLinkerVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorLinkerVersion"@en ;
 	rdfs:comment "Specifies the linker major version number."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:byte ;
 	.
 
-:majorOSVersion
+observable:majorOSVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorOSVersion"@en ;
 	rdfs:comment "Specifies the major version number of the required operating system."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:majorSubsystemVersion
+observable:majorSubsystemVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorSubsystemVersion"@en ;
 	rdfs:comment "Specifies the major version number of the subsystem."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:manufacturer
+observable:manufacturer
 	a owl:DatatypeProperty ;
 	rdfs:label "manufacturer"@en ;
-	rdfs:domain :Device ;
+	rdfs:domain observable:Device ;
 	rdfs:range xsd:string ;
 	.
 
-:maxRunTime
+observable:maxRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "maxRunTime"@en ;
 	rdfs:comment "Specifies the maximum run time of the scheduled task before terminating, in milliseconds. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381874(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:long ;
 	.
 
-:message
+observable:message
 	a owl:ObjectProperty ;
 	rdfs:label "message"@en ;
-	rdfs:domain :MessageThread ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:MessageThread ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:messageID
+observable:messageID
 	a owl:DatatypeProperty ;
 	rdfs:label "messageID"@en ;
 	rdfs:comment "An unique identifier for the message."@en ;
 	rdfs:domain
-		:EmailMessage ,
-		:Message
+		observable:EmailMessage ,
+		observable:Message
 		;
 	rdfs:range xsd:string ;
 	.
 
-:messageText
+observable:messageText
 	a owl:DatatypeProperty ;
 	rdfs:label "messageText"@en ;
 	rdfs:comment "The contents of the message."@en ;
-	rdfs:domain :Message ;
+	rdfs:domain observable:Message ;
 	rdfs:range xsd:string ;
 	.
 
-:messageType
+observable:messageType
 	a owl:DatatypeProperty ;
 	rdfs:label "messageType"@en ;
 	rdfs:comment "The type of a message, for example incoming, draft or outgoing."@en ;
-	rdfs:domain :Message ;
+	rdfs:domain observable:Message ;
 	rdfs:range xsd:string ;
 	.
 
-:metadataChangeTime
+observable:metadataChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "metadataChangeTime"@en ;
 	rdfs:comment "The date and time at which the file metadata was last modified."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:mftFileID
+observable:mftFileID
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileID"@en ;
 	rdfs:comment "Specifies the record number for the file within an NTFS Master File Table."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:integer ;
 	.
 
-:mftFileNameAccessedTime
+observable:mftFileNameAccessedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameAccessedTime"@en ;
 	rdfs:comment "The access date and time recorded in an MFT entry $File_Name attribute."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:mftFileNameCreatedTime
+observable:mftFileNameCreatedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameCreatedTime"@en ;
 	rdfs:comment "The creation date and time recorded in an MFT entry $File_Name attribute."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:mftFileNameLength
+observable:mftFileNameLength
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameLength"@en ;
 	rdfs:comment " Specifies the length of an NTFS file name, in unicode characters."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:integer ;
 	.
 
-:mftFileNameModifiedTime
+observable:mftFileNameModifiedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameModifiedTime"@en ;
 	rdfs:comment "The modification date and time recorded in an MFT entry $File_Name attribute."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:mftFileNameRecordChangeTime
+observable:mftFileNameRecordChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameRecordChangeTime"@en ;
 	rdfs:comment "The metadata modification date and time recorded in an MFT entry $File_Name attribute."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:mftFlags
+observable:mftFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFlags"@en ;
 	rdfs:comment "Specifies basic permissions for the file (Read-Only, Hidden, Archive, Compressed, etc.)."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:integer ;
 	.
 
-:mftParentID
+observable:mftParentID
 	a owl:DatatypeProperty ;
 	rdfs:label "mftParentID"@en ;
 	rdfs:comment "Specifies the record number within an NTFS Master File Table for parent directory of the file."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:integer ;
 	.
 
-:mftRecordChangeTime
+observable:mftRecordChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftRecordChangeTime"@en ;
 	rdfs:comment "The date and time at which an NTFS file metadata was last modified."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:middleName
+observable:middleName
 	a owl:DatatypeProperty ;
 	rdfs:label "middleName"@en ;
 	rdfs:comment "The middle name of the contact."@en ;
-	rdfs:domain :Contact ;
+	rdfs:domain observable:Contact ;
 	rdfs:range xsd:string ;
 	.
 
-:mimeClass
+observable:mimeClass
 	a owl:DatatypeProperty ;
 	rdfs:label "mimeClass"@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:string ;
 	.
 
-:mimeType
+observable:mimeType
 	a owl:DatatypeProperty ;
 	rdfs:label "mimeType"@en ;
 	rdfs:comment "MIME type of the data. For example 'text/html' or 'audio/mp3'."@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:string ;
 	.
 
-:minorImageVersion
+observable:minorImageVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorImageVersion"@en ;
 	rdfs:comment "Specifies the minor version number of the image."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:minorLinkerVersion
+observable:minorLinkerVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorLinkerVersion"@en ;
 	rdfs:comment "Specifies the linker minor version number."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:byte ;
 	.
 
-:minorOSVersion
+observable:minorOSVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorOSVersion"@en ;
 	rdfs:comment "Specifies the minor version number of the required operating system."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:minorSubsystemVersion
+observable:minorSubsystemVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorSubsystemVersion"@en ;
 	rdfs:comment """Specifies the minor version number of the subsystem.
           """@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:mockLocationsAllowed
+observable:mockLocationsAllowed
 	a owl:DatatypeProperty ;
 	rdfs:label "mockLocationsAllowed"@en ;
 	rdfs:comment "???."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:boolean ;
 	.
 
-:model
+observable:model
 	a owl:DatatypeProperty ;
 	rdfs:label "model"@en ;
-	rdfs:domain :Device ;
+	rdfs:domain observable:Device ;
 	rdfs:range xsd:string ;
 	.
 
-:modifiedTime
+observable:modifiedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "modifiedTime"@en ;
 	rdfs:comment "The date and time at which the Object was last modified."@en ;
-	rdfs:domain :File ;
+	rdfs:domain observable:File ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:mostRecentRunTime
+observable:mostRecentRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mostRecentRunTime"@en ;
 	rdfs:comment "Specifies the most recent run date/time of this scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381254(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:mountPoint
+observable:mountPoint
 	a owl:DatatypeProperty ;
 	rdfs:label "mountPoint"@en ;
 	rdfs:comment "Specifies the mount point of the partition."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:string ;
 	.
 
-:msProductID
+observable:msProductID
 	a owl:DatatypeProperty ;
 	rdfs:label "msProductID"@en ;
 	rdfs:comment "The Microsoft Product ID. See also: http://support.microsoft.com/gp/pidwin."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
+	rdfs:domain observable:WindowsComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:msProductName
+observable:msProductName
 	a owl:DatatypeProperty ;
 	rdfs:label "msProductName"@en ;
 	rdfs:comment "The Microsoft ProductName of the current installation of Windows. This is typically found in HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion!ProductName."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
+	rdfs:domain observable:WindowsComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:nameConstraints
+observable:nameConstraints
 	a owl:DatatypeProperty ;
 	rdfs:label "nameConstraints"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:nameserver
+observable:nameserver
 	a owl:ObjectProperty ;
 	rdfs:label "nameserver"@en ;
 	rdfs:comment "Specifies a list of nameserver entries for a Whois entry."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:netBIOSName
+observable:netBIOSName
 	a owl:DatatypeProperty ;
 	rdfs:label "netBIOSName"@en ;
 	rdfs:comment "Specifies the NetBIOS (Network Basic Input/Output System) name of the Windows system. This is not the same as the host name."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
+	rdfs:domain observable:WindowsComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:network
+observable:network
 	a owl:DatatypeProperty ;
 	rdfs:label "network"@en ;
 	rdfs:comment "???."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:string ;
 	.
 
-:networkInterface
+observable:networkInterface
 	a owl:ObjectProperty ;
 	rdfs:label "networkInterface"@en ;
 	rdfs:comment "Specifies the list of network interfaces present on the system."@en ;
-	rdfs:domain :ComputerSpecification ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:ComputerSpecification ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:newObject
+observable:newObject
 	a owl:ObjectProperty ;
 	rdfs:label "newObject"@en ;
 	rdfs:comment "Specifies the cyberitem and its properties as they are after the state change effect occurred."@en ;
-	rdfs:domain :StateChangeEffect ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:StateChangeEffect ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:nextRunTime
+observable:nextRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "nextRunTime"@en ;
 	rdfs:comment "Specifies the next run date/time of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381257(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:ntfsHardLinkCount
+observable:ntfsHardLinkCount
 	a owl:DatatypeProperty ;
 	rdfs:label "ntfsHardLinkCount"@en ;
 	rdfs:comment "Specifies the number of directory entries that reference an NTFS file record."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:integer ;
 	.
 
-:ntfsOwnerID
+observable:ntfsOwnerID
 	a owl:DatatypeProperty ;
 	rdfs:label "ntfsOwnerID"@en ;
 	rdfs:comment "Specifies the identifier of the file owner, from the security index."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:string ;
 	.
 
-:ntfsOwnerSID
+observable:ntfsOwnerSID
 	a owl:DatatypeProperty ;
 	rdfs:label "ntfsOwnerSID"@en ;
 	rdfs:comment "Specifies the security ID (key in the $SII Index and $SDS DataStream in the file $Secure) for an NTFS file."@en ;
-	rdfs:domain :MftRecord ;
+	rdfs:domain observable:MftRecord ;
 	rdfs:range xsd:string ;
 	.
 
-:number
+observable:number
 	a owl:DatatypeProperty ;
 	rdfs:label "number"@en ;
-	rdfs:domain :AutonomousSystem ;
+	rdfs:domain observable:AutonomousSystem ;
 	rdfs:range xsd:integer ;
 	.
 
-:numberOfLaunches
+observable:numberOfLaunches
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfLaunches"@en ;
-	rdfs:domain :Application ;
+	rdfs:domain observable:Application ;
 	rdfs:range xsd:integer ;
 	.
 
-:numberOfRVAAndSizes
+observable:numberOfRVAAndSizes
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfRVAAndSizes"@en ;
 	rdfs:comment "Specifies the number of data-directory entries in the remainder of the optional header."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:numberOfSections
+observable:numberOfSections
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfSections"@en ;
 	rdfs:comment """Specifies the number of sections in the PE binary, as a non-negative integer.
           """@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:integer ;
 	.
 
-:numberOfSubkeys
+observable:numberOfSubkeys
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfSubkeys"@en ;
-	rdfs:domain :WindowsRegistryKey ;
+	rdfs:domain observable:WindowsRegistryKey ;
 	rdfs:range xsd:integer ;
 	.
 
-:numberOfSymbols
+observable:numberOfSymbols
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfSymbols"@en ;
 	rdfs:comment "Specifies the number of entries in the symbol table of the PE binary, as a non-negative integer."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:integer ;
 	.
 
-:objectGUID
+observable:objectGUID
 	a owl:DatatypeProperty ;
 	rdfs:label "objectGUID"@en ;
-	rdfs:domain :WindowsActiveDirectoryAccount ;
+	rdfs:domain observable:WindowsActiveDirectoryAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:oldObject
+observable:oldObject
 	a owl:ObjectProperty ;
 	rdfs:label "oldObject"@en ;
 	rdfs:comment "Specifies the cyberitem and its properties as they were before the state change effect occurred."@en ;
-	rdfs:domain :StateChangeEffect ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:StateChangeEffect ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:omment
+observable:omment
 	a owl:DatatypeProperty ;
 	rdfs:label "omment"@en ;
 	rdfs:comment "Specifies a comment for the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381232(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:string ;
 	.
 
-:openFileDescriptor
+observable:openFileDescriptor
 	a owl:DatatypeProperty ;
 	rdfs:label "openFileDescriptor"@en ;
 	rdfs:comment "Specifies a listing of the current file descriptors used by the Unix process."@en ;
-	rdfs:domain :UNIXProcess ;
+	rdfs:domain observable:UNIXProcess ;
 	rdfs:range xsd:integer ;
 	.
 
-:operatingSystem
+observable:operatingSystem
 	a owl:ObjectProperty ;
 	rdfs:label "operatingSystem"@en ;
-	rdfs:domain :Application ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:Application ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:optionalHeader
+observable:optionalHeader
 	a owl:ObjectProperty ;
 	rdfs:label "optionalHeader"@en ;
 	rdfs:comment "Specifies the PE optional header of the PE binary."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
-	rdfs:range :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
+	rdfs:range observable:WindowsPEOptionalHeader ;
 	.
 
-:options
+observable:options
 	a owl:DatatypeProperty ;
 	rdfs:label "options"@en ;
 	rdfs:comment "Specifies any options used when mounting the volume."@en ;
-	rdfs:domain :UNIXVolume ;
+	rdfs:domain observable:UNIXVolume ;
 	rdfs:range xsd:string ;
 	.
 
-:otherHeaders
+observable:otherHeaders
 	a owl:ObjectProperty ;
 	rdfs:label "otherHeaders"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Dictionary> ;
 	.
 
-:owner
+observable:owner
 	a owl:ObjectProperty ;
 	rdfs:label "owner"@en ;
 	rdfs:comment
@@ -10076,85 +10076,85 @@ How does this relate to Application?
 		"The owner of this account."@en
 		;
 	rdfs:domain
-		:Account ,
-		:FilePermissions
+		observable:Account ,
+		observable:FilePermissions
 		;
 	rdfs:range
 		<https://unifiedcyberontology.org/ontology/uco/core#UcoObject> ,
-		:CyberItem
+		observable:CyberItem
 		;
 	.
 
-:ownerSID
+observable:ownerSID
 	a owl:DatatypeProperty ;
 	rdfs:label "ownerSID"@en ;
-	rdfs:domain :WindowsProcess ;
+	rdfs:domain observable:WindowsProcess ;
 	rdfs:range xsd:string ;
 	.
 
-:parameterAddress
+observable:parameterAddress
 	a owl:DatatypeProperty ;
 	rdfs:label "parameterAddress"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:parameters
+observable:parameters
 	a owl:DatatypeProperty ;
 	rdfs:label "parameters"@en ;
 	rdfs:comment "Specifies the command line parameters used to launch the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381875(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:string ;
 	.
 
-:parent
+observable:parent
 	a owl:ObjectProperty ;
 	rdfs:label "parent"@en ;
 	rdfs:comment "The process that created this process."@en ;
-	rdfs:domain :Process ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:Process ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:participant
+observable:participant
 	a owl:ObjectProperty ;
 	rdfs:label "participant"@en ;
-	rdfs:domain :MessageThread ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:MessageThread ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:partition
+observable:partition
 	a owl:ObjectProperty ;
 	rdfs:label "partition"@en ;
 	rdfs:comment "The partitions that reside on the disk."@en ;
-	rdfs:domain :Disk ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:Disk ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:partitionID
+observable:partitionID
 	a owl:DatatypeProperty ;
 	rdfs:label "partitionID"@en ;
 	rdfs:comment "Specifies the numerical identifier of the partition."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:integer ;
 	.
 
-:partitionLength
+observable:partitionLength
 	a owl:DatatypeProperty ;
 	rdfs:label "partitionLength"@en ;
 	rdfs:comment "Specifies the length of the partition, in bytes."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:long ;
 	.
 
-:partitionOffset
+observable:partitionOffset
 	a owl:DatatypeProperty ;
 	rdfs:label "partitionOffset"@en ;
 	rdfs:comment "Specifies the starting offset of the partition, in bytes."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:long ;
 	.
 
-:password
+observable:password
 	a owl:DatatypeProperty ;
 	rdfs:label "password"@en ;
 	rdfs:comment
@@ -10162,1338 +10162,1338 @@ How does this relate to Application?
 		"The account authentication password."@en
 		;
 	rdfs:domain
-		:AccountAuthentication ,
-		:URL
+		observable:AccountAuthentication ,
+		observable:URL
 		;
 	rdfs:range xsd:string ;
 	.
 
-:passwordLastChanged
+observable:passwordLastChanged
 	a owl:DatatypeProperty ;
 	rdfs:label "passwordLastChanged"@en ;
 	rdfs:comment "The date and time that the password was last changed."@en ;
-	rdfs:domain :AccountAuthentication ;
+	rdfs:domain observable:AccountAuthentication ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:passwordType
+observable:passwordType
 	a owl:DatatypeProperty ;
 	rdfs:label "passwordType"@en ;
 	rdfs:comment "The type of password, for instance plain-text or encrypted."@en ;
-	rdfs:domain :AccountAuthentication ;
+	rdfs:domain observable:AccountAuthentication ;
 	rdfs:range xsd:string ;
 	.
 
-:path
+observable:path
 	a owl:DatatypeProperty ;
 	rdfs:label "path"@en ;
 	rdfs:comment "Specifies the location of one object within another containing object."@en ;
-	rdfs:domain :PathRelation ;
+	rdfs:domain observable:PathRelation ;
 	rdfs:range xsd:string ;
 	.
 
-:pdfId0
+observable:pdfId0
 	a owl:DatatypeProperty ;
 	rdfs:label "pdfId0"@en ;
-	rdfs:domain :PDFFIle ;
+	rdfs:domain observable:PDFFIle ;
 	rdfs:range xsd:string ;
 	.
 
-:pdfId1
+observable:pdfId1
 	a owl:DatatypeProperty ;
 	rdfs:label "pdfId1"@en ;
-	rdfs:domain :PDFFIle ;
+	rdfs:domain observable:PDFFIle ;
 	rdfs:range xsd:string ;
 	.
 
-:peType
+observable:peType
 	a owl:DatatypeProperty ;
 	rdfs:label "peType"@en ;
 	rdfs:comment "Specifies the type of the PE binary."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:string ;
 	.
 
-:phone
+observable:phone
 	a owl:ObjectProperty ;
 	rdfs:label "phone"@en ;
 	rdfs:comment "A phone number(account)."@en ;
-	rdfs:domain :WhoisContactType ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoisContactType ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:phoneActivationTime
+observable:phoneActivationTime
 	a owl:DatatypeProperty ;
 	rdfs:label "phoneActivationTime"@en ;
 	rdfs:comment "The date and time that a device was activated."@en ;
-	rdfs:domain :MobileDevice ;
+	rdfs:domain observable:MobileDevice ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:phoneNumber
+observable:phoneNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "phoneNumber"@en ;
 	rdfs:comment "A phone number(account)."@en ;
-	rdfs:domain :PhoneAccount ;
+	rdfs:domain observable:PhoneAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:phoneNumbers
+observable:phoneNumbers
 	a owl:DatatypeProperty ;
 	rdfs:label "phoneNumbers"@en ;
 	rdfs:comment "The phone numbers of the contact."@en ;
-	rdfs:domain :Contact ;
+	rdfs:domain observable:Contact ;
 	rdfs:range xsd:string ;
 	.
 
-:pictureHeight
+observable:pictureHeight
 	a owl:DatatypeProperty ;
 	rdfs:label "pictureHeight"@en ;
-	rdfs:domain :RasterPicture ;
+	rdfs:domain observable:RasterPicture ;
 	rdfs:range xsd:integer ;
 	.
 
-:pictureWidth
+observable:pictureWidth
 	a owl:DatatypeProperty ;
 	rdfs:label "pictureWidth"@en ;
 	rdfs:comment "The width of the picture in pixels."@en ;
-	rdfs:domain :RasterPicture ;
+	rdfs:domain observable:RasterPicture ;
 	rdfs:range xsd:integer ;
 	.
 
-:picturetype
+observable:picturetype
 	a owl:DatatypeProperty ;
 	rdfs:label "picturetype"@en ;
 	rdfs:comment "The type of a picture, for example a thumbnail."@en ;
-	rdfs:domain :RasterPicture ;
+	rdfs:domain observable:RasterPicture ;
 	rdfs:range xsd:string ;
 	.
 
-:pid
+observable:pid
 	a owl:DatatypeProperty ;
 	rdfs:label "pid"@en ;
 	rdfs:comment "The Process ID, or PID, of the process."@en ;
-	rdfs:domain :Process ;
+	rdfs:domain observable:Process ;
 	rdfs:range xsd:integer ;
 	.
 
-:pointerToSymbolTable
+observable:pointerToSymbolTable
 	a owl:DatatypeProperty ;
 	rdfs:label "pointerToSymbolTable"@en ;
 	rdfs:comment "Specifies the file offset of the COFF symbol table."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:policyConstraints
+observable:policyConstraints
 	a owl:DatatypeProperty ;
 	rdfs:label "policyConstraints"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:policyMappings
+observable:policyMappings
 	a owl:DatatypeProperty ;
 	rdfs:label "policyMappings"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:port
+observable:port
 	a owl:DatatypeProperty ;
 	rdfs:label "port"@en ;
 	rdfs:comment "Port on which communication takes place."@en ;
-	rdfs:domain :URL ;
+	rdfs:domain observable:URL ;
 	rdfs:range xsd:long ;
 	.
 
-:prefetchHash
+observable:prefetchHash
 	a owl:DatatypeProperty ;
 	rdfs:label "prefetchHash"@en ;
 	rdfs:comment "An eight character hash of the location from which the application was run."@en ;
-	rdfs:domain :WindowsPrefetch ;
+	rdfs:domain observable:WindowsPrefetch ;
 	rdfs:range xsd:string ;
 	.
 
-:priority
+observable:priority
 	a owl:DatatypeProperty ;
 	rdfs:label "priority"@en ;
 	rdfs:comment "The priority of the email."@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:privateKeyUsagePeriodNotAfter
+observable:privateKeyUsagePeriodNotAfter
 	a owl:DatatypeProperty ;
 	rdfs:label "privateKeyUsagePeriodNotAfter"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:privateKeyUsagePeriodNotBefore
+observable:privateKeyUsagePeriodNotBefore
 	a owl:DatatypeProperty ;
 	rdfs:label "privateKeyUsagePeriodNotBefore"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:processorArchitecture
+observable:processorArchitecture
 	a owl:DatatypeProperty ;
 	rdfs:label "processorArchitecture"@en ;
 	rdfs:comment "sSpecifies the specific architecture (e.g. x86) used by the CPU of the system."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:properties
+observable:properties
 	a owl:DatatypeProperty ;
 	rdfs:label "properties"@en ;
 	rdfs:comment "Specifies the properties that were enumerated as a result of the action on the cyberitem."@en ;
-	rdfs:domain :PropertiesEnumeratedEffect ;
+	rdfs:domain observable:PropertiesEnumeratedEffect ;
 	rdfs:range xsd:string ;
 	.
 
-:propertyName
+observable:propertyName
 	a owl:DatatypeProperty ;
 	rdfs:label "propertyName"@en ;
 	rdfs:comment "Specifies the Name of the property being read."@en ;
-	rdfs:domain :PropertyReadEffect ;
+	rdfs:domain observable:PropertyReadEffect ;
 	rdfs:range xsd:string ;
 	.
 
-:protocols
+observable:protocols
 	a owl:ObjectProperty ;
 	rdfs:label "protocols"@en ;
 	rdfs:comment "Specifies the protocols involved in the network connection, along with their corresponding state. "@en ;
-	rdfs:domain :NetworkConnection ;
+	rdfs:domain observable:NetworkConnection ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#ControlledDictionary> ;
 	.
 
-:query
+observable:query
 	a owl:DatatypeProperty ;
 	rdfs:label "query"@en ;
 	rdfs:comment "Query passed to the resource."@en ;
-	rdfs:domain :URL ;
+	rdfs:domain observable:URL ;
 	rdfs:range xsd:string ;
 	.
 
-:rangeOffset
+observable:rangeOffset
 	a owl:DatatypeProperty ;
 	rdfs:label "rangeOffset"@en ;
 	rdfs:comment "The offset at which the start of data can be found, relative to the rangeOffsetType defined."@en ;
-	rdfs:domain :DataRange ;
+	rdfs:domain observable:DataRange ;
 	rdfs:range xsd:integer ;
 	.
 
-:rangeOffsetType
+observable:rangeOffsetType
 	a owl:DatatypeProperty ;
 	rdfs:label "rangeOffsetType"@en ;
 	rdfs:comment "The type of offset defined for the range (e.g., image, file, address)."@en ;
-	rdfs:domain :DataRange ;
+	rdfs:domain observable:DataRange ;
 	rdfs:range xsd:string ;
 	.
 
-:rangeSize
+observable:rangeSize
 	a owl:DatatypeProperty ;
 	rdfs:label "rangeSize"@en ;
 	rdfs:comment "The size of the data in bytes."@en ;
-	rdfs:domain :DataRange ;
+	rdfs:domain observable:DataRange ;
 	rdfs:range xsd:long ;
 	.
 
-:receivedLines
+observable:receivedLines
 	a owl:DatatypeProperty ;
 	rdfs:label "receivedLines"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:receivedTime
+observable:receivedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "receivedTime"@en ;
 	rdfs:comment "The date and time at which the message received. "@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:recurrence
+observable:recurrence
 	a owl:DatatypeProperty ;
 	rdfs:label "recurrence"@en ;
 	rdfs:comment "Recurrence of the event."@en ;
-	rdfs:domain :CalendarEntry ;
+	rdfs:domain observable:CalendarEntry ;
 	rdfs:range xsd:string ;
 	.
 
-:references
+observable:references
 	a owl:ObjectProperty ;
 	rdfs:label "references"@en ;
 	rdfs:comment "A list of email message identifiers this email relates to."@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:referralURL
+observable:referralURL
 	a owl:ObjectProperty ;
 	rdfs:label "referralURL"@en ;
 	rdfs:comment "Specifies the corresponding referral URL for a registrar."@en ;
-	rdfs:domain :WhoisRegistrarInfoType ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoisRegistrarInfoType ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:regionSize
+observable:regionSize
 	a owl:DatatypeProperty ;
 	rdfs:label "regionSize"@en ;
 	rdfs:comment "The regionSize property specifies the size of the particular memory region, in bytes."@en ;
-	rdfs:domain :Memory ;
+	rdfs:domain observable:Memory ;
 	rdfs:range xsd:integer ;
 	.
 
-:regionStartAddress
+observable:regionStartAddress
 	a owl:DatatypeProperty ;
 	rdfs:label "regionStartAddress"@en ;
 	rdfs:comment """The regionStartAddress property specifies the starting address of the particular memory region.
           """@en ;
-	rdfs:domain :Memory ;
+	rdfs:domain observable:Memory ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:region_end_address
+observable:region_end_address
 	a owl:DatatypeProperty ;
 	rdfs:label "region_End_Address"@en ;
 	rdfs:comment "The regionEndAddress property specifies the ending address of the particular memory region."@en ;
-	rdfs:domain :Memory ;
+	rdfs:domain observable:Memory ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:regionalInternetRegistry
+observable:regionalInternetRegistry
 	a owl:DatatypeProperty ;
 	rdfs:label "regionalInternetRegistry"@en ;
 	rdfs:comment "specifies the name of the Regional Internet Registry (RIR) which allocated the IP address contained in a WHOIS entry."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :RegionalRegistryTypeEnum ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:RegionalRegistryTypeEnum ;
 	.
 
-:registeredOrganization
+observable:registeredOrganization
 	a owl:ObjectProperty ;
 	rdfs:label "registeredOrganization"@en ;
 	rdfs:comment "The organization that this copy of Windows is registered to."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
+	rdfs:domain observable:WindowsComputerSpecification ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/identity#Identity> ;
 	.
 
-:registeredOwner
+observable:registeredOwner
 	a owl:ObjectProperty ;
 	rdfs:label "registeredOwner"@en ;
 	rdfs:comment "The person or organization that is the registered owner of this copy of Windows."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
+	rdfs:domain observable:WindowsComputerSpecification ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/identity#Identity> ;
 	.
 
-:registrantIDs
+observable:registrantIDs
 	a owl:DatatypeProperty ;
 	rdfs:label "registrantIDs"@en ;
 	rdfs:comment "Specifies the registrant IDs associated with a domain lookup."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:string ;
 	.
 
-:registrarGUID
+observable:registrarGUID
 	a owl:DatatypeProperty ;
 	rdfs:label "registrarGUID"@en ;
 	rdfs:comment "Specifies the Registrar GUID field of a Whois entry."@en ;
-	rdfs:domain :WhoisRegistrarInfoType ;
+	rdfs:domain observable:WhoisRegistrarInfoType ;
 	rdfs:range xsd:string ;
 	.
 
-:registrarID
+observable:registrarID
 	a owl:DatatypeProperty ;
 	rdfs:label "registrarID"@en ;
 	rdfs:comment "Specifies the Registrar ID field of a Whois entry."@en ;
-	rdfs:domain :WhoisRegistrarInfoType ;
+	rdfs:domain observable:WhoisRegistrarInfoType ;
 	rdfs:range xsd:string ;
 	.
 
-:registrarInfo
+observable:registrarInfo
 	a owl:ObjectProperty ;
 	rdfs:label "registrarInfo"@en ;
 	rdfs:comment "Specifies registrar info that would be returned from a registrar lookup."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :WhoisRegistrarInfoType ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:WhoisRegistrarInfoType ;
 	.
 
-:registrarName
+observable:registrarName
 	a owl:DatatypeProperty ;
 	rdfs:label "registrarName"@en ;
 	rdfs:comment "The name of the registrar organization."@en ;
-	rdfs:domain :WhoisRegistrarInfoType ;
+	rdfs:domain observable:WhoisRegistrarInfoType ;
 	rdfs:range xsd:string ;
 	.
 
-:registryValues
+observable:registryValues
 	a owl:ObjectProperty ;
 	rdfs:label "registryValues"@en ;
 	rdfs:comment "The values that were enumerated as a result of the action on the object."@en ;
-	rdfs:domain :WindowsRegistryKey ;
-	rdfs:range :WindowsRegistryValue ;
+	rdfs:domain observable:WindowsRegistryKey ;
+	rdfs:range observable:WindowsRegistryValue ;
 	.
 
-:remarks
+observable:remarks
 	a owl:DatatypeProperty ;
 	rdfs:label "remarks"@en ;
 	rdfs:comment "Specifies any remarks associated with this Whois entry."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:string ;
 	.
 
-:remindTime
+observable:remindTime
 	a owl:DatatypeProperty ;
 	rdfs:label "remindTime"@en ;
-	rdfs:domain :CalendarEntry ;
+	rdfs:domain observable:CalendarEntry ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:requestMethod
+observable:requestMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "requestMethod"@en ;
 	rdfs:comment """Specifies the HTTP method portion of the HTTP request line, as a lowercase string.
           """@en ;
-	rdfs:domain :HTTPConnection ;
+	rdfs:domain observable:HTTPConnection ;
 	rdfs:range xsd:string ;
 	.
 
-:requestValue
+observable:requestValue
 	a owl:DatatypeProperty ;
 	rdfs:label "requestValue"@en ;
 	rdfs:comment "Specifies the value (typically a resource path) portion of the HTTP request line."@en ;
-	rdfs:domain :HTTPConnection ;
+	rdfs:domain observable:HTTPConnection ;
 	rdfs:range xsd:string ;
 	.
 
-:requestVersion
+observable:requestVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "requestVersion"@en ;
 	rdfs:comment "Specifies the HTTP version portion of the HTTP request line, as a lowercase string."@en ;
-	rdfs:domain :HTTPConnection ;
+	rdfs:domain observable:HTTPConnection ;
 	rdfs:range xsd:string ;
 	.
 
-:rowCondition
+observable:rowCondition
 	a owl:DatatypeProperty ;
 	rdfs:label "rowCondition"@en ;
-	rdfs:domain :SQLiteBlob ;
+	rdfs:domain observable:SQLiteBlob ;
 	rdfs:range xsd:string ;
 	.
 
-:rowIndex
+observable:rowIndex
 	a owl:DatatypeProperty ;
 	rdfs:label "rowIndex"@en ;
-	rdfs:domain :SQLiteBlob ;
+	rdfs:domain observable:SQLiteBlob ;
 	rdfs:range xsd:positiveInteger ;
 	.
 
-:ruid
+observable:ruid
 	a owl:DatatypeProperty ;
 	rdfs:label "ruid"@en ;
 	rdfs:comment "Specifies the real user ID, which represents the Unix user who created the process."@en ;
-	rdfs:domain :UNIXProcess ;
+	rdfs:domain observable:UNIXProcess ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-:runningStatus
+observable:runningStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "runningStatus"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:string ;
 	.
 
-:scheme
+observable:scheme
 	a owl:DatatypeProperty ;
 	rdfs:label "scheme"@en ;
 	rdfs:comment "Identifies the type of URL."@en ;
-	rdfs:domain :URL ;
+	rdfs:domain observable:URL ;
 	rdfs:range xsd:string ;
 	.
 
-:screenName
+observable:screenName
 	a owl:DatatypeProperty ;
 	rdfs:label "screenName"@en ;
 	rdfs:comment "The display name of the contact."@en ;
-	rdfs:domain :Contact ;
+	rdfs:domain observable:Contact ;
 	rdfs:range xsd:string ;
 	.
 
-:sectionAlignment
+observable:sectionAlignment
 	a owl:DatatypeProperty ;
 	rdfs:label "sectionAlignment"@en ;
 	rdfs:comment "Specifies the alignment (in bytes) of PE sections when they are loaded into memory."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sections
+observable:sections
 	a owl:ObjectProperty ;
 	rdfs:label "sections"@en ;
 	rdfs:comment "Specifies metadata about the sections in the PE file."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
-	rdfs:range :WindowsPESection ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
+	rdfs:range observable:WindowsPESection ;
 	.
 
-:sectorSize
+observable:sectorSize
 	a owl:DatatypeProperty ;
 	rdfs:label "sectorSize"@en ;
 	rdfs:comment "The sector size of the volume in bytes."@en ;
-	rdfs:domain :Volume ;
+	rdfs:domain observable:Volume ;
 	rdfs:range xsd:long ;
 	.
 
-:securityAttributes
+observable:securityAttributes
 	a owl:DatatypeProperty ;
 	rdfs:label "securityAttributes"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:string ;
 	.
 
-:sender
+observable:sender
 	a owl:ObjectProperty ;
 	rdfs:label "sender"@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:sentTime
+observable:sentTime
 	a owl:DatatypeProperty ;
 	rdfs:label "sentTime"@en ;
 	rdfs:comment "The date and time at which the message sent."@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:serialNumber
+observable:serialNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "serialNumber"@en ;
-	rdfs:domain :Device ;
+	rdfs:domain observable:Device ;
 	rdfs:range xsd:string ;
 	.
 
-:serverName
+observable:serverName
 	a owl:ObjectProperty ;
 	rdfs:label "serverName"@en ;
 	rdfs:comment "Specifies the corresponding server name for a whois entry. This usually corresponds to a nameserver lookup."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:serviceName
+observable:serviceName
 	a owl:DatatypeProperty ;
 	rdfs:label "serviceName"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:serviceStatus
+observable:serviceStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "serviceStatus"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:serviceType
+observable:serviceType
 	a owl:DatatypeProperty ;
 	rdfs:label "serviceType"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:sessionID
+observable:sessionID
 	a owl:DatatypeProperty ;
 	rdfs:label "sessionID"@en ;
 	rdfs:comment "An identifier for the session from which the message originates."@en ;
-	rdfs:domain :Message ;
+	rdfs:domain observable:Message ;
 	rdfs:range xsd:string ;
 	.
 
-:shell
+observable:shell
 	a owl:DatatypeProperty ;
 	rdfs:label "shell"@en ;
-	rdfs:domain :UNIXAccount ;
+	rdfs:domain observable:UNIXAccount ;
 	rdfs:range xsd:string ;
 	.
 
-:showMessageBody
+observable:showMessageBody
 	a owl:DatatypeProperty ;
 	rdfs:label "showMessageBody"@en ;
 	rdfs:comment "Specifies the message text that is displayed in the body of the message box by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381302(v=vs.85).aspx."@en ;
-	rdfs:domain :IShowMessageActionType ;
+	rdfs:domain observable:IShowMessageActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:showMessageTitle
+observable:showMessageTitle
 	a owl:DatatypeProperty ;
 	rdfs:label "showMessageTitle"@en ;
 	rdfs:comment "Specifies the title of the message box shown by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381302(v=vs.85).aspx."@en ;
-	rdfs:domain :IShowMessageActionType ;
+	rdfs:domain observable:IShowMessageActionType ;
 	rdfs:range xsd:string ;
 	.
 
-:sid
+observable:sid
 	a owl:DatatypeProperty ;
 	rdfs:label "sid"@en ;
-	rdfs:domain :NTFSFileSystem ;
+	rdfs:domain observable:NTFSFileSystem ;
 	rdfs:range xsd:string ;
 	.
 
-:signature
+observable:signature
 	a owl:DatatypeProperty ;
 	rdfs:label "signature"@en ;
 	rdfs:comment "A"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:string ;
 	.
 
-:signatureAlgorithm
+observable:signatureAlgorithm
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureAlgorithm"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:string ;
 	.
 
-:signatureDescription
+observable:signatureDescription
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureDescription"@en ;
-	rdfs:domain :DigitalSignatureInfo ;
+	rdfs:domain observable:DigitalSignatureInfo ;
 	rdfs:range xsd:string ;
 	.
 
-:signatureExists
+observable:signatureExists
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureExists"@en ;
-	rdfs:domain :DigitalSignatureInfo ;
+	rdfs:domain observable:DigitalSignatureInfo ;
 	rdfs:range xsd:boolean ;
 	.
 
-:signatureVerified
+observable:signatureVerified
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureVerified"@en ;
-	rdfs:domain :DigitalSignatureInfo ;
+	rdfs:domain observable:DigitalSignatureInfo ;
 	rdfs:range xsd:boolean ;
 	.
 
-:size
+observable:size
 	a owl:DatatypeProperty ;
 	rdfs:label "size"@en ;
 	rdfs:comment "Specifies the size of the section, in bytes."@en ;
-	rdfs:domain :WindowsPESection ;
+	rdfs:domain observable:WindowsPESection ;
 	rdfs:range xsd:integer ;
 	.
 
-:sizeInBytes
+observable:sizeInBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeInBytes"@en ;
 	rdfs:comment "The size of the data in bytes."@en ;
-	rdfs:domain :ContentData ;
+	rdfs:domain observable:ContentData ;
 	rdfs:range xsd:long ;
 	.
 
-:sizeOfCode
+observable:sizeOfCode
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfCode"@en ;
 	rdfs:comment "Specifies the size of the code (text) section. If there are multiple such sections, this refers to the sum of the sizes of each section."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfHeaders
+observable:sizeOfHeaders
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfHeaders"@en ;
 	rdfs:comment "Specifies the combined size of the MS-DOS, PE header, and section headers, rounded up a multiple of the value specified in the file_alignment header."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfHeapCommit
+observable:sizeOfHeapCommit
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfHeapCommit"@en ;
 	rdfs:comment "Specifies the size of the local heap space to commit."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfHeapReserve
+observable:sizeOfHeapReserve
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfHeapReserve"@en ;
 	rdfs:comment "Specifies the size of the local heap space to reserve."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfImage
+observable:sizeOfImage
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfImage"@en ;
 	rdfs:comment "Specifies the size, in bytes, of the image, including all headers, as the image is loaded in memory."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfInitializedData
+observable:sizeOfInitializedData
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfInitializedData"@en ;
 	rdfs:comment "Specifies the size of the initialized data section. If there are multiple such sections, this refers to the sum of the sizes of each section."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfOptionalHeader
+observable:sizeOfOptionalHeader
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfOptionalHeader"@en ;
 	rdfs:comment "Specifies the size of the optional header of the PE binary. "@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:integer ;
 	.
 
-:sizeOfStackCommit
+observable:sizeOfStackCommit
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfStackCommit"@en ;
 	rdfs:comment "Specifies the size of the stack to commit."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfStackReserve
+observable:sizeOfStackReserve
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfStackReserve"@en ;
 	rdfs:comment "Specifies the size of the stack to reserve."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sizeOfUninitializedData
+observable:sizeOfUninitializedData
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfUninitializedData"@en ;
 	rdfs:comment "Specifies the size of the uninitialized data section. If there are multiple such sections, this refers to the sum of the sizes of each section."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:sourceFlags
+observable:sourceFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "sourceFlags"@en ;
 	rdfs:comment "Specifies the source TCP flags."@en ;
-	rdfs:domain :TCPConnection ;
+	rdfs:domain observable:TCPConnection ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:sourcePort
+observable:sourcePort
 	a owl:DatatypeProperty ;
 	rdfs:label "sourcePort"@en ;
 	rdfs:comment """Specifies the source port used in the connection, as an integer in the range of 0 - 65535.
           """@en ;
-	rdfs:domain :NetworkConnection ;
+	rdfs:domain observable:NetworkConnection ;
 	rdfs:range xsd:integer ;
 	.
 
-:spaceLeft
+observable:spaceLeft
 	a owl:DatatypeProperty ;
 	rdfs:label "spaceLeft"@en ;
 	rdfs:comment "Specifies the amount of space left on the partition, in bytes."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:long ;
 	.
 
-:spaceUsed
+observable:spaceUsed
 	a owl:DatatypeProperty ;
 	rdfs:label "spaceUsed"@en ;
 	rdfs:comment "Specifies the amount of space used on the partition, in bytes."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:long ;
 	.
 
-:sponsoringRegistrar
+observable:sponsoringRegistrar
 	a owl:DatatypeProperty ;
 	rdfs:label "sponsoringRegistrar"@en ;
 	rdfs:comment "Specifies the name of the sponsoring registrar for a domain."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:string ;
 	.
 
-:src
+observable:src
 	a owl:ObjectProperty ;
 	rdfs:label "src"@en ;
 	rdfs:comment "Specifies the source(s) of the network connection."@en ;
-	rdfs:domain :NetworkConnection ;
+	rdfs:domain observable:NetworkConnection ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/core#UcoObject> ;
 	.
 
-:srcBytes
+observable:srcBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "srcBytes"@en ;
-	rdfs:domain :NetworkFlow ;
+	rdfs:domain observable:NetworkFlow ;
 	rdfs:range xsd:integer ;
 	.
 
-:srcPackets
+observable:srcPackets
 	a owl:DatatypeProperty ;
 	rdfs:label "srcPackets"@en ;
-	rdfs:domain :NetworkFlow ;
+	rdfs:domain observable:NetworkFlow ;
 	rdfs:range xsd:integer ;
 	.
 
-:srcPayload
+observable:srcPayload
 	a owl:ObjectProperty ;
 	rdfs:label "srcPayload"@en ;
-	rdfs:domain :NetworkFlow ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:NetworkFlow ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:ssid
+observable:ssid
 	a owl:DatatypeProperty ;
 	rdfs:label "ssid"@en ;
 	rdfs:comment "Network identifier."@en ;
-	rdfs:domain :WirelessNetworkConnection ;
+	rdfs:domain observable:WirelessNetworkConnection ;
 	rdfs:range xsd:string ;
 	.
 
-:stackSize
+observable:stackSize
 	a owl:DatatypeProperty ;
 	rdfs:label "stackSize"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-:startAddress
+observable:startAddress
 	a owl:DatatypeProperty ;
 	rdfs:label "startAddress"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-:startCommandLine
+observable:startCommandLine
 	a owl:DatatypeProperty ;
 	rdfs:label "startCommandLine"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:startTime
+observable:startTime
 	a owl:DatatypeProperty ;
 	rdfs:label "startTime"@en ;
-	rdfs:domain :PhoneCall ;
+	rdfs:domain observable:PhoneCall ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:startType
+observable:startType
 	a owl:DatatypeProperty ;
 	rdfs:label "startType"@en ;
-	rdfs:domain :WindowsService ;
+	rdfs:domain observable:WindowsService ;
 	rdfs:range xsd:string ;
 	.
 
-:startupInfo
+observable:startupInfo
 	a owl:ObjectProperty ;
 	rdfs:label "startupInfo"@en ;
-	rdfs:domain :WindowsProcess ;
+	rdfs:domain observable:WindowsProcess ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Dictionary> ;
 	.
 
-:state
+observable:state
 	a owl:DatatypeProperty ;
 	rdfs:label "State"@en ;
-	rdfs:domain :CyberItem ;
+	rdfs:domain observable:CyberItem ;
 	rdfs:range xsd:string ;
 	.
 
-:status
+observable:status
 	a owl:DatatypeProperty ;
 	rdfs:label "status"@en ;
 	rdfs:comment "Specifies a list of statuses for a given Whois entry."@en ;
-	rdfs:domain :WhoIs ;
-	rdfs:range :WhoisStatusTypeEnum ;
+	rdfs:domain observable:WhoIs ;
+	rdfs:range observable:WhoisStatusTypeEnum ;
 	.
 
-:storageCapacityInBytes
+observable:storageCapacityInBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "storageCapacityInBytes"@en ;
 	rdfs:comment "The number of bytes that can be stored on a SIM card."@en ;
 	rdfs:domain
-		:MobileDevice ,
-		:SIMCard
+		observable:MobileDevice ,
+		observable:SIMCard
 		;
 	rdfs:range xsd:long ;
 	.
 
-:stringValue
+observable:stringValue
 	a owl:DatatypeProperty ;
 	rdfs:label "stringValue"@en ;
 	rdfs:comment "Specifies the actual value of the extracted string."@en ;
-	rdfs:domain :ExtractedString ;
+	rdfs:domain observable:ExtractedString ;
 	rdfs:range xsd:string ;
 	.
 
-:strings
+observable:strings
 	a owl:ObjectProperty ;
 	rdfs:label "strings"@en ;
-	rdfs:domain :ExtractedStrings ;
-	rdfs:range :ExtractedString ;
+	rdfs:domain observable:ExtractedStrings ;
+	rdfs:range observable:ExtractedString ;
 	.
 
-:subject
+observable:subject
 	a owl:DatatypeProperty ;
 	rdfs:label "subject"@en ;
 	rdfs:comment "The subject of the email."@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:subjectAlternativeName
+observable:subjectAlternativeName
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectAlternativeName"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:subjectDirectoryAttributes
+observable:subjectDirectoryAttributes
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectDirectoryAttributes"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:subjectHash
+observable:subjectHash
 	a owl:ObjectProperty ;
 	rdfs:label "subjectHash"@en ;
 	rdfs:comment "A hash calculated on the certificate subject name."@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Hash> ;
 	.
 
-:subjectKeyIdentifier
+observable:subjectKeyIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectKeyIdentifier"@en ;
-	rdfs:domain :X509V3Extensions ;
+	rdfs:domain observable:X509V3Extensions ;
 	rdfs:range xsd:string ;
 	.
 
-:subjectPublicKeyAlgorithm
+observable:subjectPublicKeyAlgorithm
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectPublicKeyAlgorithm"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:string ;
 	.
 
-:subjectPublicKeyExponent
+observable:subjectPublicKeyExponent
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectPublicKeyExponent"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:integer ;
 	.
 
-:subjectPublicKeyModulus
+observable:subjectPublicKeyModulus
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectPublicKeyModulus"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:string ;
 	.
 
-:subsystem
+observable:subsystem
 	a owl:DatatypeProperty ;
 	rdfs:label "subsystem"@en ;
 	rdfs:comment "Specifies the subsystem (e.g., GUI, device driver, etc.) that is required to run this image."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-:swid
+observable:swid
 	a owl:DatatypeProperty ;
 	rdfs:label "swid"@en ;
 	rdfs:comment "Specifies the SWID tag for the software."@en ;
-	rdfs:domain :Software ;
+	rdfs:domain observable:Software ;
 	rdfs:range xsd:string ;
 	.
 
-:symbolicName
+observable:symbolicName
 	a owl:DatatypeProperty ;
 	rdfs:label "symbolicName"@en ;
 	rdfs:comment "The symbolic name of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
-	rdfs:domain :GlobalFlagType ;
+	rdfs:domain observable:GlobalFlagType ;
 	rdfs:range xsd:string ;
 	.
 
-:systemTime
+observable:systemTime
 	a owl:DatatypeProperty ;
 	rdfs:label "systemTime"@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:tableName
+observable:tableName
 	a owl:DatatypeProperty ;
 	rdfs:label "tableName"@en ;
-	rdfs:domain :SQLiteBlob ;
+	rdfs:domain observable:SQLiteBlob ;
 	rdfs:range xsd:string ;
 	.
 
-:targetFile
+observable:targetFile
 	a owl:ObjectProperty ;
 	rdfs:label "targetFile"@en ;
 	rdfs:comment "Specifies the file targeted by a symbolic link."@en ;
-	rdfs:domain :SymbolicLink ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:SymbolicLink ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:taskCreator
+observable:taskCreator
 	a owl:DatatypeProperty ;
 	rdfs:label "taskCreator"@en ;
 	rdfs:comment "Specifies the name of the creator of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381235(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
+	rdfs:domain observable:WindowsTask ;
 	rdfs:range xsd:string ;
 	.
 
-:text
+observable:text
 	a owl:DatatypeProperty ;
 	rdfs:label "text"@en ;
-	rdfs:domain :Note ;
+	rdfs:domain observable:Note ;
 	rdfs:range xsd:string ;
 	.
 
-:threadID
+observable:threadID
 	a owl:DatatypeProperty ;
 	rdfs:label "threadID"@en ;
-	rdfs:domain :WindowsThread ;
+	rdfs:domain observable:WindowsThread ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-:thumbprintHash
+observable:thumbprintHash
 	a owl:ObjectProperty ;
 	rdfs:label "thumbprintHash"@en ;
 	rdfs:comment "A hash calculated on the entire certificate including signature."@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Hash> ;
 	.
 
-:timeDateStamp
+observable:timeDateStamp
 	a owl:DatatypeProperty ;
 	rdfs:label "timeDateStamp"@en ;
 	rdfs:comment "Specifies the time when the PE binary was created."@en ;
-	rdfs:domain :WindowsPEBinaryFile ;
+	rdfs:domain observable:WindowsPEBinaryFile ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:timesExecuted
+observable:timesExecuted
 	a owl:DatatypeProperty ;
 	rdfs:label "timesExecuted"@en ;
 	rdfs:comment "The number of times the prefetch application has executed."@en ;
-	rdfs:domain :WindowsPrefetch ;
+	rdfs:domain observable:WindowsPrefetch ;
 	rdfs:range xsd:long ;
 	.
 
-:timezoneDST
+observable:timezoneDST
 	a owl:DatatypeProperty ;
 	rdfs:label "timezoneDST"@en ;
 	rdfs:comment "Specifies the time zone used by the system, taking daylight savings time (DST) into account."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:timezoneStandard
+observable:timezoneStandard
 	a owl:DatatypeProperty ;
 	rdfs:label "timezoneStandard"@en ;
 	rdfs:comment "Specifies the time zone used by the system, without taking daylight savings time (DST) into account."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:to
+observable:to
 	a owl:ObjectProperty ;
 	rdfs:label "to"@en ;
 	rdfs:comment "The receiver's phone number."@en ;
-	rdfs:domain :PhoneCall ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:PhoneCall ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:totalFragments
+observable:totalFragments
 	a owl:DatatypeProperty ;
 	rdfs:label "totalFragments"@en ;
-	rdfs:domain :Fragment ;
+	rdfs:domain observable:Fragment ;
 	rdfs:range xsd:integer ;
 	.
 
-:totalRam
+observable:totalRam
 	a owl:DatatypeProperty ;
 	rdfs:label "totalRam"@en ;
 	rdfs:comment "Specifies the total amount of physical memory present on the system, in bytes."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:long ;
 	.
 
-:totalSpace
+observable:totalSpace
 	a owl:DatatypeProperty ;
 	rdfs:label "totalSpace"@en ;
 	rdfs:comment "Specifies the total amount of space available on the partition, in bytes."@en ;
-	rdfs:domain :DiskPartition ;
+	rdfs:domain observable:DiskPartition ;
 	rdfs:range xsd:long ;
 	.
 
-:triggerBeginTime
+observable:triggerBeginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerBeginTime"@en ;
 	rdfs:comment "Specifies the date/time that the trigger is activated."@en ;
-	rdfs:domain :TriggerType ;
+	rdfs:domain observable:TriggerType ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:triggerDelay
+observable:triggerDelay
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerDelay"@en ;
 	rdfs:comment "Specifies the delay that takes place between when the task is registered and when the task is started."@en ;
-	rdfs:domain :TriggerType ;
+	rdfs:domain observable:TriggerType ;
 	rdfs:range xsd:string ;
 	.
 
-:triggerEndTime
+observable:triggerEndTime
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerEndTime"@en ;
 	rdfs:comment "Specifies the date/time that the trigger is deactivated."@en ;
-	rdfs:domain :TriggerType ;
+	rdfs:domain observable:TriggerType ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:triggerFrequency
+observable:triggerFrequency
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerFrequency"@en ;
 	rdfs:comment "Specifies the frequency at which the trigger repeats."@en ;
-	rdfs:domain :TriggerType ;
-	rdfs:range :TriggerFrequencyEnum ;
+	rdfs:domain observable:TriggerType ;
+	rdfs:range observable:TriggerFrequencyEnum ;
 	.
 
-:triggerList
+observable:triggerList
 	a owl:ObjectProperty ;
 	rdfs:label "triggerList"@en ;
 	rdfs:comment "Specifies a set of triggers used by the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383264(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
-	rdfs:range :TriggerType ;
+	rdfs:domain observable:WindowsTask ;
+	rdfs:range observable:TriggerType ;
 	.
 
-:triggerMaxRunTime
+observable:triggerMaxRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerMaxRunTime"@en ;
 	rdfs:comment "The maximum amount of time that the task launched by the trigger is allowed to run. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383868(v=vs.85).aspx."@en ;
-	rdfs:domain :TriggerType ;
+	rdfs:domain observable:TriggerType ;
 	rdfs:range xsd:string ;
 	.
 
-:triggerSessionChangeType
+observable:triggerSessionChangeType
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerSessionChangeType"@en ;
 	rdfs:comment "Specifies the type of Terminal Server session change that would trigger a task launch. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381298(v=vs.85).aspx."@en ;
-	rdfs:domain :TriggerType ;
+	rdfs:domain observable:TriggerType ;
 	rdfs:range xsd:string ;
 	.
 
-:triggerType
+observable:triggerType
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerType"@en ;
 	rdfs:comment "Specifies the type of the task trigger."@en ;
-	rdfs:domain :TriggerType ;
-	rdfs:range :TriggerTypeEnum ;
+	rdfs:domain observable:TriggerType ;
+	rdfs:range observable:TriggerTypeEnum ;
 	.
 
-:updatedDate
+observable:updatedDate
 	a owl:DatatypeProperty ;
 	rdfs:label "updatedDate"@en ;
 	rdfs:comment "Specifies the date in which the registered domain information was last updated."@en ;
-	rdfs:domain :WhoIs ;
+	rdfs:domain observable:WhoIs ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:uptime
+observable:uptime
 	a owl:DatatypeProperty ;
 	rdfs:label "uptime"@en ;
 	rdfs:comment "Specifies the duration that represents the current amount of time that the system has been up."@en ;
-	rdfs:domain :ComputerSpecification ;
+	rdfs:domain observable:ComputerSpecification ;
 	rdfs:range xsd:string ;
 	.
 
-:url
+observable:url
 	a owl:DatatypeProperty ;
 	rdfs:label "url"@en ;
-	rdfs:domain :Attachment ;
+	rdfs:domain observable:Attachment ;
 	rdfs:range xsd:anyURI ;
 	.
 
-:urlTargeted
+observable:urlTargeted
 	a owl:DatatypeProperty ;
 	rdfs:label "urlTargeted"@en ;
 	rdfs:comment "The target of the bookmark."@en ;
-	rdfs:domain :BrowserBookmark ;
+	rdfs:domain observable:BrowserBookmark ;
 	rdfs:range xsd:anyURI ;
 	.
 
-:userName
+observable:userName
 	a owl:ObjectProperty ;
 	rdfs:label "userName"@en ;
 	rdfs:comment "Username used to authenticate to this resource."@en ;
-	rdfs:domain :URL ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:URL ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:validityNotAfter
+observable:validityNotAfter
 	a owl:DatatypeProperty ;
 	rdfs:label "validityNotAfter"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:validityNotBefore
+observable:validityNotBefore
 	a owl:DatatypeProperty ;
 	rdfs:label "validityNotBefore"@en ;
-	rdfs:domain :X509Certificate ;
+	rdfs:domain observable:X509Certificate ;
 	rdfs:range xsd:dateTime ;
 	.
 
-:value
+observable:value
 	a owl:DatatypeProperty ;
 	rdfs:label "value"@en ;
-	rdfs:domain :IPv4Address ;
+	rdfs:domain observable:IPv4Address ;
 	rdfs:range xsd:string ;
 	.
 
-:values
+observable:values
 	a owl:DatatypeProperty ;
 	rdfs:label "values"@en ;
 	rdfs:comment "The values that were enumerated as a result of the action on the object."@en ;
-	rdfs:domain :ValuesEnumeratedEffect ;
+	rdfs:domain observable:ValuesEnumeratedEffect ;
 	rdfs:range xsd:string ;
 	.
 
-:version
+observable:version
 	a owl:DatatypeProperty ;
 	rdfs:label "version"@en ;
 	rdfs:domain
-		:Application ,
-		:PDFFIle
+		observable:Application ,
+		observable:PDFFIle
 		;
 	rdfs:range xsd:string ;
 	.
 
-:visibility
+observable:visibility
 	a owl:DatatypeProperty ;
 	rdfs:label "visibility"@en ;
-	rdfs:domain :MessageThread ;
+	rdfs:domain observable:MessageThread ;
 	rdfs:range xsd:boolean ;
 	.
 
-:visitCount
+observable:visitCount
 	a owl:DatatypeProperty ;
 	rdfs:label "visitCount"@en ;
 	rdfs:comment "The minimal number of times this web page or file has been visited by this web browser."@en ;
-	rdfs:domain :BrowserBookmark ;
+	rdfs:domain observable:BrowserBookmark ;
 	rdfs:range xsd:integer ;
 	.
 
-:volume
+observable:volume
 	a owl:ObjectProperty ;
 	rdfs:label "volume"@en ;
 	rdfs:comment "The volume from which the prefetch application was run. If the applicatin was run from multiple volumes, there will be a separate prefetch file for each."@en ;
-	rdfs:domain :WindowsPrefetch ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsPrefetch ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:volumeID
+observable:volumeID
 	a owl:DatatypeProperty ;
 	rdfs:label "volumeID"@en ;
 	rdfs:comment "The unique identifier of the volume."@en ;
-	rdfs:domain :Volume ;
+	rdfs:domain observable:Volume ;
 	rdfs:range xsd:string ;
 	.
 
-:whoisServer
+observable:whoisServer
 	a owl:ObjectProperty ;
 	rdfs:label "whoisServer"@en ;
 	rdfs:comment "Specifies the corresponding whois server for a registrar."@en ;
-	rdfs:domain :WhoisRegistrarInfoType ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WhoisRegistrarInfoType ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:win32VersionValue
+observable:win32VersionValue
 	a owl:DatatypeProperty ;
 	rdfs:label "win32VersionValue"@en ;
 	rdfs:comment "Specifies the reserved win32 version value."@en ;
-	rdfs:domain :WindowsPEOptionalHeader ;
+	rdfs:domain observable:WindowsPEOptionalHeader ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-:windowTitle
+observable:windowTitle
 	a owl:DatatypeProperty ;
 	rdfs:label "windowTitle"@en ;
-	rdfs:domain :WindowsProcess ;
+	rdfs:domain observable:WindowsProcess ;
 	rdfs:range xsd:string ;
 	.
 
-:windowsDirectory
+observable:windowsDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "windowsDirectory"@en ;
 	rdfs:comment "The Windows_Directory field specifies the fully-qualified path to the Windows install directory."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsComputerSpecification ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:windowsSystemDirectory
+observable:windowsSystemDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "windowsSystemDirectory"@en ;
 	rdfs:comment "The Windows_System_Directory field specifies the fully-qualified path to the Windows system directory."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsComputerSpecification ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:windowsTempDirectory
+observable:windowsTempDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "windowsTempDirectory"@en ;
 	rdfs:comment "The Windows_Temp_Directory field specifies the fully-qualified path to the Windows temporary files directory."@en ;
-	rdfs:domain :WindowsComputerSpecification ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsComputerSpecification ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:windowsVolumeAttributes
+observable:windowsVolumeAttributes
 	a owl:DatatypeProperty ;
 	rdfs:label "windowsVolumeAttributes"@en ;
 	rdfs:comment "Specifies the attributes of a windows volume."@en ;
-	rdfs:domain :WindowsVolume ;
-	rdfs:range :WindowsVolumeAttributeEnum ;
+	rdfs:domain observable:WindowsVolume ;
+	rdfs:range observable:WindowsVolumeAttributeEnum ;
 	.
 
-:workItemData
+observable:workItemData
 	a owl:ObjectProperty ;
 	rdfs:label "workItemData"@en ;
 	rdfs:comment "Specifies application defined data associated with the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381271(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsTask ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:workingDirectory
+observable:workingDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "workingDirectory"@en ;
 	rdfs:comment "Specifies the working directory for the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381878(v=vs.85).aspx."@en ;
-	rdfs:domain :WindowsTask ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:WindowsTask ;
+	rdfs:range observable:CyberItem ;
 	.
 
-:x509v3extensions
+observable:x509v3extensions
 	a owl:ObjectProperty ;
 	rdfs:label "x509V3Extensions"@en ;
-	rdfs:domain :X509Certificate ;
-	rdfs:range :X509V3Extensions ;
+	rdfs:domain observable:X509Certificate ;
+	rdfs:range observable:X509V3Extensions ;
 	.
 
-:xMailer
+observable:xMailer
 	a owl:DatatypeProperty ;
 	rdfs:label "xMailer"@en ;
-	rdfs:domain :EmailMessage ;
+	rdfs:domain observable:EmailMessage ;
 	rdfs:range xsd:string ;
 	.
 
-:xOriginatingIP
+observable:xOriginatingIP
 	a owl:ObjectProperty ;
 	rdfs:label "xOriginatingIP"@en ;
-	rdfs:domain :EmailMessage ;
-	rdfs:range :CyberItem ;
+	rdfs:domain observable:EmailMessage ;
+	rdfs:range observable:CyberItem ;
 	.
 


### PR DESCRIPTION
The prefix was replaced and the rdf-toolkit used to normalize the file.