### PR TITLE
Add missed update for partitionID type

### DIFF
--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -1543,7 +1543,7 @@ observable:DiskPartitionFacet
 			a owl:Restriction ;
 			owl:onProperty observable:partitionID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:integer ;
+			owl:onDataRange xsd:string ;
 		] ,
 		[
 			a owl:Restriction ;


### PR DESCRIPTION
The proposal filed in Issue 160 changed the type of partitionID to be a
string instead of an integer.  Unfortunately, one update point was
missed.

References:
* [Issue 160] Change Proposal: Revise range and documentation of
  partitionID
* [OC-120] (CP-46) DiskPartitionFacet accidentally has partitionID range
  as xsd:integer

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>