### PR TITLE
Added 'Attachment_Of' vocabulary term

### DIFF
--- a/uco-vocabulary/vocabulary.ttl
+++ b/uco-vocabulary/vocabulary.ttl
@@ -609,6 +609,7 @@ vocabulary:ObservableObjectRelationshipVocab
 	owl:oneOf (
 		"Allocated"^^vocabulary:ObservableObjectRelationshipVocab
 		"Allocated_By"^^vocabulary:ObservableObjectRelationshipVocab
+		"Attachment_Of"^^vocabulary:ObservableObjectRelationshipVocab
 		"Bound"^^vocabulary:ObservableObjectRelationshipVocab
 		"Bound_By"^^vocabulary:ObservableObjectRelationshipVocab
 		"Characterized_By"^^vocabulary:ObservableObjectRelationshipVocab


### PR DESCRIPTION
Added 'Attachment_Of' as an additional string for
vocabulary:ObservableObjectRelationshipVocab.

Acked-by: TJ Balon (balon@tjbalon.io)