### PR TITLE
Add missed update for partitionID type

### DIFF
--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -1541,12 +1541,6 @@ observable:DiskPartitionFacet
 		] ,
 		[
 			a owl:Restriction ;
-			owl:onProperty observable:partitionID ;
-			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			owl:onDataRange xsd:integer ;
-		] ,
-		[
-			a owl:Restriction ;
 			owl:onProperty observable:partitionLength ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:integer ;
@@ -1578,6 +1572,12 @@ observable:DiskPartitionFacet
 		[
 			a owl:Restriction ;
 			owl:onProperty observable:mountPoint ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty observable:partitionID ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
 		]


### PR DESCRIPTION
The proposal filed in Issue 160 changed the type of partitionID to be a
string instead of an integer.  Unfortunately, one update point was
missed.

(Patch v2: I did not realize that rdf-toolkit also has a "Hidden"
Restriction sort key, by onDataRange before onProperty.  Branch name was
also of incorrect form.)

References:
* [Issue 160] Change Proposal: Revise range and documentation of
  partitionID
* [OC-120] (CP-46) DiskPartitionFacet accidentally has partitionID range
  as xsd:integer

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>