### PR TITLE
Continuation of CP-16.

### DIFF
--- a/uco-observable/observable-da.ttl
+++ b/uco-observable/observable-da.ttl
@@ -1504,15 +1504,15 @@ observable:referralURL
 	rdfs:domain observable:WhoisRegistrarInfoType ;
 	.
 
+observable:regionEndAddress
+	rdfs:domain observable:MemoryFacet ;
+	.
+
 observable:regionSize
 	rdfs:domain observable:MemoryFacet ;
 	.
 
 observable:regionStartAddress
-	rdfs:domain observable:MemoryFacet ;
-	.
-
-observable:region_end_address
 	rdfs:domain observable:MemoryFacet ;
 	.
 


### PR DESCRIPTION
Fixed naming convention of observable:region_end_address within observable-da.ttl. This is in continuation of implementing changes for CP-16.

Acked-by: Trevor Bobka <tbobka@mitre.org>