### PR TITLE
Change NTFSFileSystemFacet to NTFSFileFacet

### DIFF
--- a/uco-observable/observable-da.ttl
+++ b/uco-observable/observable-da.ttl
@@ -133,7 +133,7 @@ observable:allocationStatus
 	.
 
 observable:alternateDataStreams
-	rdfs:domain observable:NTFSFileSystemFacet ;
+	rdfs:domain observable:NTFSFileFacet ;
 	.
 
 observable:application
@@ -596,7 +596,7 @@ observable:entropy
 	.
 
 observable:entryID
-	rdfs:domain observable:NTFSFileSystemFacet ;
+	rdfs:domain observable:NTFSFileFacet ;
 	.
 
 observable:environmentVariables
@@ -1653,7 +1653,7 @@ observable:showMessageTitle
 	.
 
 observable:sid
-	rdfs:domain observable:NTFSFileSystemFacet ;
+	rdfs:domain observable:NTFSFileFacet ;
 	.
 
 observable:signature

--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -3039,14 +3039,7 @@ observable:NTFSFile
 	rdfs:comment "An NTFS file is a New Technology File System (NTFS) file."@en ;
 	.
 
-observable:NTFSFilePermissionsFacet
-	a owl:Class ;
-	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
-	rdfs:label "NTFSFilePermissionsFacet"@en ;
-	rdfs:comment "An NTFS file permissions facet is a grouping of characteristics unique to the access rights (e.g., view, change, navigate, execute) of a file on an NTFS (new technology filesystem) file system."@en ;
-	.
-
-observable:NTFSFileSystemFacet
+observable:NTFSFileFacet
 	a owl:Class ;
 	rdfs:subClassOf
 		<https://unifiedcyberontology.org/ontology/uco/core#Facet> ,
@@ -3063,8 +3056,15 @@ observable:NTFSFileSystemFacet
 			owl:onDataRange xsd:string ;
 		]
 		;
-	rdfs:label "NTFSFileSystemFacet"@en ;
-	rdfs:comment "An NTFS file system facet is a grouping of characteristics unique to a file on an NTFS (new technology filesystem) file system."@en ;
+	rdfs:label "NTFSFileFacet"@en ;
+	rdfs:comment "An NTFS file facet is a grouping of characteristics unique to a file on an NTFS (new technology filesystem) file system."@en ;
+	.
+
+observable:NTFSFilePermissionsFacet
+	a owl:Class ;
+	rdfs:subClassOf <https://unifiedcyberontology.org/ontology/uco/core#Facet> ;
+	rdfs:label "NTFSFilePermissionsFacet"@en ;
+	rdfs:comment "An NTFS file permissions facet is a grouping of characteristics unique to the access rights (e.g., view, change, navigate, execute) of a file on an NTFS (new technology filesystem) file system."@en ;
 	.
 
 observable:NamedPipe


### PR DESCRIPTION
References:
* [OC-99] (CP-38) NTFSFileSystemFacet describes an NTFS file, not file
  system

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>