### PR TITLE
Consolidate versionInfo to one declaration of 0.6.0

### DIFF
--- a/uco-action/action.ttl
+++ b/uco-action/action.ttl
@@ -24,7 +24,6 @@
 		<https://unifiedcyberontology.org/ontology/uco/types> ,
 		<https://unifiedcyberontology.org/ontology/uco/vocabulary>
 		;
-	owl:versionInfo "0.4.0" ;
 	.
 
 action:Action

--- a/uco-core/core-da.ttl
+++ b/uco-core/core-da.ttl
@@ -11,7 +11,6 @@
 	a owl:Ontology ;
 	rdfs:label "uco-core"@en ;
 	rdfs:comment "This ontology defines classes and properties that are shared across the various UCO ontologies.  At a high-level, the UCO core ontology provides base classes, relationship-oriented classes, content-aggregation classes, and shared classes."@en ;
-	owl:versionInfo "0.2.1" ;
 	.
 
 core:confidence

--- a/uco-core/core.ttl
+++ b/uco-core/core.ttl
@@ -16,7 +16,6 @@
 	rdfs:label "uco-core"@en ;
 	rdfs:comment "This ontology defines classes and properties that are shared across the various UCO ontologies.  At a high-level, the UCO core ontology provides base classes, relationship-oriented classes, content-aggregation classes, and shared classes."@en ;
 	owl:imports <https://unifiedcyberontology.org/ontology/uco/vocabulary> ;
-	owl:versionInfo "0.4.0" ;
 	.
 
 core:Annotation

--- a/uco-master/uco.ttl
+++ b/uco-master/uco.ttl
@@ -57,6 +57,7 @@
 		<https://unifiedcyberontology.org/ontology/uco/types-da> ,
 		<https://unifiedcyberontology.org/ontology/uco/victim>
 		;
+	owl:versionInfo "0.6.0" ;
 	.
 
 <https://unifiedcyberontology.org/ontology/uco/core#id>

--- a/uco-types/types.ttl
+++ b/uco-types/types.ttl
@@ -17,7 +17,6 @@
 		<https://unifiedcyberontology.org/ontology/uco/core> ,
 		<https://unifiedcyberontology.org/ontology/uco/vocabulary>
 		;
-	owl:versionInfo "0.4.0" ;
 	.
 
 types:ControlledDictionary


### PR DESCRIPTION
This patch bumps the version declaration of UCO to 0.6.0.  It also
removes some unmaintained versionInfo declarations from other
ontologies.  There is a plan to restore these other versionInfo
declarations in CASE CP-17, but CASE and UCO are currently analyzing
options for the version-incrementing strategy.

This patch is confirmed to not cause normalization issues.

References:
* [CASE-Examples-QC] https://github.com/ajnelson-nist/CASE-Examples-QC
* [CASE ONT-64] (CP-17) Define scheme for CASE and UCO importable
  versioned IRIs

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>