### PR TITLE
CP 88 Storage Device Capacity

### DIFF
--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -1610,6 +1610,12 @@ observable:DeviceFacet
 	rdfs:comment "A device facet is a grouping of characteristics unique to a piece of equipment or a mechanism designed to serve a special purpose or perform a special function. [based on https://www.merriam-webster.com/dictionary/device]"@en ;
 	sh:property
 		[
+			sh:datatype xsd:integer ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:storageCapacityInBytes ;
+		] ,
+		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -5150,7 +5150,7 @@ observable:SIMCardFacet
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:DeviceFacet ;
+	rdfs:subClassOf observable:DeviceFacet ;
 	rdfs:label "SIMCardFacet"@en ;
 	rdfs:comment "A SIM card facet is a grouping of characteristics unique to a subscriber identification module card intended to securely store the international mobile subscriber identity (IMSI) number and its related key, which are used to identify and authenticate subscribers on mobile telephony devices (such as mobile phones and computers). [based on https://en.wikipedia.org/wiki/SIM_card]"@en ;
 	sh:property

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -1744,20 +1744,17 @@ observable:DeviceFacet
 	rdfs:comment "A device facet is a grouping of characteristics unique to a piece of equipment or a mechanism designed to serve a special purpose or perform a special function. [based on https://www.merriam-webster.com/dictionary/device]"@en ;
 	sh:property
 		[
-<<<<<<< HEAD
+			sh:class identity:Identity ;
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:manufacturer ;
+		] ,
+		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:storageCapacityInBytes ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-=======
-			sh:class identity:Identity ;
->>>>>>> bfb4c57399b555b83bec736d7e73de27cfcd8ba8
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path observable:manufacturer ;
 		] ,
 		[
 			sh:datatype xsd:string ;
@@ -3872,7 +3869,7 @@ observable:MobileDeviceFacet
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DeviceFacet ;
+	rdfs:subClassOf core:Facet ;
 	rdfs:label "MobileDeviceFacet"@en ;
 	rdfs:comment "A mobile device facet is a grouping of characteristics unique to a portable computing device. [based on https://www.lexico.com/definition/mobile_device]"@en ;
 	sh:property
@@ -5235,7 +5232,7 @@ observable:SIMCardFacet
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DeviceFacet ;
+	rdfs:subClassOf core:Facet ;
 	rdfs:label "SIMCardFacet"@en ;
 	rdfs:comment "A SIM card facet is a grouping of characteristics unique to a subscriber identification module card intended to securely store the international mobile subscriber identity (IMSI) number and its related key, which are used to identify and authenticate subscribers on mobile telephony devices (such as mobile phones and computers). [based on https://en.wikipedia.org/wiki/SIM_card]"@en ;
 	sh:property

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -3730,7 +3730,7 @@ observable:MobileDeviceFacet
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf observable:DeviceFacet ;
 	rdfs:label "MobileDeviceFacet"@en ;
 	rdfs:comment "A mobile device facet is a grouping of characteristics unique to a portable computing device. [based on https://www.lexico.com/definition/mobile_device]"@en ;
 	sh:property
@@ -3751,12 +3751,6 @@ observable:MobileDeviceFacet
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:phoneActivationTime ;
-		] ,
-		[
-			sh:datatype xsd:integer ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:storageCapacityInBytes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
@@ -5156,7 +5150,7 @@ observable:SIMCardFacet
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf core:DeviceFacet ;
 	rdfs:label "SIMCardFacet"@en ;
 	rdfs:comment "A SIM card facet is a grouping of characteristics unique to a subscriber identification module card intended to securely store the international mobile subscriber identity (IMSI) number and its related key, which are used to identify and authenticate subscribers on mobile telephony devices (such as mobile phones and computers). [based on https://en.wikipedia.org/wiki/SIM_card]"@en ;
 	sh:property
@@ -5165,12 +5159,6 @@ observable:SIMCardFacet
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
 			sh:path observable:carrier ;
-		] ,
-		[
-			sh:datatype xsd:integer ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:storageCapacityInBytes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
@@ -11506,7 +11494,7 @@ observable:statusesCount
 observable:storageCapacityInBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "storageCapacityInBytes"@en ;
-	rdfs:comment "The number of bytes that can be stored on a SIM card."@en ;
+	rdfs:comment "The number of bytes that can be stored on a storage device or chip."@en ;
 	rdfs:range xsd:integer ;
 	.
 

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -1745,7 +1745,6 @@ observable:DeviceFacet
 	sh:property
 		[
 			sh:class identity:Identity ;
-			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
 			sh:path observable:manufacturer ;


### PR DESCRIPTION
- Add the `observable:storageCapacityInBytes` to the DeviceFacet
- Remove explicit property from `MobileDeviceFacet` and `SIMCardFacet`
- Change the parent class from Facet to DeviceFacet to inherit the appropriate properties
- Make the description for `observable:storageCapacityInBytes` to be more general