### PR TITLE
OC-212 Remove NoteFacet:application Cardinality

### DIFF
--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -4402,7 +4402,6 @@ observable:NoteFacet
 		[
 			sh:class observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
 			sh:path observable:application ;
 		] ,


### PR DESCRIPTION
**Background**
The `uco-observable:NoteFacet` has a property `uco-observable:application` that has a cardinality of `1 <-> 1` which is causing issues for an adopting implementation. 

**Proposed Change**
Remove the lower bound to change the cardinality of the `uco-observable:application`  property from `1 <> 1` to `0 <> 1` in the `uco-observable:NoteFacet`.

**Use Cases**
The use case we're seeing is that some forensic tools find the record of the notes, but not an associated application and in the interim, we need to make a "dummy" application.