### PR TITLE
Fix WhoisContactTypeVocab prefix

### DIFF
--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -6502,7 +6502,7 @@ observable:WhoisContactFacet
 	rdfs:label "WhoIsContactFacet"@en ;
 	rdfs:comment "A Whois contact type is a grouping of characteristics unique to contact-related information present in a response record conformant to the WHOIS protocol standard (RFC 3912). [based on https://en.wikipedia.org/wiki/WHOIS]"@en ;
 	sh:property [
-		sh:datatype observable:WhoisContactTypeVocab ;
+		sh:datatype vocabulary:WhoisContactTypeVocab ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
 		sh:path observable:whoisContactType ;


### PR DESCRIPTION
References:
* [OC-187] (CP-84) vocabulary:WhoisContactTypeVocab is currently typo'd as observable:WhoisContactFacet in observable.ttl

Signed-off-by: TJ Balon <tbalon@mitre.org>