### PR TITLE
OC-213 Expand Wireless Network Connection Properties

### DIFF
--- a/ontology/observable/observable.ttl
+++ b/ontology/observable/observable.ttl
@@ -7844,6 +7844,18 @@ observable:WirelessNetworkConnectionFacet
 	rdfs:comment "A wireless network connection facet is a grouping of characteristics unique to a connection (completed or attempted) across an IEEE 802.11 standards-conformant digital network (a group of two or more computer systems linked together). [based on https://www.webopedia.com/TERM/N/network.html]"@en ;
 	sh:property
 		[
+			sh:datatype xsd:dateTime ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:endTime ;
+		] ,
+		[
+			sh:datatype xsd:dateTime ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:startTime ;
+		] ,
+		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
@@ -7853,7 +7865,19 @@ observable:WirelessNetworkConnectionFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
+			sh:path observable:password ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:ssid ;
+		] ,
+		[
+			sh:datatype vocabulary:WirelessNetworkSecurityModeVocab ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:wirelessNetworkSecurityMode ;
 		]
 		;
 	sh:targetClass observable:WirelessNetworkConnectionFacet ;
@@ -11969,6 +11993,13 @@ observable:windowsVolumeAttributes
 	rdfs:label "windowsVolumeAttributes"@en ;
 	rdfs:comment "Specifies the attributes of a windows volume."@en ;
 	rdfs:range vocabulary:WindowsVolumeAttributeVocab ;
+	.
+
+observable:wirelessNetworkSecurityMode
+	a owl:DatatypeProperty ;
+	rdfs:label "wirelessNetworkSecurityMode"@en ;
+	rdfs:comment "Specifies the security mode of a wireless network (None, WEP, WPA, etc)."@en ;
+	rdfs:range vocabulary:WirelessNetworkSecurityModeVocab ;
 	.
 
 observable:workItemData

--- a/ontology/vocabulary/vocabulary.ttl
+++ b/ontology/vocabulary/vocabulary.ttl
@@ -1148,3 +1148,19 @@ vocabulary:WindowsVolumeAttributeVocab
 	) ;
 	.
 
+vocabulary:WirelessNetworkSecurityModeVocab
+	a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:label "Wirelss Network Security Mode Vocabulary"@en-US ;
+	rdfs:comment "Defines an open-vocabulary of security modes that may be configured for wireless network connections."@en ;
+	owl:oneOf (
+		"None"^^vocabulary:WirelessNetworkSecurityModeVocab
+		"WEP"^^vocabulary:WirelessNetworkSecurityModeVocab
+		"WPA"^^vocabulary:WirelessNetworkSecurityModeVocab
+		"WPA2-PSK"^^vocabulary:WirelessNetworkSecurityModeVocab
+		"WPA2-Enterprise"^^vocabulary:WirelessNetworkSecurityModeVocab
+		"WPA3-PSK"^^vocabulary:WirelessNetworkSecurityModeVocab
+		"WPA3-Enterprise"^^vocabulary:WirelessNetworkSecurityModeVocab
+	) ;
+	.
+


### PR DESCRIPTION
**Background**
The `uco-observable:WirelessNetworkConnectionFacet` does not include several fields that are exported by forensic tools that have value for analysis.

**Request**
Add a new Vocab for `uco-vocabulary:WirelessNetworkSecurityModeVocab` with the following values:
- None
- WEP
- WPA
- WPA2-PSK
- WPA2-Enterprise
- WPA3-PSK
- WPA3-Enterprise

Add the following properties to the `uco-observable:WirelessNetworkConnectionFacet`:
- uco-observable:password
- uco-observable:startTime
- uco-observable:endTime
- wirelessNetworkSecurityMode which is of the type `uco-vocabulary:WirelessNetworkSecurityModeVocab`

_The vocabulary concept is in flux, but has not yet been replaced by a new concept, so this CP accounts for the current state_

**Use Cases**
- Identifying the probability of a man in the middle attack based on the quality of the network security mode for the connection.
- Identifying passwords that may have been reused in other locations (particularly for enterprise mode security) or if it was a local/home configured network connection
- Determine the time and duration of the connection to the wireless network which can provide a rough location, as well as a method of action for an investigated activity

