### PR TITLE
Fix typo in instructions

### DIFF
--- a/src/review.mk
+++ b/src/review.mk
@@ -49,7 +49,7 @@ check-%.ttl: \
   %.ttl \
   .check-%.ttl
 	diff $^	\
-	  || (echo "ERROR:src/review.mk:The local $< does not match the normalized version. If the above reported changes look fine, run 'cp $@ $<' while in the sub-folder ontology/$$(basename $< .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
+	  || (echo "ERROR:src/review.mk:The local $< does not match the normalized version. If the above reported changes look fine, run 'cp .check-$< $<' while in the sub-folder ontology/$$(basename $< .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
 
 clean:
 	@rm -f $(check_reference_basenames)


### PR DESCRIPTION
This is a follow-on patch to FastTrack-CP-56, which was already merged as part of the UCO 0.8.0 release.  A minor typo is being corrected, not necessitating any revisions to the proposal or website documentation, and hence not requiring any committee action.