### PR TITLE
Implemented CP-78

### DIFF
--- a/uco-observable/observable.ttl
+++ b/uco-observable/observable.ttl
@@ -5799,6 +5799,12 @@ observable:TwitterProfileFacet
 			sh:path observable:profileIsVerified ;
 		] ,
 		[
+			sh:datatype xsd:integer ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:listedCount ;
+		] ,
+		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
@@ -5840,10 +5846,6 @@ observable:TwitterProfileFacet
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:userLocationString ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:path observable:listedCount ;
 		]
 		;
 	sh:targetClass observable:TwitterProfileFacet ;
@@ -10064,6 +10066,13 @@ observable:libraryType
 	rdfs:label "libraryType"@en ;
 	rdfs:comment "Specifies the type of library being characterized."@en ;
 	rdfs:range xsd:string ;
+	.
+
+observable:listedCount
+	a owl:DatatypeProperty ;
+	rdfs:label "listedCount"@en ;
+	rdfs:comment "Specifies the number of public lists that this profile is associated with."@en ;
+	rdfs:range xsd:integer ;
 	.
 
 observable:loaderFlags


### PR DESCRIPTION
Added the observable:listedCount property that was excluded in the
implementation of CP-7. Also, ensured the proper SHACL constraints were added
for the its property restriction within observable:TwitterProfileFacet.

Acked-by: Trevor Bobka <tbobka@mitre.org>