### PR TITLE
Normalize content with rdf-toolkit

### DIFF
--- a/uco-core/core-da.ttl
+++ b/uco-core/core-da.ttl
@@ -133,3 +133,4 @@ core:type
 core:value
 	rdfs:domain core:ControlledVocabulary ;
 	.
+

--- a/uco-core/core.ttl
+++ b/uco-core/core.ttl
@@ -452,3 +452,4 @@ core:value
 <https://unifiedcyberontology.org/ontology/uco/marking#MarkingDefinition>
 	a owl:Class ;
 	.
+

--- a/uco-master/uco.ttl
+++ b/uco-master/uco.ttl
@@ -1,43 +1,65 @@
+# baseURI: https://unifiedcyberontology.org/ontology/uco/uco
+# imports: https://unifiedcyberontology.org/ontology/uco/action
+# imports: https://unifiedcyberontology.org/ontology/uco/action-da
+# imports: https://unifiedcyberontology.org/ontology/uco/core
+# imports: https://unifiedcyberontology.org/ontology/uco/core-da
+# imports: https://unifiedcyberontology.org/ontology/uco/identity
+# imports: https://unifiedcyberontology.org/ontology/uco/identity-da
+# imports: https://unifiedcyberontology.org/ontology/uco/location
+# imports: https://unifiedcyberontology.org/ontology/uco/location-da
+# imports: https://unifiedcyberontology.org/ontology/uco/marking
+# imports: https://unifiedcyberontology.org/ontology/uco/marking-da
+# imports: https://unifiedcyberontology.org/ontology/uco/observable
+# imports: https://unifiedcyberontology.org/ontology/uco/observable-da
+# imports: https://unifiedcyberontology.org/ontology/uco/pattern
+# imports: https://unifiedcyberontology.org/ontology/uco/pattern-da
+# imports: https://unifiedcyberontology.org/ontology/uco/role
+# imports: https://unifiedcyberontology.org/ontology/uco/time
+# imports: https://unifiedcyberontology.org/ontology/uco/tool
+# imports: https://unifiedcyberontology.org/ontology/uco/tool-da
+# imports: https://unifiedcyberontology.org/ontology/uco/types
+# imports: https://unifiedcyberontology.org/ontology/uco/types-da
+# imports: https://unifiedcyberontology.org/ontology/uco/victim
+
+@base <https://unifiedcyberontology.org/ontology/uco/uco> .
 @prefix : <https://unifiedcyberontology.org/ontology/uco/uco#> .
-@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix uco: <https://unifiedcyberontology.org/ontology/uco/uco#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <https://unifiedcyberontology.org/ontology/uco/uco> .
 
-<https://unifiedcyberontology.org/ontology/uco/uco> rdf:type owl:Ontology ;
-                                                     owl:imports <https://unifiedcyberontology.org/ontology/uco/action> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/action-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/core> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/core-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/identity> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/identity-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/location> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/location-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/marking> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/marking-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/observable> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/observable-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/pattern> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/pattern-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/role> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/time> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/tool> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/tool-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/types> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/types-da> ,
-                                                                 <https://unifiedcyberontology.org/ontology/uco/victim> ;
-                                                     rdfs:label "uco-master"@en .
+<https://unifiedcyberontology.org/ontology/uco/uco>
+	a owl:Ontology ;
+	rdfs:label "uco-master"@en ;
+	owl:imports
+		<https://unifiedcyberontology.org/ontology/uco/action> ,
+		<https://unifiedcyberontology.org/ontology/uco/action-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/core> ,
+		<https://unifiedcyberontology.org/ontology/uco/core-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/identity> ,
+		<https://unifiedcyberontology.org/ontology/uco/identity-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/location> ,
+		<https://unifiedcyberontology.org/ontology/uco/location-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/marking> ,
+		<https://unifiedcyberontology.org/ontology/uco/marking-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/observable> ,
+		<https://unifiedcyberontology.org/ontology/uco/observable-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/pattern> ,
+		<https://unifiedcyberontology.org/ontology/uco/pattern-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/role> ,
+		<https://unifiedcyberontology.org/ontology/uco/time> ,
+		<https://unifiedcyberontology.org/ontology/uco/tool> ,
+		<https://unifiedcyberontology.org/ontology/uco/tool-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/types> ,
+		<https://unifiedcyberontology.org/ontology/uco/types-da> ,
+		<https://unifiedcyberontology.org/ontology/uco/victim>
+		;
+	.
 
-#################################################################
-#    Data properties
-#################################################################
+<https://unifiedcyberontology.org/ontology/uco/core#id>
+	rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Identifier> ;
+	.
 
-###  https://unifiedcyberontology.org/ontology/uco/core#id
-<https://unifiedcyberontology.org/ontology/uco/core#id> rdfs:range <https://unifiedcyberontology.org/ontology/uco/types#Identifier> .
-
-
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/uco-observable/observable-da.ttl
+++ b/uco-observable/observable-da.ttl
@@ -1288,10 +1288,6 @@ observable:oldObject
 	rdfs:domain observable:StateChangeEffectFacet ;
 	.
 
-observable:taskComment
-	rdfs:domain observable:WindowsTaskFacet ;
-	.
-
 observable:openFileDescriptor
 	rdfs:domain observable:UNIXProcessFacet ;
 	.
@@ -1869,6 +1865,10 @@ observable:targetFile
 	rdfs:domain observable:SymbolicLinkFacet ;
 	.
 
+observable:taskComment
+	rdfs:domain observable:WindowsTaskFacet ;
+	.
+
 observable:taskCreator
 	rdfs:domain observable:WindowsTaskFacet ;
 	.
@@ -2055,3 +2055,4 @@ observable:xMailer
 observable:xOriginatingIP
 	rdfs:domain observable:EmailMessageFacet ;
 	.
+

--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -28,6 +28,31 @@
 		;
 	.
 
+observable:AccountAuthenticationFacet
+	a owl:Class ;
+	rdfs:subClassOf
+		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:passwordLastChanged ;
+			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:password ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:passwordType ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		]
+		;
+	rdfs:label "AccountAuthenticationFacet"@en ;
+	.
+
 observable:AccountFacet
 	a owl:Class ;
 	rdfs:subClassOf
@@ -79,31 +104,6 @@ observable:AccountFacet
 	rdfs:comment "The fundamental properties of an account."@en ;
 	.
 
-observable:AccountAuthenticationFacet
-	a owl:Class ;
-	rdfs:subClassOf
-		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:passwordLastChanged ;
-			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:password ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:string ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:passwordType ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:string ;
-		]
-		;
-	rdfs:label "AccountAuthenticationFacet"@en ;
-	.
-
 observable:AlternateDataStream
 	a owl:Class ;
 	rdfs:subClassOf
@@ -126,6 +126,21 @@ observable:AlternateDataStream
 		]
 		;
 	rdfs:label "AlternateDataStream"@en ;
+	.
+
+observable:ApplicationAccountFacet
+	a owl:Class ;
+	rdfs:subClassOf
+		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:ObservableObject ;
+			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		]
+		;
+	rdfs:label "ApplicationAccountFacet"@en ;
+	rdfs:comment "Characteristics of an account within a particular application."@en ;
 	.
 
 observable:ApplicationFacet
@@ -159,21 +174,6 @@ observable:ApplicationFacet
 		;
 	rdfs:label "ApplicationFacet"@en ;
 	rdfs:comment "Characteristics of a software application."@en ;
-	.
-
-observable:ApplicationAccountFacet
-	a owl:Class ;
-	rdfs:subClassOf
-		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:application ;
-			owl:onClass observable:ObservableObject ;
-			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		]
-		;
-	rdfs:label "ApplicationAccountFacet"@en ;
-	rdfs:comment "Characteristics of an account within a particular application."@en ;
 	.
 
 observable:ArchiveFileFacet
@@ -378,27 +378,6 @@ observable:BrowserCookieFacet
 	rdfs:comment "A piece of data used by a (remote) web page, stored on the local machine."@en ;
 	.
 
-observable:CalendarFacet
-	a owl:Class ;
-	rdfs:subClassOf
-		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:application ;
-			owl:onClass observable:ObservableObject ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:owner ;
-			owl:onClass observable:ObservableObject ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		]
-		;
-	rdfs:label "CalendarFacet"@en ;
-	rdfs:comment "A collection of appointments and meetings."@en ;
-	.
-
 observable:CalendarEntryFacet
 	a owl:Class ;
 	rdfs:subClassOf
@@ -483,6 +462,27 @@ observable:CalendarEntryFacet
 		;
 	rdfs:label "CalendarEntryFacet"@en ;
 	rdfs:comment "Characteristics of an entry (appointment, meeting, event) within a calendar."@en ;
+	.
+
+observable:CalendarFacet
+	a owl:Class ;
+	rdfs:subClassOf
+		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:application ;
+			owl:onClass observable:ObservableObject ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:owner ;
+			owl:onClass observable:ObservableObject ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		]
+		;
+	rdfs:label "CalendarFacet"@en ;
+	rdfs:comment "A collection of appointments and meetings."@en ;
 	.
 
 observable:CompressedStreamFacet
@@ -742,54 +742,6 @@ observable:ContentDataFacet
 		;
 	rdfs:label "ContentDataFacet"@en ;
 	rdfs:comment "Characteristics of a block of digital data."@en ;
-	.
-
-observable:ObservableAction
-	a owl:Class ;
-	rdfs:subClassOf
-		<https://unifiedcyberontology.org/ontology/uco/action#Action> ,
-		observable:Observable
-		;
-	rdfs:label "ObservableAction"@en ;
-	rdfs:comment "Something that may be done or performed within the digital domain."@en ;
-	.
-
-observable:ObservableObject
-	a owl:Class ;
-	rdfs:subClassOf
-		<https://unifiedcyberontology.org/ontology/uco/core#Item> ,
-		observable:Observable ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:state ;
-			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty observable:hasChanged ;
-			owl:onDataRange xsd:boolean ;
-			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		]
-		;
-	rdfs:label "ObservableObject"@en ;
-	rdfs:comment "A distinct article or unit within the digital domain."@en ;
-	.
-
-observable:ObservablePattern
-	a owl:Class ;
-	rdfs:subClassOf observable:Observable ;
-	rdfs:label "ObservablePattern"@en ;
-	rdfs:comment "A logical pattern composed of observable object and observable action properties."@en ;
-	.
-
-observable:ObservableRelationship
-	a owl:Class ;
-	rdfs:subClassOf
-		<https://unifiedcyberontology.org/ontology/uco/core#Relationship> ,
-		observable:Observable
-		;
-	rdfs:label "ObservableRelationship"@en ;
-	rdfs:comment "An association or link between two cyber observable objects."@en ;
 	.
 
 observable:DataRangeFacet
@@ -2562,6 +2514,54 @@ observable:Observable
 """@en ;
 	.
 
+observable:ObservableAction
+	a owl:Class ;
+	rdfs:subClassOf
+		<https://unifiedcyberontology.org/ontology/uco/action#Action> ,
+		observable:Observable
+		;
+	rdfs:label "ObservableAction"@en ;
+	rdfs:comment "Something that may be done or performed within the digital domain."@en ;
+	.
+
+observable:ObservableObject
+	a owl:Class ;
+	rdfs:subClassOf
+		<https://unifiedcyberontology.org/ontology/uco/core#Item> ,
+		observable:Observable ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:state ;
+			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:hasChanged ;
+			owl:onDataRange xsd:boolean ;
+			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		]
+		;
+	rdfs:label "ObservableObject"@en ;
+	rdfs:comment "A distinct article or unit within the digital domain."@en ;
+	.
+
+observable:ObservablePattern
+	a owl:Class ;
+	rdfs:subClassOf observable:Observable ;
+	rdfs:label "ObservablePattern"@en ;
+	rdfs:comment "A logical pattern composed of observable object and observable action properties."@en ;
+	.
+
+observable:ObservableRelationship
+	a owl:Class ;
+	rdfs:subClassOf
+		<https://unifiedcyberontology.org/ontology/uco/core#Relationship> ,
+		observable:Observable
+		;
+	rdfs:label "ObservableRelationship"@en ;
+	rdfs:comment "An association or link between two cyber observable objects."@en ;
+	.
+
 observable:Observation
 	a owl:Class ;
 	rdfs:subClassOf
@@ -3172,12 +3172,6 @@ observable:TaskActionType
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty observable:iEmailAction ;
-			owl:onClass observable:ObservableObject ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
 			owl:onProperty observable:iComHandlerAction ;
 			owl:onClass observable:IComHandlerActionType ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
@@ -3192,6 +3186,12 @@ observable:TaskActionType
 			a owl:Restriction ;
 			owl:onProperty observable:iShowMessageAction ;
 			owl:onClass observable:IShowMessageActionType ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:iEmailAction ;
+			owl:onClass observable:ObservableObject ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
 		[
@@ -7991,3 +7991,4 @@ observable:xOriginatingIP
 	rdfs:label "xOriginatingIP"@en ;
 	rdfs:range observable:ObservableObject ;
 	.
+

--- a/uco-types/types.ttl
+++ b/uco-types/types.ttl
@@ -151,3 +151,4 @@ types:value
 	rdfs:comment "A specific property value."@en ;
 	rdfs:range xsd:string ;
 	.
+

--- a/uco-vocabulary/vocabulary.ttl
+++ b/uco-vocabulary/vocabulary.ttl
@@ -463,6 +463,77 @@ vocab:CharacterEncodingVocab
 	) ;
 	.
 
+vocab:DiskTypeVocab
+	a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:label "Disk Type Vocabulary"@en-US ;
+	rdfs:comment "Defines an open-vocabulary of disk types."@en ;
+	owl:oneOf (
+		"CDRom"^^vocab:DiskTypeVocab
+		"Fixed"^^vocab:DiskTypeVocab
+		"RAMDisk"^^vocab:DiskTypeVocab
+		"Remote"^^vocab:DiskTypeVocab
+		"Removable"^^vocab:DiskTypeVocab
+	) ;
+	.
+
+vocab:EndiannessTypeVocab
+	a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:label "Endianness Type Vocabulary"@en-US ;
+	rdfs:comment "Defines an open-vocabulary of byte ordering methods."@en ;
+	owl:oneOf (
+		"Big-endian"^^vocab:EndiannessTypeVocab
+		"Little-endian"^^vocab:EndiannessTypeVocab
+		"Middle-endian"^^vocab:EndiannessTypeVocab
+	) ;
+	.
+
+vocab:HashNameVocab
+	a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:label "Hash Name Vocabulary"@en-US ;
+	rdfs:comment "Defines an open-vocabulary of hashing algorithm names."@en-US ;
+	owl:oneOf (
+		"MD5"^^vocab:HashNameVocab
+		"MD6"^^vocab:HashNameVocab
+		"SHA1"^^vocab:HashNameVocab
+		"SHA224"^^vocab:HashNameVocab
+		"SHA256"^^vocab:HashNameVocab
+		"SHA384"^^vocab:HashNameVocab
+		"SHA512"^^vocab:HashNameVocab
+		"SSDEEP"^^vocab:HashNameVocab
+	) ;
+	.
+
+vocab:LibraryTypeVocab
+	a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:label "Library Type Vocabulary"@en-US ;
+	rdfs:comment "Defines an open-vocabulary of library types."@en ;
+	owl:oneOf (
+		"Dynamic"^^vocab:LibraryTypeVocab
+		"Other"^^vocab:LibraryTypeVocab
+		"Remote"^^vocab:LibraryTypeVocab
+		"Shared"^^vocab:LibraryTypeVocab
+		"Static"^^vocab:LibraryTypeVocab
+	) ;
+	.
+
+vocab:MemoryBlockTypeVocab
+	a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:label "Memory Block Type Vocabulary"@en-US ;
+	rdfs:comment "Defines an open-vocabulary of types of memory blocks."@en ;
+	owl:oneOf (
+		"Bit-mapped"^^vocab:MemoryBlockTypeVocab
+		"Byte-mapped"^^vocab:MemoryBlockTypeVocab
+		"Initialized"^^vocab:MemoryBlockTypeVocab
+		"Overlay"^^vocab:MemoryBlockTypeVocab
+		"Uninitialized"^^vocab:MemoryBlockTypeVocab
+	) ;
+	.
+
 vocab:ObservableObjectRelationshipVocab
 	a rdfs:Datatype ;
 	rdfs:subClassOf rdfs:Resource ;
@@ -624,77 +695,6 @@ vocab:ObservableObjectStateVocab
 		"Started"^^vocab:ObservableObjectStateVocab
 		"Stopped"^^vocab:ObservableObjectStateVocab
 		"Unlocked"^^vocab:ObservableObjectStateVocab
-	) ;
-	.
-
-vocab:DiskTypeVocab
-	a rdfs:Datatype ;
-	rdfs:subClassOf rdfs:Resource ;
-	rdfs:label "Disk Type Vocabulary"@en-US ;
-	rdfs:comment "Defines an open-vocabulary of disk types."@en ;
-	owl:oneOf (
-		"CDRom"^^vocab:DiskTypeVocab
-		"Fixed"^^vocab:DiskTypeVocab
-		"RAMDisk"^^vocab:DiskTypeVocab
-		"Remote"^^vocab:DiskTypeVocab
-		"Removable"^^vocab:DiskTypeVocab
-	) ;
-	.
-
-vocab:EndiannessTypeVocab
-	a rdfs:Datatype ;
-	rdfs:subClassOf rdfs:Resource ;
-	rdfs:label "Endianness Type Vocabulary"@en-US ;
-	rdfs:comment "Defines an open-vocabulary of byte ordering methods."@en ;
-	owl:oneOf (
-		"Big-endian"^^vocab:EndiannessTypeVocab
-		"Little-endian"^^vocab:EndiannessTypeVocab
-		"Middle-endian"^^vocab:EndiannessTypeVocab
-	) ;
-	.
-
-vocab:HashNameVocab
-	a rdfs:Datatype ;
-	rdfs:subClassOf rdfs:Resource ;
-	rdfs:label "Hash Name Vocabulary"@en-US ;
-	rdfs:comment "Defines an open-vocabulary of hashing algorithm names."@en-US ;
-	owl:oneOf (
-		"MD5"^^vocab:HashNameVocab
-		"MD6"^^vocab:HashNameVocab
-		"SHA1"^^vocab:HashNameVocab
-		"SHA224"^^vocab:HashNameVocab
-		"SHA256"^^vocab:HashNameVocab
-		"SHA384"^^vocab:HashNameVocab
-		"SHA512"^^vocab:HashNameVocab
-		"SSDEEP"^^vocab:HashNameVocab
-	) ;
-	.
-
-vocab:LibraryTypeVocab
-	a rdfs:Datatype ;
-	rdfs:subClassOf rdfs:Resource ;
-	rdfs:label "Library Type Vocabulary"@en-US ;
-	rdfs:comment "Defines an open-vocabulary of library types."@en ;
-	owl:oneOf (
-		"Dynamic"^^vocab:LibraryTypeVocab
-		"Other"^^vocab:LibraryTypeVocab
-		"Remote"^^vocab:LibraryTypeVocab
-		"Shared"^^vocab:LibraryTypeVocab
-		"Static"^^vocab:LibraryTypeVocab
-	) ;
-	.
-
-vocab:MemoryBlockTypeVocab
-	a rdfs:Datatype ;
-	rdfs:subClassOf rdfs:Resource ;
-	rdfs:label "Memory Block Type Vocabulary"@en-US ;
-	rdfs:comment "Defines an open-vocabulary of types of memory blocks."@en ;
-	owl:oneOf (
-		"Bit-mapped"^^vocab:MemoryBlockTypeVocab
-		"Byte-mapped"^^vocab:MemoryBlockTypeVocab
-		"Initialized"^^vocab:MemoryBlockTypeVocab
-		"Overlay"^^vocab:MemoryBlockTypeVocab
-		"Uninitialized"^^vocab:MemoryBlockTypeVocab
 	) ;
 	.
 
@@ -1060,3 +1060,4 @@ vocab:WindowsVolumeAttributeVocab
 		"ShadowCopy"^^vocab:WindowsVolumeAttributeVocab
 	) ;
 	.
+


### PR DESCRIPTION
This patch applies rdf-toolkit to all of the Turtle files in UCO
(including *-da.ttl files), following the normalization process adopted
by the CASE community.

Normalization was confirmed by the CASE-Examples-QC repository.

Please note this disclaimer related to mention of specific software:
Participation by NIST in the creation of the instructions to this
toolkit is not intended to imply a recommendation or endorsement by the
National Institute of Standards and Technology, nor is it intended to
imply that any specific software or toolkit is necessarily the best
available for the purpose.

References:
* [CASE-Examples-QC] https://github.com/ajnelson-nist/CASE-Examples-QC
  Branch: OC-43
* [CASE ONT-5] (CP-3) Establish ontology normalization procedure
* [Normalization process] https://github.com/casework/CASE/blob/master/NORMALIZING.md

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>