### PR TITLE
Implemented CP-77

### DIFF
--- a/uco-types/types.ttl
+++ b/uco-types/types.ttl
@@ -149,10 +149,13 @@ types:entry
 	a owl:ObjectProperty ;
 	rdfs:label "entry"@en ;
 	rdfs:comment "A dictionary entry."@en ;
-	rdfs:range
-		types:ControlledDictionaryEntry ,
-		types:DictionaryEntry
-		;
+	rdfs:range [
+		a rdfs:Datatype ;
+		owl:unionOf (
+			types:ControlledDictionaryEntry
+			types:DictionaryEntry
+		) ;
+	] ;
 	.
 
 types:hashMethod

--- a/uco-types/types.ttl
+++ b/uco-types/types.ttl
@@ -28,10 +28,7 @@ types:ControlledDictionary
 	rdfs:label "ControlledDictionary"@en ;
 	rdfs:comment "A controlled dictionary is a list of (term/key, value) pairs where each term/key exists no more than once and is constrained to an explicitly defined set of values."@en ;
 	sh:property [
-		sh:class
-			types:ControlledDictionaryEntry ,
-			types:DictionaryEntry
-			;
+		sh:class types:ControlledDictionaryEntry ;
 		sh:minCount "1"^^xsd:integer ;
 		sh:nodeKind sh:BlankNodeOrIRI ;
 		sh:path types:entry ;
@@ -152,7 +149,10 @@ types:entry
 	a owl:ObjectProperty ;
 	rdfs:label "entry"@en ;
 	rdfs:comment "A dictionary entry."@en ;
-	rdfs:range types:DictionaryEntry ;
+	rdfs:range
+		types:ControlledDictionaryEntry ,
+		types:DictionaryEntry
+		;
 	.
 
 types:hashMethod


### PR DESCRIPTION
Extended the range of types:entry to include types:DictionaryEntry and
types:ControlledDictionaryEntry. Also, removed types:DictionaryEntry from the
property restriction for types:entry within the types:ControlledDictionary
class.

Acked-by: Trevor Bobka <tbobka@mitre.org>