### PR TITLE
(CP-89) Move properties from ActionReferencesFacet to Action

### DIFF
--- a/ontology/action/action.ttl
+++ b/ontology/action/action.ttl
@@ -46,8 +46,45 @@ action:Action
 		] ,
 		[
 			sh:class core:UcoObject ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path action:environment ;
+		] ,
+		[
+			sh:class core:UcoObject ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path action:performer ;
+		] ,
+		[
+			sh:class core:UcoObject ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
 			sh:path action:error ;
+		] ,
+		[
+			sh:class core:UcoObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path action:instrument ;
+		] ,
+		[
+			sh:class core:UcoObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path action:object ;
+		] ,
+		[
+			sh:class core:UcoObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path action:participant ;
+		] ,
+		[
+			sh:class core:UcoObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path action:result ;
+		] ,
+		[
+			sh:class location:Location ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path action:location ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
@@ -244,57 +281,6 @@ action:ActionPattern
 	rdfs:label "ActionPattern"@en ;
 	rdfs:comment "An action pattern is a grouping of characteristics unique to a combination of actions forming a consistent or characteristic arrangement."@en ;
 	sh:targetClass action:ActionPattern ;
-	.
-
-action:ActionReferencesFacet
-	a
-		owl:Class ,
-		sh:NodeShape
-		;
-	rdfs:subClassOf core:Facet ;
-	rdfs:label "ActionReferencesFacet"@en ;
-	rdfs:comment """An action references facet is a grouping of characteristics unique to the core elements (who, how, with what, where, etc.) for an action. The characteristics are references to separate UCO objects detailing the particular characteristic.
-  """@en ;
-	sh:property
-		[
-			sh:class core:UcoObject ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path action:environment ;
-		] ,
-		[
-			sh:class core:UcoObject ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path action:performer ;
-		] ,
-		[
-			sh:class core:UcoObject ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path action:instrument ;
-		] ,
-		[
-			sh:class core:UcoObject ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path action:object ;
-		] ,
-		[
-			sh:class core:UcoObject ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path action:participant ;
-		] ,
-		[
-			sh:class core:UcoObject ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path action:result ;
-		] ,
-		[
-			sh:class location:Location ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path action:location ;
-		]
-		;
-	sh:targetClass action:ActionReferencesFacet ;
 	.
 
 action:ArrayOfAction

--- a/tests/examples/action_result_PASS.json
+++ b/tests/examples/action_result_PASS.json
@@ -11,35 +11,32 @@
             "@id": "kb:action-1",
             "@type": "action:Action",
             "rdfs:comment": "This node is some action that has some ObservableObjects as results.  By the ontology, the results need to be some UcoObject or subclass of UcoObject.  They are serialized here as ObservableObjects, and are redundantly assigned types of some of their superclasses.  For completeness-tracking, let the id slug's number be a binary number tracking which superclasses are present, 2^0=core:UcoObject, 2^1=core:Item, 2^2=observable:Observable.",
-            "core:hasFacet": {
-                "@type": "action:ActionReferencesFacet",
-                "action:result": [
-                    {
-                        "@id": "kb:node-0"
-                    },
-                    {
-                        "@id": "kb:node-1"
-                    },
-                    {
-                        "@id": "kb:node-2"
-                    },
-                    {
-                        "@id": "kb:node-3"
-                    },
-                    {
-                        "@id": "kb:node-4"
-                    },
-                    {
-                        "@id": "kb:node-5"
-                    },
-                    {
-                        "@id": "kb:node-6"
-                    },
-                    {
-                        "@id": "kb:node-7"
-                    }
-                ]
-            }
+            "action:result": [
+                {
+                    "@id": "kb:node-0"
+                },
+                {
+                    "@id": "kb:node-1"
+                },
+                {
+                    "@id": "kb:node-2"
+                },
+                {
+                    "@id": "kb:node-3"
+                },
+                {
+                    "@id": "kb:node-4"
+                },
+                {
+                    "@id": "kb:node-5"
+                },
+                {
+                    "@id": "kb:node-6"
+                },
+                {
+                    "@id": "kb:node-7"
+                }
+            ]
         },
         {
             "@id": "kb:node-0",


### PR DESCRIPTION
This PR removes action:ActionReferencesFacet and moves the
properties of this class into action:Action.

In addition, the second commit addresses the issues with CI passing
upon completion of this change. @ajnelson-nist will need to confirm
that this is a proper method to address this.

References:
[*] [OC-62] (CP-89) Remove ActionReferenceFacet and move properties
into action:Action