### PR TITLE
Perform Make directory traversal in sort order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 SHELL := /bin/bash
 
-turtle_directories := $(wildcard uco-*)
+turtle_directories := $(shell find uco-* -type d -maxdepth 0 | sort)
 
 all_directories := $(foreach turtle_directory,$(turtle_directories),all-$(turtle_directory))
 

--- a/src/review.mk
+++ b/src/review.mk
@@ -25,7 +25,7 @@ srcdir_without_ucohyphen := $(subst uco-,,$(shell basename "$(srcdir)"))
 ifeq ($(srcdir_without_ucohyphen),master)
 ttl_basenames := uco.ttl
 else
-ttl_basenames := $(wildcard $(srcdir_without_ucohyphen)*.ttl)
+ttl_basenames := $(shell find $(srcdir_without_ucohyphen)*.ttl -type f | sort)
 endif
 
 # These are reference files, named with a leading dot.


### PR DESCRIPTION
This patch is a revision to the implementation of CP-39, to guarantee
the visit order of subdirectories.

While undergoing an in-depth normalization review of each Turtle file
today, I and a person I was working with realized that the visit order
of subdirectories was non-deterministic between Make runs.  On the scale
of nuisances, this is minor, as it causes some confusion on when a
per-file review will be completed, but does not cause any true review
errors because UCO's subdirectories are all independently reviewable.
(The non-determinimism was not apparent in my reviews for the initial
patch because my testing tended to run with full parallelism from
'make -j'.)

Aside from directory and file visit order, no semantic or behavioral
changes are made in this patch.

References:
* [OC-98] (CP-39) UCO should implement CI including at least rdf-toolkit
  runs

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>