### PR TITLE
Implemented CP-74

### DIFF
--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -7720,18 +7720,15 @@ observable:WindowsTaskFacet
 			sh:path observable:taskCreator ;
 		] ,
 		[
-			sh:datatype
-				xsd:string ,
-				vocabulary:TaskPriorityVocab
-				;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:priority ;
-		] ,
-		[
 			sh:datatype vocabulary:TaskFlagVocab ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:flags ;
+		] ,
+		[
+			sh:datatype vocabulary:TaskPriorityVocab ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:priority ;
 		] ,
 		[
 			sh:datatype
@@ -7783,10 +7780,7 @@ observable:WindowsThreadFacet
 			sh:path observable:startAddress ;
 		] ,
 		[
-			sh:datatype
-				xsd:integer ,
-				xsd:string
-				;
+			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:priority ;
@@ -10803,7 +10797,11 @@ observable:priority
 	a owl:DatatypeProperty ;
 	rdfs:label "priority"@en ;
 	rdfs:comment "The priority of the email."@en ;
-	rdfs:range xsd:string ;
+	rdfs:range
+		xsd:integer ,
+		xsd:string ,
+		vocabulary:TaskPriorityVocab
+		;
 	.
 
 observable:privateKeyUsagePeriodNotAfter


### PR DESCRIPTION
Extended the range of observable:priority to be an owl:unoinOf xsd:integer,
xsd:string, and vocabulary:TaskPriorityVocab. Also, removed xsd:string from
being a property restriction for observable:priority within
observable:WindowsTaskFacet and observable:WindowsThreadFacet.

Acked-By: Trevor Bobka <tbobka@mitre.org>