### PR TITLE
Bug fix cp31

### DIFF
--- a/uco-core/core-da.ttl
+++ b/uco-core/core-da.ttl
@@ -2,7 +2,6 @@
 
 @base <https://unifiedcyberontology.org/ontology/uco/core-da> .
 @prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
-@prefix investigation: <https://unifiedcyberontology.org/ontology/uco/investigation#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -48,10 +47,7 @@ core:description
 	.
 
 core:endTime
-	rdfs:domain
-		core:Relationship ,
-		investigation:Authorization
-		;
+	rdfs:domain core:Relationship ;
 	.
 
 core:externalIdentifier


### PR DESCRIPTION
References should have been removed in UCO 0.5.0.

References:
* [OC-83] (CP-31) core-da.ttl includes errant assertion on investigation
  namespace
* [UCO 209] https://github.com/ucoProject/UCO/issues/209

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>