### PR TITLE
Implemented CP-75

### DIFF
--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -7160,10 +7160,7 @@ observable:WindowsPESection
 			sh:path observable:hashes ;
 		] ,
 		[
-			sh:datatype
-				xsd:double ,
-				xsd:float
-				;
+			sh:datatype xsd:double ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:entropy ;


### PR DESCRIPTION
Removed 'xsd:float' from the property restriction of observable:entropy on
the observable:WindowsPESection class.

Acked-by: Trevor Bobka <tbobka@mitre.org>