### PR TITLE
Correct casing of picturetype to pictureType

### DIFF
--- a/uco-observable/observable-da.ttl
+++ b/uco-observable/observable-da.ttl
@@ -1408,11 +1408,11 @@ observable:pictureHeight
 	rdfs:domain observable:RasterPictureFacet ;
 	.
 
-observable:pictureWidth
+observable:pictureType
 	rdfs:domain observable:RasterPictureFacet ;
 	.
 
-observable:picturetype
+observable:pictureWidth
 	rdfs:domain observable:RasterPictureFacet ;
 	.
 


### PR DESCRIPTION
This is a continuation of Github Issue 143, originally thought resolved
for UCO 0.4.0.  The casing correction was not applied in the domain
assertions file, which could impact the SHACL conversion of UCO.

This patch has no attached Change Proposal because of its prior approval
under Issue 143.

This was discovered through inspection of UCO with the tool, "ROBOT".

References:
* [Issue 143] Casing correction - "picturetype"
  https://github.com/ucoProject/UCO/issues/143
* [OC-68] (CP-23) Convert current property restrictions and domain
  assertions to SHACL class shapes
* [ROBOT] R.C. Jackson, J.P. Balhoff, E. Douglass, N.L. Harris, C.J.
  Mungall, and J.A. Overton. ROBOT: A tool for automating ontology
  workflows. BMC Bioinformatics, vol. 20, July 2019.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>