### PR TITLE
Allow unbounded cardinality on mimeType

### DIFF
--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -1490,7 +1490,6 @@ observable:ContentDataFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:mimeType ;
 		] ,


### PR DESCRIPTION
References:
* [OC-116] (CP-104) observable:mimeType should have unbounded
  cardinality to support polyglots

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>