### PR TITLE
OC-210 Remove Application Lower Cardinality

### DIFF
--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -821,7 +821,6 @@ observable:CallFacet
 		[
 			sh:class observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
 			sh:path observable:application ;
 		] ,

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -4720,6 +4720,11 @@ observable:PhoneCallFacet
 			sh:path observable:to ;
 		] ,
 		[
+			sh:class observable:ObservableObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:participant ;
+		] ,
+		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -4715,14 +4715,8 @@ observable:PhoneCallFacet
 		] ,
 		[
 			sh:class observable:ObservableObject ;
-			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
 			sh:path observable:to ;
-		] ,
-		[
-			sh:class observable:ObservableObject ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path observable:participant ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -798,6 +798,77 @@ observable:CalendarFacet
 	sh:targetClass observable:CalendarFacet ;
 	.
 
+observable:Call
+	a
+		owl:Class ,
+		sh:NodeShape
+		;
+	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:label "Call"@en ;
+	rdfs:comment "A call facet is a connection as part of a realtime cyber communication between one or more parties."@en ;
+	sh:targetClass observable:Call ;
+	.
+
+observable:CallFacet
+	a
+		owl:Class ,
+		sh:NodeShape
+		;
+	rdfs:subClassOf core:Facet ;
+	rdfs:label "CallFacet"@en ;
+	rdfs:comment "A call facet is a grouping of characteristics unique to a connection as part of a realtime cyber communication between one or more parties."@en ;
+	sh:property
+		[
+			sh:class observable:ObservableObject ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:minCount "1"^^xsd:integer ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:application ;
+		] ,
+		[
+			sh:class observable:ObservableObject ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:from ;
+		] ,
+		[
+			sh:class observable:ObservableObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:participant ;
+		] ,
+		[
+			sh:class observable:ObservableObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:to ;
+		] ,
+		[
+			sh:datatype xsd:dateTime ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:endTime ;
+		] ,
+		[
+			sh:datatype xsd:dateTime ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:startTime ;
+		] ,
+		[
+			sh:datatype xsd:integer ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:duration ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:callType ;
+		]
+		;
+	sh:targetClass observable:CallFacet ;
+	.
+
 observable:CharacterDeviceNode
 	a
 		owl:Class ,
@@ -4678,72 +4749,6 @@ observable:PhoneAccountFacet
 		sh:path observable:phoneNumber ;
 	] ;
 	sh:targetClass observable:PhoneAccountFacet ;
-	.
-
-observable:PhoneCall
-	a
-		owl:Class ,
-		sh:NodeShape
-		;
-	rdfs:subClassOf observable:ObservableObject ;
-	rdfs:label "PhoneCall"@en ;
-	rdfs:comment "A phone call is a connection over a telephone network between the called party and the calling party. [based on https://en.wikipedia.org/wiki/Telephone_call]"@en ;
-	sh:targetClass observable:PhoneCall ;
-	.
-
-observable:PhoneCallFacet
-	a
-		owl:Class ,
-		sh:NodeShape
-		;
-	rdfs:subClassOf core:Facet ;
-	rdfs:label "PhoneCallFacet"@en ;
-	rdfs:comment "A phone call facet is a grouping of characteristics unique to a connection over a telephone network between the called party and the calling party. [based on https://en.wikipedia.org/wiki/Telephone_call]"@en ;
-	sh:property
-		[
-			sh:class observable:ObservableObject ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path observable:application ;
-		] ,
-		[
-			sh:class observable:ObservableObject ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path observable:from ;
-		] ,
-		[
-			sh:class observable:ObservableObject ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path observable:to ;
-		] ,
-		[
-			sh:datatype xsd:dateTime ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:endTime ;
-		] ,
-		[
-			sh:datatype xsd:dateTime ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:startTime ;
-		] ,
-		[
-			sh:datatype xsd:integer ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:duration ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:callType ;
-		]
-		;
-	sh:targetClass observable:PhoneCallFacet ;
 	.
 
 observable:Pipe

--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -805,7 +805,7 @@ observable:Call
 		;
 	rdfs:subClassOf observable:ObservableObject ;
 	rdfs:label "Call"@en ;
-	rdfs:comment "A call facet is a connection as part of a realtime cyber communication between one or more parties."@en ;
+	rdfs:comment "A call is a connection as part of a realtime cyber communication between one or more parties."@en ;
 	sh:targetClass observable:Call ;
 	.
 


### PR DESCRIPTION
**Background**
The `uco-observable:CallFacet` has a property `uco-observable:application` that has a cardinality of `1 <-> 1` which is causing issues for an adopting implementation. 

**Proposed Change**
Remove the lower bound to change the cardinality of the `uco-observable:application`  property from `1 <-> 1` to `0 <-> 1` in the `uco-observable:CallFacet`.

**Use Cases**
The use case we're seeing is that some forensic tools find the record of the phone call, but not an associated application and in the interim, we need to make a "dummy" application.

Additional use cases for removing the lower cardinality restriction include devices such as feature phones that don't have a separately defined application (such as Samsung's `com.samsung.android.dialer`).