### PR TITLE
Removed unnecessary "owl:onDatatype xsd:string ;" assertions

### DIFF
--- a/uco-vocabulary/vocabulary.ttl
+++ b/uco-vocabulary/vocabulary.ttl
@@ -19,7 +19,6 @@ vocab:AccountTypeVocab
 	a rdfs:Datatype ;
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Account Type Vocabulary"@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"ldap"^^vocab:AccountTypeVocab
 		"nis"^^vocab:AccountTypeVocab
@@ -38,7 +37,6 @@ vocab:ActionArgumentNameVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Action Argument Name Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary for common arguments of cyber actions."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"APC Address"^^vocab:ActionArgumentNameVocab
 		"APC Mode"^^vocab:ActionArgumentNameVocab
@@ -100,7 +98,6 @@ vocab:ActionNameVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Action Name Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common specific cyber action names."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Accept Socket Connection"^^vocab:ActionNameVocab
 		"Add Connection to Network Share"^^vocab:ActionNameVocab
@@ -292,7 +289,6 @@ vocab:ActionRelationshipTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Action Relationship Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary for capturing types of relationships between actions."@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Dependent_On"^^vocab:ActionRelationshipTypeVocab
 		"Equivalent_To"^^vocab:ActionRelationshipTypeVocab
@@ -310,7 +306,6 @@ vocab:ActionStatusTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Action Status Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of action status types."@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Complete/Finish"^^vocab:ActionStatusTypeVocab
 		"Error"^^vocab:ActionStatusTypeVocab
@@ -328,7 +323,6 @@ vocab:ActionTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Action Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common general action types."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Accept"^^vocab:ActionTypeVocab
 		"Access"^^vocab:ActionTypeVocab
@@ -450,7 +444,6 @@ vocab:BitnessVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Bitness Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of word sizes that define classes of operating systems."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"32"^^vocab:BitnessVocab
 		"64"^^vocab:BitnessVocab
@@ -463,7 +456,6 @@ vocab:CharacterEncodingVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Character Encoding Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of character encodings."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"ASCII"^^vocab:CharacterEncodingVocab
 		"UTF-16"^^vocab:CharacterEncodingVocab
@@ -487,7 +479,6 @@ vocab:CyberItemRelationshipVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Cyber Item Relationship Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of inter-cyberitem relationships."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Allocated"^^vocab:CyberItemRelationshipVocab
 		"Allocated_By"^^vocab:CyberItemRelationshipVocab
@@ -634,7 +625,6 @@ vocab:CyberItemStateVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Cyber Item State Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of cyberitem states."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Active"^^vocab:CyberItemStateVocab
 		"Closed"^^vocab:CyberItemStateVocab
@@ -655,7 +645,6 @@ vocab:DiskTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Disk Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of disk types."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"CDRom"^^vocab:DiskTypeVocab
 		"Fixed"^^vocab:DiskTypeVocab
@@ -671,7 +660,6 @@ vocab:EndiannessTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Endianness Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of byte ordering methods."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Big-endian"^^vocab:EndiannessTypeVocab
 		"Little-endian"^^vocab:EndiannessTypeVocab
@@ -685,7 +673,6 @@ vocab:HashNameVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Hash Name Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of hashing algorithm names."@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"MD5"^^vocab:HashNameVocab
 		"MD6"^^vocab:HashNameVocab
@@ -704,7 +691,6 @@ vocab:InvestigationFormVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Investigation Form Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of investigation forms."@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"case"^^vocab:InvestigationFormVocab
 		"incident"^^vocab:InvestigationFormVocab
@@ -718,7 +704,6 @@ vocab:LibraryTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Library Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of library types."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Dynamic"^^vocab:LibraryTypeVocab
 		"Other"^^vocab:LibraryTypeVocab
@@ -734,7 +719,6 @@ vocab:MemoryBlockTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Memory Block Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of types of memory blocks."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Bit-mapped"^^vocab:MemoryBlockTypeVocab
 		"Byte-mapped"^^vocab:MemoryBlockTypeVocab
@@ -750,7 +734,6 @@ vocab:PartitionTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Partition Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of partition types. See http://www.win.tue.nl/~aeb/partitions/partition_types-1.html for more information about the various partition types."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"PARTITION_ENTRY_UNUSED"^^vocab:PartitionTypeVocab
 		"PARTITION_EXTENDED"^^vocab:PartitionTypeVocab
@@ -780,7 +763,6 @@ vocab:ProcessorArchVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Processor Architecture Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of computer processor architectures."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"ARM"^^vocab:ProcessorArchVocab
 		"Alpha"^^vocab:ProcessorArchVocab
@@ -803,7 +785,6 @@ vocab:RegionalRegistryTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Regional Registry Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of Regional Internet Registries (RIRs) names, represented via their respective acronyms."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"APNIC"^^vocab:RegionalRegistryTypeVocab
 		"ARIN"^^vocab:RegionalRegistryTypeVocab
@@ -818,7 +799,6 @@ vocab:RegistryDatatypeVocab
 	a rdfs:Datatype ;
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Registry Datatype Vocabulary"@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"reg_binary"^^vocab:RegistryDatatypeVocab
 		"reg_dword"^^vocab:RegistryDatatypeVocab
@@ -842,7 +822,6 @@ vocab:SIMFormVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "SIM Form Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common SIM card form factors."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Full-size SIM"^^vocab:SIMFormVocab
 		"Micro SIM"^^vocab:SIMFormVocab
@@ -856,7 +835,6 @@ vocab:SIMTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "SIM Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common SIM card types."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"SIM"^^vocab:SIMTypeVocab
 		"UICC"^^vocab:SIMTypeVocab
@@ -870,7 +848,6 @@ vocab:TaskActionTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Task Action Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of task action types. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380596(v=vs.85).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"TASK_ACTION_COM_HANDLER"^^vocab:TaskActionTypeVocab
 		"TASK_ACTION_EXEC"^^vocab:TaskActionTypeVocab
@@ -885,7 +862,6 @@ vocab:TaskFlagVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Task Flag Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the run flags for a task scheduler task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx See Also: http://msdn.microsoft.com/en-us/library/microsoft.office.excel.server.addins.computecluster.taskscheduler.taskflags(v=office.12).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"TASK_FLAG_DELETE_WHEN_DONE"^^vocab:TaskFlagVocab
 		"TASK_FLAG_DISABLED"^^vocab:TaskFlagVocab
@@ -909,7 +885,6 @@ vocab:TaskPriorityVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Task Priority Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the priority levels of task scheduler tasks. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383512(v=vs.85).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"ABOVE_NORMAL_PRIORITY_CLASS"^^vocab:TaskPriorityVocab
 		"BELOW_NORMAL_PRIORITY_CLASS"^^vocab:TaskPriorityVocab
@@ -926,7 +901,6 @@ vocab:TaskStatusVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Task Status Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the possible statuses of a scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383604(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381263(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381833(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383617(v=vs.85).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"SCHED_E_ACCOUNT_DBASE_CORRUPT"^^vocab:TaskStatusVocab
 		"SCHED_E_ACCOUNT_INFORMATION_NOT_SET"^^vocab:TaskStatusVocab
@@ -961,7 +935,6 @@ vocab:ThreadRunningStatusVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Thread Running Status Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the various states that a thread may be in before, during, or after execution. See http://msdn.microsoft.com/en-us/library/system.diagnostics.threadstate(v=vs.110).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Initialized"^^vocab:ThreadRunningStatusVocab
 		"Ready"^^vocab:ThreadRunningStatusVocab
@@ -980,7 +953,6 @@ vocab:TimestampPrecisionVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Timestamp Precision Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of timestamp precision granularities."@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"day"^^vocab:TimestampPrecisionVocab
 		"hour"^^vocab:TimestampPrecisionVocab
@@ -997,7 +969,6 @@ vocab:TrendVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Trend Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of trend values."@en-US ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Decreasing"^^vocab:TrendVocab
 		"Increasing"^^vocab:TrendVocab
@@ -1010,7 +981,6 @@ vocab:TriggerFrequencyVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Trigger Frequency Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the frequency types that a trigger may use. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383620(v=vs.85).aspx and http://msdn.microsoft.com/en-us/library/windows/desktop/aa383987(v=vs.85).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"TASK_EVENT_TRIGGER_AT_LOGON"^^vocab:TriggerFrequencyVocab
 		"TASK_EVENT_TRIGGER_AT_SYSTEMSTART"^^vocab:TriggerFrequencyVocab
@@ -1029,7 +999,6 @@ vocab:TriggerTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Trigger Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the types of triggers associated with a task."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"TASK_TRIGGER_BOOT"^^vocab:TriggerTypeVocab
 		"TASK_TRIGGER_EVENT"^^vocab:TriggerTypeVocab
@@ -1047,7 +1016,6 @@ vocab:UnixProcessStateVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "UNIX Process State Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of Unix process states"@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Dead"^^vocab:UnixProcessStateVocab
 		"InterruptibleSleep"^^vocab:UnixProcessStateVocab
@@ -1065,7 +1033,6 @@ vocab:WhoisContactTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Whois Contact Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of types of registrar contacts listed in a whois entry."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"ADMIN"^^vocab:WhoisContactTypeVocab
 		"BILLING"^^vocab:WhoisContactTypeVocab
@@ -1079,7 +1046,6 @@ vocab:WhoisDNSSECTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Whois DNSSEC Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of acceptable values for the DNSSEC field in a Whois entry."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Signed"^^vocab:WhoisDNSSECTypeVocab
 		"Unsigned"^^vocab:WhoisDNSSECTypeVocab
@@ -1092,7 +1058,6 @@ vocab:WhoisStatusTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Whois Status Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of all valid statuses for a domain within a whois entry."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"ADD_PERIOD"^^vocab:WhoisStatusTypeVocab
 		"AUTO_RENEW_PERIOD"^^vocab:WhoisStatusTypeVocab
@@ -1122,7 +1087,6 @@ vocab:WindowsDriveTypeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Windows Drive Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of possible drive types, as enumerated by the WINAPI GetDriveType function: http://msdn.microsoft.com/en-us/library/windows/desktop/aa364939(v=vs.85).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"DRIVE_CDROM"^^vocab:WindowsDriveTypeVocab
 		"DRIVE_FIXED"^^vocab:WindowsDriveTypeVocab
@@ -1140,7 +1104,6 @@ vocab:WindowsVolumeAttributeVocab
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Windows Volume Attribute Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of attributes that may be returned by the diskpart attributes command: http://technet.microsoft.com/en-us/library/cc766465(v=ws.10).aspx."@en ;
-	owl:onDatatype xsd:string ;
 	owl:oneOf (
 		"Hidden"^^vocab:WindowsVolumeAttributeVocab
 		"NoDefaultDriveLetter"^^vocab:WindowsVolumeAttributeVocab
@@ -1149,4 +1112,3 @@ vocab:WindowsVolumeAttributeVocab
 	) ;
 	edt:typeIdentifier "windows-volume-attribute-ov" ;
 	.
-


### PR DESCRIPTION
Removed unnecessary "owl:onDatatype xsd:string ;" assertion from each vocabulary definition in support of Issue-179.