### PR TITLE
Carry rename of contactInfo to registrantContactInfo to observable-da…

### DIFF
--- a/uco-observable/observable-da.ttl
+++ b/uco-observable/observable-da.ttl
@@ -344,10 +344,6 @@ observable:computerName
 	rdfs:domain observable:EventFacet ;
 	.
 
-observable:contactInfo
-	rdfs:domain observable:WhoIsFacet ;
-	.
-
 observable:contentDisposition
 	rdfs:domain observable:EmailMessageFacet ;
 	.
@@ -1526,6 +1522,10 @@ observable:registeredOrganization
 
 observable:registeredOwner
 	rdfs:domain observable:WindowsComputerSpecificationFacet ;
+	.
+
+observable:registrantContactInfo
+	rdfs:domain observable:WhoIsFacet ;
 	.
 
 observable:registrantIDs


### PR DESCRIPTION
….ttl

This is a continuation of Change Proposal 5, originally thought resolved
for UCO 0.6.0.  A property rename was not applied in the domain
assertions file, which could impact the SHACL conversion of UCO.

This patch has no new attached Change Proposal because of its prior
approval under Change Proposal 5.

This was discovered through inspection of UCO with the tool, "ROBOT".

References:
* [OC-24] (CP-5) Refactor and improve contacts
* [OC-68] (CP-23) Convert current property restrictions and domain
  assertions to SHACL class shapes
* [ROBOT] R.C. Jackson, J.P. Balhoff, E. Douglass, N.L. Harris, C.J.
  Mungall, and J.A. Overton. ROBOT: A tool for automating ontology
  workflows. BMC Bioinformatics, vol. 20, July 2019.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>