### PR TITLE
added Protege (Stanford RDF IDE desktop)

### DIFF
--- a/LoadUCO.ttl
+++ b/LoadUCO.ttl
@@ -1,0 +1,33 @@
+
+@base <https://ontology.unifiedcyberontology.org/ontology/LoadUCO> .
+@prefix : <https://unifiedcyberontology.org/ontology/uco/uco#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix uco: <https://unifiedcyberontology.org/ontology/uco/uco#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://ontology.unifiedcyberontology.org/ontology/LoadUCO>
+	a owl:Ontology ;
+	rdfs:label "uco-master"@en ;
+	owl:imports
+		<https://ontology.unifiedcyberontology.org/uco/action> ,
+		<https://ontology.unifiedcyberontology.org/uco/core> ,
+		<https://ontology.unifiedcyberontology.org/uco/identity> ,
+		<https://ontology.unifiedcyberontology.org/uco/location> ,
+		<https://ontology.unifiedcyberontology.org/uco/marking> ,
+		<https://ontology.unifiedcyberontology.org/uco/observable> ,
+		<https://ontology.unifiedcyberontology.org/uco/pattern> ,
+		<https://ontology.unifiedcyberontology.org/uco/role> ,
+		<https://ontology.unifiedcyberontology.org/uco/time> ,
+		<https://ontology.unifiedcyberontology.org/uco/tool> ,
+		<https://ontology.unifiedcyberontology.org/uco/types> ,
+		<https://ontology.unifiedcyberontology.org/uco/victim> ,
+		<https://ontology.unifiedcyberontology.org/uco/vocabulary>
+		;
+	owl:versionInfo "0.9.0" ;
+	.
+
+

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Automatically built by the UCO infrastructure -->
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" uri="./ontology/action/action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/identity/identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/marking/marking.ttl" name="https://ontology.unifiedcyberontology.org/uco/marking"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/observable/observable.ttl" name="https://ontology.unifiedcyberontology.org/uco/observable"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/role/role.ttl" name="https://ontology.unifiedcyberontology.org/uco/role"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/time/time.ttl" name="https://ontology.unifiedcyberontology.org/uco/time"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/tool/tool.ttl" name="https://ontology.unifiedcyberontology.org/uco/tool"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/victim/victim.ttl" name="https://ontology.unifiedcyberontology.org/uco/victim"/>
+    <uri id="User Entered Import Resolution" uri="./ontology/vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary"/>
+
+</catalog>
+

--- a/create-catalog-v001.xml.sh
+++ b/create-catalog-v001.xml.sh
@@ -1,0 +1,104 @@
+#!/bin/bash -x
+
+CATLOG_PRE_XML="<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>
+<!-- Automatically built by the UCO infrastructure -->
+<catalog prefer=\"public\" xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">"
+
+CATLOG_POST_XML="
+</catalog>
+"
+CATALOG_FILE="catalog-v001.xml"
+
+# <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+#<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+#    <group id=\"Folder Repository, directory=, recursive=true, Auto-Update=true, version=2\" prefer=\"public\" xml:base=\"\">
+#        <uri id=\"Automatically generated entry\" name=\"https://unifiedcyberontology.org/ontology/uco/uco\" uri=\"./uco.ttl\"/>
+#    </group>
+#</catalog>
+
+
+UCO_ONTOLOGY_PREFIX="https://ontology.unifiedcyberontology.org/uco"
+
+echo -e "${CATLOG_PRE_XML=}" | tee ${CATALOG_FILE}
+TTL_FILES=$(find . |grep -v  git | grep -v master | grep -v "LoadUCO"| grep -v 'test' | grep ttl | sort)
+for ttl in ${TTL_FILES}; do
+    # <uri id="User Entered Import Resolution" uri="./ont-policy.rdf" name="https://spec.edmcouncil.org/fibo/./ont-policy/"/>
+    #ENTRY="<uri id=\"Automatically generated entry\" name=\"https://unifiedcyberontology.org/ontology/uco/uco\" uri=\"./.ttl\"/>"
+    #ENTRY="<uri id=\"User Entered Import Resolution\" uri=\"./ont-policy.rdf\" name=\"https://spec.edmcouncil.org/fibo/./ont-policy/\"/>
+    # <https://unifiedcyberontology.org/ontology/uco/types-da>
+    ENTRY_L="    <uri id=\"User Entered Import Resolution\" uri=\""
+    URI="${ttl}"
+    ENTRY_M="\" name=\""
+    TTL_NAME=$(basename $ttl)
+    #ONTOLOGY_NAME="https://ontology.unifiedcyberontology.org/uco/${TTL_NAME%.*}"
+    ONTOLOGY_NAME="${UCO_ONTOLOGY_PREFIX}/${TTL_NAME%.*}"
+    ENTRY_R="\"/>"
+    ENTRY="${ENTRY_L}${URI}${ENTRY_M}${ONTOLOGY_NAME}${ENTRY_R}"
+    echo -e "${ENTRY}" | tee -a ${CATALOG_FILE}
+    echo "ttl=$ttl"
+done
+echo -e "${CATLOG_POST_XML}" | tee -a ${CATALOG_FILE}
+
+
+LoadUCO_ttl_prefix='
+@base <https://ontology.unifiedcyberontology.org/ontology/LoadUCO> .
+@prefix : <https://unifiedcyberontology.org/ontology/uco/uco#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix uco: <https://unifiedcyberontology.org/ontology/uco/uco#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://ontology.unifiedcyberontology.org/ontology/LoadUCO>
+	a owl:Ontology ;
+	rdfs:label "uco-master"@en ;
+	owl:imports
+'
+		
+LOADUCO_ttl_postfix="
+		;
+	owl:versionInfo \"{{UCO_VERSION}}\" ;
+	.
+"
+
+
+IRI_LIST_1=`cd ontology && ack "imports: https" | grep "#" |awk -F'[ ]' '{print $3}' | sort -u|sed 's/^/</g' | sed 's/$/>/g' `
+IRI_LIST=${IRI_LIST_1:-IRI_LIST}
+echo -e ">>> IRI_LIST:\n${IRI_LIST}"
+
+LoadUCO_iri_list=""
+for iri in ${IRI_LIST}; do
+    if [ "${LoadUCO_iri_list}" != "" ]; then
+        LoadUCO_iri_list=${LoadUCO_iri_list}" ,\n		${iri}"
+    else
+        LoadUCO_iri_list="		${iri}"
+    fi
+done
+
+
+
+UCO_VERSION=0.9.0
+function find_UCO_version() {
+    filepath=`curl -s https://github.com/ucoProject/UCO/releases/ | grep "/tags/" | head -1|cut -d'"' -f2 `
+    echo ">>> UCO releases: $filepath"
+    filename=$(basename $filepath)
+    UCO_VERSION=${filename%.*}
+}
+find_UCO_version
+
+LOADUCO_ttl_postfix="
+		;
+	owl:versionInfo \"${UCO_VERSION}\" ;
+	.
+"
+echo -e ">>> LOADUCO_ttl_postfix: ${LOADUCO_ttl_postfix}"
+
+LoadUCO="${LoadUCO_ttl_prefix}${LoadUCO_iri_list}${LOADUCO_ttl_postfix}\n"
+LoadUCO_FILE="LoadUCO.ttl"
+echo -e "${LoadUCO}" | tee ${LoadUCO_FILE}
+
+cat ${LoadUCO_FILE}
+
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,2858 @@
+
+
+
+
+
+
+
+<!DOCTYPE html>
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark" data-a11y-animated-images="system" id="top">
+  <head>
+    <meta charset="utf-8">
+  <link rel="dns-prefetch" href="https://github.githubassets.com">
+  <link rel="dns-prefetch" href="https://avatars.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
+  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+  <link rel="preconnect" href="https://github.githubassets.com" crossorigin>
+  <link rel="preconnect" href="https://avatars.githubusercontent.com">
+
+
+
+  <link crossorigin="anonymous" media="all" integrity="sha512-UXiu4O52iBFkqt6Kx5t+pqHYP2/LWWIw9+l5ia74TWw+xPzpH44BFfAQp7yzCe0XFGZa72Xiqyml6tox1KkUjw==" rel="stylesheet" href="https://github.githubassets.com/assets/light-5178aee0ee76.css" /><link crossorigin="anonymous" media="all" integrity="sha512-IX1PnI5wWBz8Kgb1JI0f2QFa/WuRQQHJHe0vkKinQzsxRlNb4b8NgODX5htSZVAAkA1O6Vch+RRlDTI8j96slA==" rel="stylesheet" href="https://github.githubassets.com/assets/dark-217d4f9c8e70.css" /><link data-color-theme="dark_dimmed" crossorigin="anonymous" media="all" integrity="sha512-Ct+ijw5ofrvpiRNwv+EhmU4CBCIgm7ApMfRCT8IQK4luRFZf8tLg0CC0VLyTPVLgMbQ9+74znLAZwi1RSzjpiA==" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_dimmed-0adfa28f0e68.css" /><link data-color-theme="dark_high_contrast" crossorigin="anonymous" media="all" integrity="sha512-HIV1s2ZEVz1WLyBRua8znQozNKaQ0LM5AHRX9sMlitm5TNY3QMJzKsRD5FPCF9oluzIXNO9JxRK4bBjxGhcctA==" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_high_contrast-1c8575b36644.css" /><link data-color-theme="dark_colorblind" crossorigin="anonymous" media="all" integrity="sha512-URPSviCw4m4n71IKn4qyu7MEDpGbCiTfsMTNrUjPwcg38KtEKDt12vzjlNzoy3YDFiQ8D0TCCYKCtrZpqX097g==" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_colorblind-5113d2be20b0.css" /><link data-color-theme="light_colorblind" crossorigin="anonymous" media="all" integrity="sha512-yWrddCSE7sqLZ4iqcSOoAsVnCbxs4IgN+oDKgxarp3O6V9dQ8XKyE+ffedHQa55VkB1tY0iNI3QqACG8p1k8IA==" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_colorblind-c96add742484.css" /><link data-color-theme="light_high_contrast" crossorigin="anonymous" media="all" integrity="sha512-KQ+S9ehnvP9vzfiaBA1FbrSWS1RuJBo/ez+bKUm+XKGEMR22w7Oyc712UyVcpYIqpTCTvaaJ3MfeU0x4xPeI+A==" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_high_contrast-290f92f5e867.css" /><link data-color-theme="light_tritanopia" crossorigin="anonymous" media="all" integrity="sha512-zdiPFGv3QFuv1X24wK9Sa7DM3W/It82kehdMBrepjoJJyJyBISVFUJLvMMkvr4uu8j11Rn35dXZiVrN1FNWzGA==" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_tritanopia-cdd88f146bf7.css" /><link data-color-theme="dark_tritanopia" crossorigin="anonymous" media="all" integrity="sha512-IXHqDweLGMT47BTl4v+0woPqFAAtkFBeVqg9U/AliukeUyVREIssCu32RfWmXNdMjwmdVBcS+q9SMQMYuYF5dQ==" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_tritanopia-2171ea0f078b.css" />
+  
+    <link crossorigin="anonymous" media="all" integrity="sha512-SUqyEQoqiybF4TGdLH0th4vDL9I9EFGTXfcth9CIVAoNeQJfAyfu8MtmOMWbGnqP6VxFIQ6VdDHxhdXNG1k//Q==" rel="stylesheet" href="https://github.githubassets.com/assets/primer-494ab2110a2a.css" />
+    <link crossorigin="anonymous" media="all" integrity="sha512-QYwQx1Lni/sSc2dLr2elXRPzOo9udnroJD4iebtuczyT61Ms1Gwl5mRDpWjFNCTwh+AGG7/sEOTWWC6zcpkQYQ==" rel="stylesheet" href="https://github.githubassets.com/assets/global-418c10c752e7.css" />
+    <link crossorigin="anonymous" media="all" integrity="sha512-grUkdIYCk+1YO7R2PF4y8lM1J/u5YqOiulWqSU3sDX3e+srs7rZ78EdnNVMpSe4C40CA176PTE16LWKhJqdOUQ==" rel="stylesheet" href="https://github.githubassets.com/assets/github-82b524748602.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-87JLsGYuQuQjPhG+A//vAsIKWQpNO4fD2NDSVFmLY8n7hf8CyLZzu4VPE/yPsysc+2XfrZApZLP9X+ddDUNdxw==" rel="stylesheet" href="https://github.githubassets.com/assets/releases-f3b24bb0662e.css" />
+
+
+
+  <script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-W1tq2QRq1LjSvl9vpUiy6Bopi6cl2QSNnwKnRQyHWdxgJiKMkfffvc8+ofiFhiHkKz7pIP1C6j5nYwPGjkFHYw==" src="https://github.githubassets.com/assets/runtime-5b5b6ad9046a.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-ivm676uepRn1vQvL/mShZVrbNfsUUZRp0a2RCZNYrFJYFlYhdDU2P+UC8axgVT17oqv1BVQLngSsGoiBN2MJpw==" src="https://github.githubassets.com/assets/vendors-node_modules_manuelpuyol_turbo_dist_turbo_es2017-esm_js-8af9baefab9e.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-GB4jwt8fni2MoE1wzROiGvrgScSHotjr1A9c1FQKUTsfuFn9W2y5/knx+uD8eOAC1rVSA3UPi3h+PTwAuaDZYQ==" src="https://github.githubassets.com/assets/vendors-node_modules_stacktrace-parser_dist_stack-trace-parser_esm_js-node_modules_github_bro-a4c183-181e23c2df1f.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-keoTmThrgzPwpv8M+UNzbBLwuDcHSqQe1uqiUawyU94rutETaze31jU/rTnxPyMMlIMK1p9mTBwksvDM5gyMoA==" src="https://github.githubassets.com/assets/environment-91ea1399386b.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-ZQM3kW293O7WR1cDuHZ02wendjejLzwVD0wy4L1eCNr34RHXiY05wmHUx4hnV9WELD/OEZRGrzK+M8uwiZ/WEw==" src="https://github.githubassets.com/assets/vendors-node_modules_selector-observer_dist_index_esm_js-650337916dbd.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-Si8390GeCVPslYj8WomaMCyj33Jutd8vZ+Sdi6WXLSbdZRyC4wwijhTNyLy0zpHhfYnrynP6qArdz1PXti1sOg==" src="https://github.githubassets.com/assets/vendors-node_modules_delegated-events_dist_index_js-node_modules_github_details-dialog-elemen-63debe-4a2f37f7419e.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-IW3JseO0m0yclixsxDwuXBlAp0+bXVZkAzcVRd5lkCD0Ue980eWiIMfA6uj69EXXq3KwhHWewR3/HTeR+v5G8A==" src="https://github.githubassets.com/assets/vendors-node_modules_github_filter-input-element_dist_index_js-node_modules_github_remote-inp-c7e9ed-216dc9b1e3b4.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-BAVgS5w6qbE0Sla6YGnqWmOZhz+RHhl6cmV3QpLJ6VbeBAv4YYn/gQDvEn5sq5cxUef2IB3pILcf7RbLm+H55w==" src="https://github.githubassets.com/assets/vendors-node_modules_github_catalyst_lib_index_js-node_modules_github_time-elements_dist_index_js-0405604b9c3a.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-0spbqRlGZ/7LnB7VMP6g5uqkJ2V+2QYrLwsoRQ98Vvw6NZuSEaqs+VvZ2AKpTj20Jv336D4Z9Ue6koMWnTzCXg==" src="https://github.githubassets.com/assets/vendors-node_modules_github_clipboard-copy-element_dist_index_esm_js-node_modules_github_mark-f079ea-d2ca5ba91946.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-9Mw9ohaZlSejC27fHCAsqzws1kjuim5Giv/Gd+unnaYq4NCWomNaUtXJxGNuczrwqQVQaxotqqjJ/axDQYtW5A==" src="https://github.githubassets.com/assets/vendors-node_modules_github_file-attachment-element_dist_index_js-node_modules_primer_view-co-b3d32f-f4cc3da21699.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-3bFxiMFoiPsz8G3Kx8W0T+xbw7cDghVfCd615pB3EYAPnIKOsfy7+okIET5ZrI5qHWxJZ0n7h7de7LSmTSaJhw==" src="https://github.githubassets.com/assets/github-elements-ddb17188c168.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-R+OdCh4StFghHD6mZ/jnOGf1VHMjoN8jXZVgVZVrUiDrolvPjzUu0umApMuJ7xFBiyODBjOqvZeVN0Pvzvh6Jg==" src="https://github.githubassets.com/assets/element-registry-47e39d0a1e12.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-6VTowByTC7C1Ae4nuESJ5iT76vchmVCzjuit7IR83B/TPkwjSserSlr83SYhLvIfNLvJfB2zH0bHBr8+fzIa+w==" src="https://github.githubassets.com/assets/vendors-node_modules_lit-html_lit-html_js-e954e8c01c93.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-3YkTrGWwrb2whIVWEwKEhghL4yI2UAHnLW/QtnYMQFLkfQUYD3gtJ2WqDJg8wzzSm0rP05KFDOsKKx4a1wQRdA==" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_index_js-node_modules_github_hotkey_dist_index-9f48bd-dd8913ac65b0.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-07t6yD+Nez3QK+s/aR8lZIU8PP43jgeNoan7nYSXtg946/sAILGgi1XYPXAq2LjM6Z39DBMeyUs9+8VfWu+Neg==" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_github_catalyst_lib_index_-bd1f73-d3bb7ac83f8d.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-V4+K12am3OXCOQYegHoAFHR3Y4Zy9u97+gR5aLOTVia3tTeNPe39FlKnvnwjndeuEOWfkzXKB2iL2UwOKOZM+g==" src="https://github.githubassets.com/assets/vendors-node_modules_github_paste-markdown_dist_index_esm_js-node_modules_koddsson_textarea-c-586f78-578f8ad766a6.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-ca88YNhx59Y6MPsxr9y+qEB18WMG/q87Aot+YnVZZHUVApcVLIKELeCV1yLAoR2k8wAvxciT0E+iFWkkdEkg8w==" src="https://github.githubassets.com/assets/vendors-node_modules_github_quote-selection_dist_index_js-node_modules_github_session-resume_-1c1fef-71af3c60d871.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-iv5zc66CDnM+oVHCDv7cko+Bee6Q895DqJ52+TvMOtDYiEWLpTjQheRSbAygXr1SdVa7CSDLpnj3ze+dv1eIaw==" src="https://github.githubassets.com/assets/app_assets_modules_github_soft-nav_navigate_ts-8afe7373ae82.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-MUqllU1zWScJrG44uhPiK8irir0nw6SepGvp+rwjRQRnLnKTlIgaCO1N7OEZ3XSqHIJyNnZR1UlA29lBZrqxSw==" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_keyboard-shortcuts-helper_ts-app_assets_modules_github_di-9b8a64-314aa5954d73.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-sFfyQjq1ObFkfG0l+z9HzzoSicV7DnX6adtbhmwkcwapEIZkJef1OWQl3cYK14uRj/DZcMBTf9630E9xIyxDeA==" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_task-list_ts-app_assets_modules_github_has-interactions_t-0091d6-b057f2423ab5.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-jUDAjbHl8wBVw4r/C8gGbDvbgdoDNGq1yL23nRD4VYX28DfHEaC5Jinko1kMZxD90NlTH2GjbSBxsaOuZK5Klw==" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_details_ts-app_assets_modules_github_behaviors_include-fr-29e9d6-8d40c08db1e5.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-23lZtf/52z40ONnc8LqhXQ+V9egvurRHmvCUvgTJffdld26nI1WnOdt/T/cS10mOmyOYXMCh8EC+UgMrnENNXg==" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_commenting_edit_ts-app_assets_modules_github_behaviors_ht-83c235-db7959b5fff9.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-u7GxN4uybFYZfQXdJWtol3NZGvwxsyw/u1UAC6ljeZ37VhILLRzlhZcY3lQ4+PAU0L+r6Vt/SIG5BjtL0yBamw==" src="https://github.githubassets.com/assets/behaviors-bbb1b1378bb2.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-d4hUbfQ2iadFUIZEYzWtw7J3+rUei1LoCrq3TAisyHMoW6ERm28NawvaJpppfMvroppQJc1HXteqjyRWmugzdA==" src="https://github.githubassets.com/assets/vendors-node_modules_delegated-events_dist_index_js-node_modules_github_catalyst_lib_index_js-57c13e1-7788546df436.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-O73Mm2+i15d5+OJHBJqEGJ7yINcBZotEHst9GPxgdFdVaI+nI9MDzrDJ50ZJUHzZxZytebBKxUc4mR+qNQuTtA==" src="https://github.githubassets.com/assets/notifications-global-3bbdcc9b6fa2.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-F8z8SSakEr7YpDXzZGEdriFwg9sCN9ptY7hKHSZowNV10rNMr5Ihp5qxYkZxWMPrmXulB8ra4tuxEPpZdMNbeg==" src="https://github.githubassets.com/assets/vendors-node_modules_virtualized-list_es_index_js-node_modules_github_template-parts_lib_index_js-17ccfc4926a4.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-cQqJbzas26L5S2gGUDcoMtQojw730pJUVTR56j+IUEay3fem8eX0x2w87B4ggDiPjAz7H/bp/AM6C82uf/m03Q==" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_decorators_js-node_modules_github_remote-form_-65a541-710a896f36ac.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-f/7QW6/re871sCPOZwb8QNzGxl95Rf95am57+GCVvdeTTo01dfEe7rZg2Dz6DOmxcaRSbQtsLGo29u5mT+XqcQ==" src="https://github.githubassets.com/assets/vendors-node_modules_github_file-attachment-element_dist_index_js-node_modules_github_filter--8b2f15-7ffed05bafeb.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-jxdSPN0NbVmEhgHRpvTnZNPzdVVKP/Yr+ZvWmX/gEkfmHbjNPQBaQ0dZHQngvBiMp7dqTWay07pi723jOakVlQ==" src="https://github.githubassets.com/assets/app_assets_modules_github_ref-selector_ts-8f17523cdd0d.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-ZJjumgoy1JW8w1cBS+AeoIqxM1nKSRwVMiZRQQ8TL2ZrbJ7SLKoUyBb7/8MYP6gm6wDG46A/a5BRZMeyWVKfpQ==" src="https://github.githubassets.com/assets/repositories-6498ee9a0a32.js"></script>
+  
+
+  <title>Releases · ucoProject/UCO · GitHub</title>
+
+
+
+    
+
+  <meta name="request-id" content="9408:1A4F:20DBA2:444D57:62E959A3" data-pjax-transient="true"/><meta name="html-safe-nonce" content="d4280ced27b65a1bd81d25e8ea0af349a228e5f4b881b42bf0f87fa560ba61e9" data-pjax-transient="true"/><meta name="visitor-payload" content="eyJyZWZlcnJlciI6IiIsInJlcXVlc3RfaWQiOiI5NDA4OjFBNEY6MjBEQkEyOjQ0NEQ1Nzo2MkU5NTlBMyIsInZpc2l0b3JfaWQiOiI3NjI3OTE2ODk0OTM2ODQ4ODAzIiwicmVnaW9uX2VkZ2UiOiJpYWQiLCJyZWdpb25fcmVuZGVyIjoiaWFkIn0=" data-pjax-transient="true"/><meta name="visitor-hmac" content="b568eb76c993dcbccc711fc3684342a583a5a8c25d451db9ccbbcb3f03c306f6" data-pjax-transient="true"/>
+
+    <meta name="hovercard-subject-tag" content="repository:56257593" data-pjax-transient>
+
+
+  <meta name="github-keyboard-shortcuts" content="repository" data-pjax-transient="true" />
+  
+
+  <meta name="selected-link" value="repo_releases" data-pjax-transient>
+
+    <meta name="google-site-verification" content="c1kuD-K2HIVF635lypcsWPoD4kilo5-jA_wBFyT4uMY">
+  <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
+
+<meta name="octolytics-url" content="https://collector.github.com/github/collect" />
+
+  <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/releases/index" data-pjax-transient="true" />
+
+  
+
+
+
+
+  
+
+    <meta name="user-login" content="">
+
+  
+
+    <meta name="viewport" content="width=device-width">
+    
+      <meta name="description" content="This repository is for development of the Unified Cyber Ontology. - Releases · ucoProject/UCO">
+      <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+    <meta property="fb:app_id" content="1401488693436528">
+    <meta name="apple-itunes-app" content="app-id=1477376905" />
+      <meta name="twitter:image:src" content="https://opengraph.githubassets.com/e421fa35634be23da08740b41b0b4ecb650d396242ac4880183e1a7b991252cc/ucoProject/UCO" /><meta name="twitter:site" content="@github" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="Releases · ucoProject/UCO" /><meta name="twitter:description" content="This repository is for development of the Unified Cyber Ontology. - ucoProject/UCO" />
+      <meta property="og:image" content="https://opengraph.githubassets.com/e421fa35634be23da08740b41b0b4ecb650d396242ac4880183e1a7b991252cc/ucoProject/UCO" /><meta property="og:image:alt" content="This repository is for development of the Unified Cyber Ontology. - ucoProject/UCO" /><meta property="og:image:width" content="1200" /><meta property="og:image:height" content="600" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="Releases · ucoProject/UCO" /><meta property="og:url" content="/ucoProject/UCO/releases" /><meta property="og:description" content="This repository is for development of the Unified Cyber Ontology. - ucoProject/UCO" />
+      
+    <link rel="assets" href="https://github.githubassets.com/">
+
+
+        <meta name="hostname" content="github.com">
+
+
+
+        <meta name="expected-hostname" content="github.com">
+
+    <meta name="enabled-features" content="IMAGE_METRIC_TRACKING,GEOJSON_AZURE_MAPS">
+
+
+  <meta http-equiv="x-pjax-version" content="d6acd96081a1520bd822bec2393d56f08d66d5463fad7c6efc6bea0dce68f8db" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-csp-version" content="171483bb7fa1e692e90fd1050e6472447a67ec3e4df764579d3e8998bee757d8" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-css-version" content="b149fe36a2dac4973e4feb7c3dacc0ceae51247b58057120bcda5338a833966b" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-js-version" content="21382e621176efd9720a90e4d920be93c2a80210fe809e19fbf6c96c6c62d3a5" data-turbo-track="reload">
+
+  <meta name="turbo-cache-control" content="no-preview" data-pjax-transient="">
+
+      <link rel="alternate" type="application/atom+xml" title="UCO Release Notes" href="https://github.com/ucoProject/UCO/releases.atom" />
+  <link rel="alternate" type="application/atom+xml" title="UCO Tags" href="https://github.com/ucoProject/UCO/tags.atom" />
+
+  <meta name="go-import" content="github.com/ucoProject/UCO git https://github.com/ucoProject/UCO.git">
+
+  <meta name="octolytics-dimension-user_id" content="18468767" /><meta name="octolytics-dimension-user_login" content="ucoProject" /><meta name="octolytics-dimension-repository_id" content="56257593" /><meta name="octolytics-dimension-repository_nwo" content="ucoProject/UCO" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="56257593" /><meta name="octolytics-dimension-repository_network_root_nwo" content="ucoProject/UCO" />
+
+
+
+  <meta name="turbo-body-classes" content="logged-out env-production page-responsive">
+
+
+  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+
+  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+
+  <meta name="browser-optimizely-client-errors-url" content="https://api.github.com/_private/browser/optimizely_client/errors">
+
+  <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000">
+  <link rel="alternate icon" class="js-site-favicon" type="image/png" href="https://github.githubassets.com/favicons/favicon.png">
+  <link rel="icon" class="js-site-favicon" type="image/svg+xml" href="https://github.githubassets.com/favicons/favicon.svg">
+
+<meta name="theme-color" content="#1e2327">
+<meta name="color-scheme" content="light dark" />
+
+
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+
+  </head>
+
+  <body class="logged-out env-production page-responsive" style="word-wrap: break-word;">
+    
+
+    <div class="position-relative js-header-wrapper ">
+      <a href="#start-of-content" class="px-2 py-4 color-bg-accent-emphasis color-fg-on-emphasis show-on-focus js-skip-to-content">Skip to content</a>
+      <span data-view-component="true" class="progress-pjax-loader js-pjax-loader-bar Progress position-fixed width-full">
+    <span style="width: 0%;" data-view-component="true" class="Progress-item progress-pjax-loader-bar left-0 top-0 color-bg-accent-emphasis"></span>
+</span>      
+      
+
+
+        
+
+            <script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-XuPRbGVej1NDP7Zyq7fBPsxmaaAHjV+vW5vQwhRi+k0C0ADFEfw5IqgoS+Z/3XI3QXgacTAEdZZi7vjbKCR21w==" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_delegated-events_dist_inde-94fd67-5ee3d16c655e.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" integrity="sha512-CejWN1w/QjbOG5EH1fhNyPkPpg4nInnprTALGEaox9Elu1bcW2zEoX+fELCZABRe4/cmv+6Tna/5OIpxsXd6+A==" src="https://github.githubassets.com/assets/sessions-09e8d6375c3f.js"></script>
+<header class="Header-old header-logged-out js-details-container Details position-relative f4 py-2" role="banner">
+  <div class="container-xl d-lg-flex flex-items-center p-responsive">
+    <div class="d-flex flex-justify-between flex-items-center">
+      <a class="mr-4 color-fg-inherit" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+        <svg height="32" aria-hidden="true" viewBox="0 0 16 16" version="1.1" width="32" data-view-component="true" class="octicon octicon-mark-github">
+    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+</svg>
+      </a>
+
+        <div class="d-lg-none css-truncate css-truncate-target width-fit p-2">
+          
+
+        </div>
+
+      <div class="d-flex flex-items-center">
+            <a href="/signup?ref_cta=Sign+up&amp;ref_loc=header+logged+out&amp;ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Freleases%2Findex&amp;source=header-repo"
+              class="d-inline-block d-lg-none f5 no-underline border color-border-default rounded-2 px-2 py-1 mr-3 mr-sm-5 color-fg-inherit"
+              data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/ucoProject/UCO/releases&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="0c6900c7c240b072828e64a09b4131547f7c2ad52d0dacc25e4ffad00c601b65"
+            >
+              Sign&nbsp;up
+            </a>
+
+        <button aria-label="Toggle navigation" aria-expanded="false" type="button" data-view-component="true" class="js-details-target btn-link d-lg-none mt-1 color-fg-inherit">  <svg aria-hidden="true" height="24" viewBox="0 0 16 16" version="1.1" width="24" data-view-component="true" class="octicon octicon-three-bars">
+    <path fill-rule="evenodd" d="M1 2.75A.75.75 0 011.75 2h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 2.75zm0 5A.75.75 0 011.75 7h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 7.75zM1.75 12a.75.75 0 100 1.5h12.5a.75.75 0 100-1.5H1.75z"></path>
+</svg>
+  
+</button>      </div>
+    </div>
+
+    <div class="HeaderMenu HeaderMenu--logged-out position-fixed top-0 right-0 bottom-0 height-fit position-lg-relative d-lg-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-flex d-lg-none flex-justify-end border-bottom color-bg-subtle p-3">
+        <button aria-label="Toggle navigation" aria-expanded="false" type="button" data-view-component="true" class="js-details-target btn-link">  <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-x color-fg-muted">
+    <path fill-rule="evenodd" d="M5.72 5.72a.75.75 0 011.06 0L12 10.94l5.22-5.22a.75.75 0 111.06 1.06L13.06 12l5.22 5.22a.75.75 0 11-1.06 1.06L12 13.06l-5.22 5.22a.75.75 0 01-1.06-1.06L10.94 12 5.72 6.78a.75.75 0 010-1.06z"></path>
+</svg>
+  
+</button>      </div>
+
+        <nav class="mt-0 px-3 px-lg-0 mb-5 mb-lg-0" aria-label="Global">
+          <ul class="d-lg-flex list-style-none">
+              <li class="mr-0 mr-lg-3 position-relative flex-wrap flex-justify-between flex-items-center border-bottom border-lg-bottom-0 d-block d-lg-flex flex-lg-nowrap flex-lg-items-center">
+    <details class="HeaderMenu-details details-overlay details-reset width-full">
+      <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
+        Product
+        <svg x="0" y="0" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative"><path d="M1,1l6.2,6L13,1"></path></svg>
+      </summary>
+      <div class="dropdown-menu flex-auto rounded px-0 mt-0 pb-4 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
+        <ul class="list-style-none f5 pb-1">
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--primary text-bold py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Features&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Features;&quot;}" href="/features">
+      Features
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Mobile&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Mobile;&quot;}" href="/mobile">
+      Mobile
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Actions&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Actions;&quot;}" href="/features/actions">
+      Actions
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Codespaces&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Codespaces;&quot;}" href="/features/codespaces">
+      Codespaces
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Copilot&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Copilot;&quot;}" href="/features/copilot">
+      Copilot
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Packages&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Packages;&quot;}" href="/features/packages">
+      Packages
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Security&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Security;&quot;}" href="/features/security">
+      Security
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Code review&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Code review;&quot;}" href="/features/code-review">
+      Code review
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Issues&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Issues;&quot;}" href="/features/issues">
+      Issues
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Discussions&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Discussions;&quot;}" href="/features/discussions">
+      Discussions
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Integrations&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Integrations;&quot;}" href="/features/integrations">
+      Integrations
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--primary text-bold border-top pt-4 pb-2 mt-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to GitHub Sponsors&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:GitHub Sponsors;&quot;}" href="/sponsors">
+      GitHub Sponsors
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--primary text-bold py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Customer stories&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Customer stories;&quot;}" href="/customer-stories">
+      Customer stories
+</a>  </li>
+
+        </ul>
+      </div>
+    </details>
+</li>
+
+
+              <li class="mr-0 mr-lg-3 position-relative flex-wrap flex-justify-between flex-items-center border-bottom border-lg-bottom-0 d-block d-lg-flex flex-lg-nowrap flex-lg-items-center">
+    <a class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-analytics-event="{&quot;category&quot;:&quot;Header menu top item (logged out)&quot;,&quot;action&quot;:&quot;click to go to Team&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Team;&quot;}" href="/team">Team</a>
+</li>
+
+              <li class="mr-0 mr-lg-3 position-relative flex-wrap flex-justify-between flex-items-center border-bottom border-lg-bottom-0 d-block d-lg-flex flex-lg-nowrap flex-lg-items-center">
+    <a class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-analytics-event="{&quot;category&quot;:&quot;Header menu top item (logged out)&quot;,&quot;action&quot;:&quot;click to go to Enterprise&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Enterprise;&quot;}" href="/enterprise">Enterprise</a>
+</li>
+
+
+            <li class="mr-0 mr-lg-3 position-relative flex-wrap flex-justify-between flex-items-center border-bottom border-lg-bottom-0 d-block d-lg-flex flex-lg-nowrap flex-lg-items-center">
+    <details class="HeaderMenu-details details-overlay details-reset width-full">
+      <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
+        Explore
+        <svg x="0" y="0" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative"><path d="M1,1l6.2,6L13,1"></path></svg>
+      </summary>
+      <div class="dropdown-menu flex-auto rounded px-0 mt-0 pb-4 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
+        <ul class="list-style-none f5 pb-1">
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--primary text-bold py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Explore GitHub&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Explore GitHub;&quot;}" href="/explore">
+      Explore GitHub
+</a>  </li>
+
+              <li class="color-fg-muted text-normal f6 text-mono mb-1 border-top pt-3 mt-3 mb-1">Learn and contribute</li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Topics&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Topics;&quot;}" href="/topics">
+      Topics
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Collections&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Collections;&quot;}" href="/collections">
+      Collections
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Trending&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Trending;&quot;}" href="/trending">
+      Trending
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Skills&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Skills;&quot;}" href="https://skills.github.com/">
+      Skills
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to GitHub Sponsors&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:GitHub Sponsors;&quot;}" href="/sponsors/explore">
+      GitHub Sponsors
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Open source guides&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Open source guides;&quot;}" href="https://opensource.guide">
+      Open source guides
+</a>  </li>
+
+              <li class="color-fg-muted text-normal f6 text-mono mb-1 border-top pt-3 mt-3 mb-1">Connect with others</li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to The ReadME Project&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:The ReadME Project;&quot;}" href="/readme">
+      The ReadME Project
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Events&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Events;&quot;}" href="/events">
+      Events
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to Community forum&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Community forum;&quot;}" href="https://github.community">
+      Community forum
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to GitHub Education&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:GitHub Education;&quot;}" href="https://education.github.com">
+      GitHub Education
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Explore&quot;,&quot;action&quot;:&quot;click to go to GitHub Stars program&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:GitHub Stars program;&quot;}" href="https://stars.github.com">
+      GitHub Stars program
+</a>  </li>
+
+        </ul>
+      </div>
+    </details>
+</li>
+
+
+            <li class="mr-0 mr-lg-3 position-relative flex-wrap flex-justify-between flex-items-center border-bottom border-lg-bottom-0 d-block d-lg-flex flex-lg-nowrap flex-lg-items-center">
+    <a class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-analytics-event="{&quot;category&quot;:&quot;Header menu top item (logged out)&quot;,&quot;action&quot;:&quot;click to go to Marketplace&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Marketplace;&quot;}" href="/marketplace">Marketplace</a>
+</li>
+
+
+            <li class="mr-0 mr-lg-3 position-relative flex-wrap flex-justify-between flex-items-center border-bottom border-lg-bottom-0 d-block d-lg-flex flex-lg-nowrap flex-lg-items-center">
+    <details class="HeaderMenu-details details-overlay details-reset width-full">
+      <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
+        Pricing
+        <svg x="0" y="0" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative"><path d="M1,1l6.2,6L13,1"></path></svg>
+      </summary>
+      <div class="dropdown-menu flex-auto rounded px-0 mt-0 pb-4 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
+        <ul class="list-style-none f5 pb-1">
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--primary text-bold py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Pricing&quot;,&quot;action&quot;:&quot;click to go to Plans&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Plans;&quot;}" href="/pricing">
+      Plans
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Pricing&quot;,&quot;action&quot;:&quot;click to go to Compare plans&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Compare plans;&quot;}" href="/pricing#compare-features">
+      Compare plans
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--secondary py-2" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Pricing&quot;,&quot;action&quot;:&quot;click to go to Contact Sales&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Contact Sales;&quot;}" href="https://github.com/enterprise/contact">
+      Contact Sales
+</a>  </li>
+
+              <li>
+    <a class="lh-condensed-ultra d-block no-underline position-relative Link--primary text-bold border-top pt-4 pb-2 mt-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Pricing&quot;,&quot;action&quot;:&quot;click to go to Education&quot;,&quot;label&quot;:&quot;ref_page:/ucoProject/UCO/releases;ref_cta:Education;&quot;}" href="https://education.github.com">
+      Education
+</a>  </li>
+
+        </ul>
+      </div>
+    </details>
+</li>
+
+          </ul>
+        </nav>
+
+      <div class="d-lg-flex flex-items-center px-3 px-lg-0 text-center text-lg-left">
+          <div class="d-lg-flex min-width-0 mb-3 mb-lg-0">
+            
+
+
+
+<div class="header-search flex-auto js-site-search position-relative flex-self-stretch flex-md-self-auto mb-3 mb-md-0 mr-0 mr-md-3 scoped-search site-scoped-search js-jump-to"
+>
+  <div class="position-relative">
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-scope-type="Repository" data-scope-id="56257593" data-scoped-search-url="/ucoProject/UCO/search" data-owner-scoped-search-url="/orgs/ucoProject/search" data-unscoped-search-url="/search" data-turbo="false" action="/ucoProject/UCO/search" accept-charset="UTF-8" method="get">
+      <label class="form-control input-sm header-search-wrapper p-0 js-chromeless-input-container header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center">
+        <input type="text"
+          class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
+          data-hotkey=s,/
+          name="q"
+          data-test-selector="nav-search-input"
+          placeholder="Search"
+          data-unscoped-placeholder="Search GitHub"
+          data-scoped-placeholder="Search"
+          autocapitalize="off"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded="false"
+          aria-autocomplete="list"
+          aria-controls="jump-to-results"
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations"
+          spellcheck="false"
+          autocomplete="off"
+        >
+        <input type="hidden" data-csrf="true" class="js-data-jump-to-suggestions-path-csrf" value="vLs08VcECcBDgABxgmgoqV+dmmHdRa/XnaqkeTyWbRaHx5J3RcoxbS2nr3lGX1QGV7VtcUC94vkepe0Xunfrqg==" />
+        <input type="hidden" class="js-site-search-type-field" name="type" >
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" aria-hidden="true" class="mr-1 header-search-key-slash"><path fill="none" stroke="#979A9C" opacity=".4" d="M3.5.5h12c1.7 0 3 1.3 3 3v13c0 1.7-1.3 3-3 3h-12c-1.7 0-3-1.3-3-3v-13c0-1.7 1.3-3 3-3z"></path><path fill="#979A9C" d="M11.8 6L8 15.1h-.9L10.8 6h1z"></path></svg>
+
+
+          <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
+            
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="" data-item-type="suggestion">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg title="Repository" aria-label="Repository" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo js-jump-to-octicon-repo d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path>
+</svg>
+      <svg title="Project" aria-label="Project" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-project js-jump-to-octicon-project d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M1.75 0A1.75 1.75 0 000 1.75v12.5C0 15.216.784 16 1.75 16h12.5A1.75 1.75 0 0016 14.25V1.75A1.75 1.75 0 0014.25 0H1.75zM1.5 1.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v12.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25V1.75zM11.75 3a.75.75 0 00-.75.75v7.5a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75zm-8.25.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5zM8 3a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 3z"></path>
+</svg>
+      <svg title="Search" aria-label="Search" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search js-jump-to-octicon-search d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path>
+</svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="color-fg-muted">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="" data-item-type="scoped_search">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg title="Repository" aria-label="Repository" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo js-jump-to-octicon-repo d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path>
+</svg>
+      <svg title="Project" aria-label="Project" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-project js-jump-to-octicon-project d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M1.75 0A1.75 1.75 0 000 1.75v12.5C0 15.216.784 16 1.75 16h12.5A1.75 1.75 0 0016 14.25V1.75A1.75 1.75 0 0014.25 0H1.75zM1.5 1.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v12.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25V1.75zM11.75 3a.75.75 0 00-.75.75v7.5a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75zm-8.25.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5zM8 3a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 3z"></path>
+</svg>
+      <svg title="Search" aria-label="Search" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search js-jump-to-octicon-search d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path>
+</svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-owner-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="" data-item-type="owner_scoped_search">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg title="Repository" aria-label="Repository" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo js-jump-to-octicon-repo d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path>
+</svg>
+      <svg title="Project" aria-label="Project" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-project js-jump-to-octicon-project d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M1.75 0A1.75 1.75 0 000 1.75v12.5C0 15.216.784 16 1.75 16h12.5A1.75 1.75 0 0016 14.25V1.75A1.75 1.75 0 0014.25 0H1.75zM1.5 1.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v12.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25V1.75zM11.75 3a.75.75 0 00-.75.75v7.5a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75zm-8.25.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5zM8 3a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 3z"></path>
+</svg>
+      <svg title="Search" aria-label="Search" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search js-jump-to-octicon-search d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path>
+</svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this organization">
+        In this organization
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="" data-item-type="global_search">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg title="Repository" aria-label="Repository" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo js-jump-to-octicon-repo d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path>
+</svg>
+      <svg title="Project" aria-label="Project" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-project js-jump-to-octicon-project d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M1.75 0A1.75 1.75 0 000 1.75v12.5C0 15.216.784 16 1.75 16h12.5A1.75 1.75 0 0016 14.25V1.75A1.75 1.75 0 0014.25 0H1.75zM1.5 1.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v12.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25V1.75zM11.75 3a.75.75 0 00-.75.75v7.5a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75zm-8.25.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5zM8 3a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 3z"></path>
+</svg>
+      <svg title="Search" aria-label="Search" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search js-jump-to-octicon-search d-none flex-shrink-0">
+    <path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path>
+</svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-2 flex-shrink-0 color-bg-subtle px-1 color-fg-muted ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
+          </div>
+      </label>
+</form>  </div>
+</div>
+
+          </div>
+
+        <div class="position-relative mr-3 mb-4 mb-lg-0 d-inline-block">
+          <a href="/login?return_to=https%3A%2F%2Fgithub.com%2FucoProject%2FUCO%2Freleases%2F"
+            class="HeaderMenu-link flex-shrink-0 no-underline"
+            data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/ucoProject/UCO/releases&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="5389bb8f66240b2603b8daf992b8268b2c2f20b29b7613b0149b0044fd0d022f"
+            data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">
+            Sign in
+          </a>
+        </div>
+
+          <a href="/signup?ref_cta=Sign+up&amp;ref_loc=header+logged+out&amp;ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Freleases%2Findex&amp;source=header-repo&amp;source_repo=ucoProject%2FUCO"
+            class="HeaderMenu-link flex-shrink-0 d-inline-block no-underline border color-border-default rounded px-2 py-1"
+            data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/ucoProject/UCO/releases&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="5389bb8f66240b2603b8daf992b8268b2c2f20b29b7613b0149b0044fd0d022f"
+            data-analytics-event="{&quot;category&quot;:&quot;Sign up&quot;,&quot;action&quot;:&quot;click to sign up for account&quot;,&quot;label&quot;:&quot;ref_page:/&lt;user-name&gt;/&lt;repo-name&gt;/releases/index;ref_cta:Sign up;ref_loc:header logged out&quot;}"
+          >
+            Sign up
+          </a>
+      </div>
+    </div>
+  </div>
+</header>
+
+    </div>
+
+  <div id="start-of-content" class="show-on-focus"></div>
+
+
+
+
+
+
+
+    <div data-pjax-replace id="js-flash-container" data-turbo-replace>
+
+
+
+  <template class="js-flash-template">
+    <div class="flash flash-full  {{ className }}">
+  <div class="px-2" >
+    <button class="flash-close js-flash-close" type="button" aria-label="Dismiss this message">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+    </button>
+    
+      <div>{{ message }}</div>
+
+  </div>
+</div>
+  </template>
+</div>
+
+
+    
+  <include-fragment class="js-notification-shelf-include-fragment" data-base-src="https://github.com/notifications/beta/shelf"></include-fragment>
+
+
+
+
+
+  <div
+    class="application-main "
+    data-commit-hovercards-enabled
+    data-discussion-hovercards-enabled
+    data-issue-and-pr-hovercards-enabled
+  >
+        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
+    <main id="js-repo-pjax-container" data-pjax-container >
+      
+  
+
+    
+    
+
+
+
+
+
+
+
+
+  <div id="repository-container-header" class="pt-3 hide-full-screen" style="background-color: var(--color-page-header-bg);" data-pjax-replace data-turbo-replace>
+
+      <div class="d-flex mb-3 px-3 px-md-4 px-lg-5">
+
+        <div class="flex-auto min-width-0 width-fit mr-3">
+            <div class=" d-flex flex-wrap flex-items-center wb-break-word f3 text-normal">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo color-fg-muted mr-2">
+    <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path>
+</svg>
+  <span class="author flex-self-stretch" itemprop="author">
+    <a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/ucoProject/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/ucoProject">ucoProject</a>
+  </span>
+  <span class="mx-1 flex-self-stretch color-fg-muted">/</span>
+  <strong itemprop="name" class="mr-2 flex-self-stretch">
+    <a data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" href="/ucoProject/UCO">UCO</a>
+  </strong>
+
+  <span></span><span class="Label Label--secondary v-align-middle mr-1">Public</span>
+</div>
+
+        </div>
+
+          <ul class="pagehead-actions flex-shrink-0 d-none d-md-inline" style="padding: 2px 0;">
+
+    
+
+  <li>
+      <a href="/login?return_to=%2FucoProject%2FUCO" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/ucoProject/UCO/releases&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="4117ecc4654bd78432175aa58384a7b4625ee271933374f5ced730a5252cebba" aria-label="You must be signed in to change notification settings" data-view-component="true" class="tooltipped tooltipped-s btn-sm btn">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-bell mr-2">
+    <path d="M8 16a2 2 0 001.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 008 16z"></path><path fill-rule="evenodd" d="M8 1.5A3.5 3.5 0 004.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.018.018 0 00-.003.01l.001.006c0 .002.002.004.004.006a.017.017 0 00.006.004l.007.001h10.964l.007-.001a.016.016 0 00.006-.004.016.016 0 00.004-.006l.001-.007a.017.017 0 00-.003-.01l-1.703-2.554a1.75 1.75 0 01-.294-.97V5A3.5 3.5 0 008 1.5zM3 5a5 5 0 0110 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.518 1.518 0 0113.482 13H2.518a1.518 1.518 0 01-1.263-2.36l1.703-2.554A.25.25 0 003 7.947V5z"></path>
+</svg>Notifications
+  
+</a>
+  </li>
+
+  <li>
+      
+  <a href="/login?return_to=%2FucoProject%2FUCO" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:56257593,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/ucoProject/UCO/releases&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="0822b502010835e3ef1745306f45b2496ef33352711835b2bc63abd37df1b1a8" aria-label="You must be signed in to fork a repository" data-view-component="true" class="tooltipped tooltipped-s btn-sm btn">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo-forked mr-2">
+    <path fill-rule="evenodd" d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v.878A2.25 2.25 0 005.75 8.5h1.5v2.128a2.251 2.251 0 101.5 0V8.5h1.5a2.25 2.25 0 002.25-2.25v-.878a2.25 2.25 0 10-1.5 0v.878a.75.75 0 01-.75.75h-4.5A.75.75 0 015 6.25v-.878zm3.75 7.378a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm3-8.75a.75.75 0 100-1.5.75.75 0 000 1.5z"></path>
+</svg>Fork
+    <span id="repo-network-counter" data-pjax-replace="true" title="25" data-view-component="true" class="Counter">25</span>
+  
+</a>
+  </li>
+
+  <li>
+        <div data-view-component="true" class="BtnGroup d-flex">
+      <a href="/login?return_to=%2FucoProject%2FUCO" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:56257593,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/ucoProject/UCO/releases&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="fc929717b74bbbf8fc069e70cc2f50afe17ade567c9e89d91182cd97501668e5" aria-label="You must be signed in to star a repository" data-view-component="true" class="tooltipped tooltipped-s btn-sm btn BtnGroup-item">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-star v-align-text-bottom d-inline-block mr-2">
+    <path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"></path>
+</svg><span data-view-component="true" class="d-inline">
+          Star
+</span>          <span id="repo-stars-counter-star" aria-label="47 users starred this repository" data-singular-suffix="user starred this repository" data-plural-suffix="users starred this repository" data-pjax-replace="true" data-turbo-replace="true" title="47" data-view-component="true" class="Counter js-social-count">47</span>
+  
+</a>      <button disabled="disabled" aria-label="You must be signed in to add this repository to a list" type="button" data-view-component="true" class="btn-sm btn BtnGroup-item px-2">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</button></div>
+  </li>
+
+  
+
+</ul>
+
+      </div>
+
+      <div id="responsive-meta-container" data-pjax-replace data-turbo-replace>
+</div>
+
+
+        
+<nav data-pjax="#js-repo-pjax-container" aria-label="Repository" data-view-component="true" class="js-repo-nav js-sidenav-container-pjax js-responsive-underlinenav overflow-hidden UnderlineNav px-3 px-md-4 px-lg-5">
+
+  <ul data-view-component="true" class="UnderlineNav-body list-style-none">
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="code-tab" href="/ucoProject/UCO" data-tab-item="i0code-tab" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages repo_deployments /ucoProject/UCO" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g c" data-ga-click="Repository, Navigation click, Code tab" aria-current="page" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item selected">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code UnderlineNav-octicon d-none d-sm-inline">
+    <path fill-rule="evenodd" d="M4.72 3.22a.75.75 0 011.06 1.06L2.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L.47 8.53a.75.75 0 010-1.06l4.25-4.25zm6.56 0a.75.75 0 10-1.06 1.06L13.94 8l-3.72 3.72a.75.75 0 101.06 1.06l4.25-4.25a.75.75 0 000-1.06l-4.25-4.25z"></path>
+</svg>
+          <span data-content="Code">Code</span>
+            <span id="code-repo-tab-count" data-pjax-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="issues-tab" href="/ucoProject/UCO/issues" data-tab-item="i1issues-tab" data-selected-links="repo_issues repo_labels repo_milestones /ucoProject/UCO/issues" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g i" data-ga-click="Repository, Navigation click, Issues tab" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-issue-opened UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
+</svg>
+          <span data-content="Issues">Issues</span>
+            <span id="issues-repo-tab-count" data-pjax-replace="" title="85" data-view-component="true" class="Counter">85</span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="pull-requests-tab" href="/ucoProject/UCO/pulls" data-tab-item="i2pull-requests-tab" data-selected-links="repo_pulls checks /ucoProject/UCO/pulls" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g p" data-ga-click="Repository, Navigation click, Pull requests tab" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-pull-request UnderlineNav-octicon d-none d-sm-inline">
+    <path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"></path>
+</svg>
+          <span data-content="Pull requests">Pull requests</span>
+            <span id="pull-requests-repo-tab-count" data-pjax-replace="" title="23" data-view-component="true" class="Counter">23</span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="actions-tab" href="/ucoProject/UCO/actions" data-tab-item="i3actions-tab" data-selected-links="repo_actions /ucoProject/UCO/actions" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g a" data-analytics-event="{&quot;category&quot;:&quot;Actions&quot;,&quot;action&quot;:&quot;clicked&quot;,&quot;label&quot;:&quot;ref_cta:Actions;ref_loc:navigation_helper&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play UnderlineNav-octicon d-none d-sm-inline">
+    <path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zM6.379 5.227A.25.25 0 006 5.442v5.117a.25.25 0 00.379.214l4.264-2.559a.25.25 0 000-.428L6.379 5.227z"></path>
+</svg>
+          <span data-content="Actions">Actions</span>
+            <span id="actions-repo-tab-count" data-pjax-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="projects-tab" href="/ucoProject/UCO/projects?type=new" data-tab-item="i4projects-tab" data-selected-links="repo_projects new_repo_project repo_project /ucoProject/UCO/projects?type=new" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g b" data-ga-click="Repository, Navigation click, Projects tab" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-table UnderlineNav-octicon d-none d-sm-inline">
+    <path fill-rule="evenodd" d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v3.585a.746.746 0 010 .83v8.085A1.75 1.75 0 0114.25 16H6.309a.748.748 0 01-1.118 0H1.75A1.75 1.75 0 010 14.25V6.165a.746.746 0 010-.83V1.75zM1.5 6.5v7.75c0 .138.112.25.25.25H5v-8H1.5zM5 5H1.5V1.75a.25.25 0 01.25-.25H5V5zm1.5 1.5v8h7.75a.25.25 0 00.25-.25V6.5h-8zm8-1.5h-8V1.5h7.75a.25.25 0 01.25.25V5z"></path>
+</svg>
+          <span data-content="Projects">Projects</span>
+            <span id="projects-repo-tab-count" data-pjax-replace="" title="0" hidden="hidden" data-view-component="true" class="Counter">0</span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="wiki-tab" href="/ucoProject/UCO/wiki" data-tab-item="i5wiki-tab" data-selected-links="repo_wiki /ucoProject/UCO/wiki" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g w" data-ga-click="Repository, Navigation click, Wikis tab" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book UnderlineNav-octicon d-none d-sm-inline">
+    <path fill-rule="evenodd" d="M0 1.75A.75.75 0 01.75 1h4.253c1.227 0 2.317.59 3 1.501A3.744 3.744 0 0111.006 1h4.245a.75.75 0 01.75.75v10.5a.75.75 0 01-.75.75h-4.507a2.25 2.25 0 00-1.591.659l-.622.621a.75.75 0 01-1.06 0l-.622-.621A2.25 2.25 0 005.258 13H.75a.75.75 0 01-.75-.75V1.75zm8.755 3a2.25 2.25 0 012.25-2.25H14.5v9h-3.757c-.71 0-1.4.201-1.992.572l.004-7.322zm-1.504 7.324l.004-5.073-.002-2.253A2.25 2.25 0 005.003 2.5H1.5v9h3.757a3.75 3.75 0 011.994.574z"></path>
+</svg>
+          <span data-content="Wiki">Wiki</span>
+            <span id="wiki-repo-tab-count" data-pjax-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="security-tab" href="/ucoProject/UCO/security" data-tab-item="i6security-tab" data-selected-links="security overview alerts policy token_scanning code_scanning /ucoProject/UCO/security" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g s" data-ga-click="Repository, Navigation click, Security tab" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield UnderlineNav-octicon d-none d-sm-inline">
+    <path fill-rule="evenodd" d="M7.467.133a1.75 1.75 0 011.066 0l5.25 1.68A1.75 1.75 0 0115 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.7 1.7 0 01-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 011.217-1.667l5.25-1.68zm.61 1.429a.25.25 0 00-.153 0l-5.25 1.68a.25.25 0 00-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.2.2 0 00.154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.25.25 0 00-.174-.237l-5.25-1.68zM9 10.5a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.75a.75.75 0 10-1.5 0v3a.75.75 0 001.5 0v-3z"></path>
+</svg>
+          <span data-content="Security">Security</span>
+            <include-fragment src="/ucoProject/UCO/security/overall-count" accept="text/fragment+html"></include-fragment>
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="insights-tab" href="/ucoProject/UCO/pulse" data-tab-item="i7insights-tab" data-selected-links="repo_graphs repo_contributors dependency_graph dependabot_updates pulse people community /ucoProject/UCO/pulse" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-ga-click="Repository, Navigation click, Insights tab" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+                  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-graph UnderlineNav-octicon d-none d-sm-inline">
+    <path fill-rule="evenodd" d="M1.5 1.75a.75.75 0 00-1.5 0v12.5c0 .414.336.75.75.75h14.5a.75.75 0 000-1.5H1.5V1.75zm14.28 2.53a.75.75 0 00-1.06-1.06L10 7.94 7.53 5.47a.75.75 0 00-1.06 0L3.22 8.72a.75.75 0 001.06 1.06L7 7.06l2.47 2.47a.75.75 0 001.06 0l5.25-5.25z"></path>
+</svg>
+          <span data-content="Insights">Insights</span>
+            <span id="insights-repo-tab-count" data-pjax-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+</ul>
+    <div style="visibility:hidden;" data-view-component="true" class="UnderlineNav-actions js-responsive-underlinenav-overflow position-absolute pr-3 pr-md-4 pr-lg-5 right-0">      <details data-view-component="true" class="details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true">          <div class="UnderlineNav-item mr-0 border-0">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-kebab-horizontal">
+    <path d="M8 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM1.5 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm13 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+</svg>
+            <span class="sr-only">More</span>
+          </div>
+</summary>
+  <div data-view-component="true">          <details-menu role="menu" data-view-component="true" class="dropdown-menu dropdown-menu-sw">
+  
+            <ul>
+                <li data-menu-item="i0code-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item selected dropdown-item" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages repo_deployments /ucoProject/UCO" href="/ucoProject/UCO">
+                    Code
+</a>                </li>
+                <li data-menu-item="i1issues-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links="repo_issues repo_labels repo_milestones /ucoProject/UCO/issues" href="/ucoProject/UCO/issues">
+                    Issues
+</a>                </li>
+                <li data-menu-item="i2pull-requests-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links="repo_pulls checks /ucoProject/UCO/pulls" href="/ucoProject/UCO/pulls">
+                    Pull requests
+</a>                </li>
+                <li data-menu-item="i3actions-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links="repo_actions /ucoProject/UCO/actions" href="/ucoProject/UCO/actions">
+                    Actions
+</a>                </li>
+                <li data-menu-item="i4projects-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links="repo_projects new_repo_project repo_project /ucoProject/UCO/projects?type=new" href="/ucoProject/UCO/projects?type=new">
+                    Projects
+</a>                </li>
+                <li data-menu-item="i5wiki-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links="repo_wiki /ucoProject/UCO/wiki" href="/ucoProject/UCO/wiki">
+                    Wiki
+</a>                </li>
+                <li data-menu-item="i6security-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links="security overview alerts policy token_scanning code_scanning /ucoProject/UCO/security" href="/ucoProject/UCO/security">
+                    Security
+</a>                </li>
+                <li data-menu-item="i7insights-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links="repo_graphs repo_contributors dependency_graph dependabot_updates pulse people community /ucoProject/UCO/pulse" href="/ucoProject/UCO/pulse">
+                    Insights
+</a>                </li>
+            </ul>
+
+</details-menu></div>
+</details></div>
+</nav>
+  </div>
+
+
+
+
+  <turbo-frame id="repo-content-turbo-frame" target="_top" data-turbo-action="advance" class="">
+      <div id="repo-content-pjax-container" class="repository-content " >
+    
+    
+
+
+    
+      
+<div class="clearfix container-xl px-3 px-md-4 px-lg-5 mt-4">
+  <div class="d-flex flex-justify-center">
+  <div class="d-flex flex-column flex-sm-row flex-wrap mb-3 pb-3 col-11 flex-justify-between border-bottom" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <nav aria-label="Releases and Tags navigation buttons" class="mb-2 flex-1">
+      <a class="js-selected-navigation-item selected subnav-item" aria-current="page" data-selected-links="repo_releases /ucoProject/UCO/releases" href="/ucoProject/UCO/releases">Releases</a>
+      <a class="js-selected-navigation-item subnav-item" data-selected-links="repo_tags /ucoProject/UCO/tags" href="/ucoProject/UCO/tags">Tags</a>
+    </nav>
+    <div class="d-flex flex-column flex-md-row">
+
+
+      <div>
+        <form class="position-relative ml-md-2" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-turbo="false" action="/ucoProject/UCO/releases" accept-charset="UTF-8" method="get">
+          <input
+            type="search"
+            name="q"
+            class="form-control subnav-search-input width-full"
+            value=""
+            placeholder="Find a release"
+            aria-label="Find a release"
+          >
+          <input type="hidden" name="expanded" value="true">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search subnav-search-icon">
+    <path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path>
+</svg>
+</form>      </div>
+    </div>
+  </div>
+</div>
+
+<div data-pjax>
+      <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2022-06-16T14:11:30Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/11739701?s=40&amp;v=4" alt="@ajnelson-nist" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/ajnelson-nist/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/ajnelson-nist">ajnelson-nist</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/0.9.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            0.9.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/3165bd62ef14909eac4a9bc2db76e041cbdb185b/hovercard" href="/ucoProject/UCO/commit/3165bd62ef14909eac4a9bc2db76e041cbdb185b" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">3165bd6</code></a><details class="dropdown dropdown-signed-commit details-reset details-overlay js-dropdown-details d-inline-block ml-1">
+    <summary class="color-fg-success"
+    title="Commit signature" >
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+    </summary>
+
+    <div class="anim-scale-in" style="position: relative; z-index: 200;">
+      <div class="dropdown-menu dropdown-menu-s py-0 color-fg-default text-left">
+
+        <div class="p-3 signed-commit-header d-flex">
+          <div class="pr-1">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified mr-2">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+          </div>
+          <div class="flex-1">
+                This commit was created on GitHub.com and signed with GitHub’s <strong class="signed-commit-verified-label">verified signature</strong>.
+          </div>
+        </div>
+
+
+        <div class="signed-commit-footer p-3 rounded-bottom-2">
+            <span class="d-block">GPG key ID: <span class="color-fg-muted">4AEE18F83AFDEB23</span></span>
+            <div class="my-1">
+            </div>
+          <a href="https://docs.github.com/github/authenticating-to-github/displaying-verification-statuses-for-all-of-your-commits">Learn about vigilant mode</a>.
+        </div>
+      </div>
+    </div>
+</details>
+
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7ba369b4-1285-11ed-9da1-f80632706106">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7ba369b4-1285-11ed-9da1-f80632706106">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="MC45LjA="
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...0.9.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/0.9.0" data-view-component="true" class="Link--primary">UCO 0.9.0</a></h1>
+    <a href="/ucoProject/UCO/releases/latest" data-view-component="true" class="v-align-text-bottom d-none d-md-inline-block"><span data-view-component="true" class="Label Label--success Label--large">Latest</span></a>
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    <a href="/ucoProject/UCO/releases/latest" data-view-component="true" class="v-align-text-bottom"><span data-view-component="true" class="Label Label--success Label--large">Latest</span></a>
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>UCO 0.9.0 primarily focused on workflow technology transitions, and was necessitated by a Java dependency upgrade. The workflow used to normalize Turtle files in UCO and in downstream repositories now minimally requires Java 11, which impacts several public repositories---especially within the <a href="https://caseontology.org/" rel="nofollow">CASE</a> community---that present Turtle files as part of their review process. The workflow to interface with the UCO and CASE ontologies has transitioned to Github Issues, which has caused some files related to programming Github interfaces to become versioned with the ontology. SHACL documentation will now use sh:description when documenting SHACL shapes. OWL-level ontological commitments are being restored since the transition to SHACL, starting with clarifying that core:UcoObject and core:Facet are disjoint classes, and that core:hasFacet is an OWL inverse-functional property. In SHACL validation updates, 0.9.0 refines some properties in email stub graph objects, polyglot designations with multiple MIME types, and a correction with names of accounts.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details open="open" data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.9.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2022-06-16T12:35:50Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.9.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2022-06-16T12:35:50Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="1rrkdYzrzrYWXc2i08Q8-jtF2Uhoq3EOoJaSZ5OnCrVNA2QjGSxiK59RvjxkKzd5XiktOqqWGERqWA2osOJEiQ" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="RE_kwDOA1psOc4EJmBU">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+  <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2022-03-23T15:38:34Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/2760288?s=40&amp;v=4" alt="@sbarnum" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/sbarnum/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/sbarnum">sbarnum</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/0.8.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            0.8.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/8495cd0134f1aeca8b3328d7e4fcdb981ceb5079/hovercard" href="/ucoProject/UCO/commit/8495cd0134f1aeca8b3328d7e4fcdb981ceb5079" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">8495cd0</code></a>
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7ba6bf6a-1285-11ed-8a51-7d3baf6a6970">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7ba6bf6a-1285-11ed-8a51-7d3baf6a6970">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="MC44LjA="
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...0.8.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/0.8.0" data-view-component="true" class="Link--primary">UCO 0.8.0</a></h1>
+    
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>UCO 0.8.0 is primarily focused on an initial implementation of Shapes Constraint Language (SHACL) review of semi-open vocabulary usage, restructuring of all UCO ontology IRIs and file structures to enable delivery of ontology resources from a new subdomain, flattening action:ActionReferencesFacet properties directly onto action:Action, normalizing decimal number properties to xsd:decimal, improvements to unit and CI testing, numerous modifications and improvements to the Observable namespace, and correcting several minor issues and bugs.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.8.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2022-03-23T15:29:10Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.8.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2022-03-23T15:29:10Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="ZeL8q8cRtBX6dUnD0L3NBWaMGYlQa-HodE49t4_5Izf-W3z9UtYYiHN5Ol1nUsaGA-Dt-5JWiKK-gKJ4rLxtCw" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="RE_kwDOA1psOc4Duxkx">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+  <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2021-08-18T19:37:18Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/2760288?s=40&amp;v=4" alt="@sbarnum" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/sbarnum/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/sbarnum">sbarnum</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/0.7.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            0.7.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/c83bbcaf7841d5b7c1f8183a12d0afaf3806f699/hovercard" href="/ucoProject/UCO/commit/c83bbcaf7841d5b7c1f8183a12d0afaf3806f699" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">c83bbca</code></a><details class="dropdown dropdown-signed-commit details-reset details-overlay js-dropdown-details d-inline-block ml-1">
+    <summary class="color-fg-success"
+    title="Commit signature" >
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+    </summary>
+
+    <div class="anim-scale-in" style="position: relative; z-index: 200;">
+      <div class="dropdown-menu dropdown-menu-s py-0 color-fg-default text-left">
+
+        <div class="p-3 signed-commit-header d-flex">
+          <div class="pr-1">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified mr-2">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+          </div>
+          <div class="flex-1">
+                This commit was created on GitHub.com and signed with GitHub’s <strong class="signed-commit-verified-label">verified signature</strong>.
+          </div>
+        </div>
+
+
+        <div class="signed-commit-footer p-3 rounded-bottom-2">
+            <span class="d-block">GPG key ID: <span class="color-fg-muted">4AEE18F83AFDEB23</span></span>
+            <div class="my-1">
+            </div>
+          <a href="https://docs.github.com/github/authenticating-to-github/displaying-verification-statuses-for-all-of-your-commits">Learn about vigilant mode</a>.
+        </div>
+      </div>
+    </div>
+</details>
+
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7ba8a910-1285-11ed-8b90-55e7978f4ed1">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7ba8a910-1285-11ed-8b90-55e7978f4ed1">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="MC43LjA="
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...0.7.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/0.7.0" data-view-component="true" class="Link--primary">UCO 0.7.0</a></h1>
+    
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>UCO 0.7.0 is primarily focused on the conversion of UCO ontologies to leverage the Shapes Constraint Language (SHACL) rather than domain assertions and owl property restrictions to define class shapes. In addition, it added a Continuous Integration (CI) method for testing and verifying the ontology and it corrects several minor issues and bugs.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.7.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2021-08-18T19:25:59Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.7.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2021-08-18T19:25:59Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="VBJD-FCx4KzLW9pk8WcLRI8YRWjuM81qJOCvscTqS1rPq8OuxXZMMUJXqfpGiADH6nSxGiwOpCDuLjB-568FZg" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="MDc6UmVsZWFzZTQ4MDY4NzQ1">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+  <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2021-03-25T22:08:50Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/2760288?s=40&amp;v=4" alt="@sbarnum" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/sbarnum/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/sbarnum">sbarnum</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/0.6.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            0.6.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/c0e821dc4309c8bc529ac4e4e2fd52cacaac2b9e/hovercard" href="/ucoProject/UCO/commit/c0e821dc4309c8bc529ac4e4e2fd52cacaac2b9e" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">c0e821d</code></a><details class="dropdown dropdown-signed-commit details-reset details-overlay js-dropdown-details d-inline-block ml-1">
+    <summary class="color-fg-success"
+    title="Commit signature" >
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+    </summary>
+
+    <div class="anim-scale-in" style="position: relative; z-index: 200;">
+      <div class="dropdown-menu dropdown-menu-s py-0 color-fg-default text-left">
+
+        <div class="p-3 signed-commit-header d-flex">
+          <div class="pr-1">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified mr-2">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+          </div>
+          <div class="flex-1">
+                This commit was created on GitHub.com and signed with GitHub’s <strong class="signed-commit-verified-label">verified signature</strong>.
+          </div>
+        </div>
+
+
+        <div class="signed-commit-footer p-3 rounded-bottom-2">
+            <span class="d-block">GPG key ID: <span class="color-fg-muted">4AEE18F83AFDEB23</span></span>
+            <div class="my-1">
+            </div>
+          <a href="https://docs.github.com/github/authenticating-to-github/displaying-verification-statuses-for-all-of-your-commits">Learn about vigilant mode</a>.
+        </div>
+      </div>
+    </div>
+</details>
+
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7baad410-1285-11ed-87b0-92e0c088a19b">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7baad410-1285-11ed-87b0-92e0c088a19b">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="MC42LjA="
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...0.6.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/0.6.0" data-view-component="true" class="Link--primary">UCO 0.6.0</a></h1>
+    
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>UCO Version 0.6.0 is primarily focused on adding several community needed classes (URLHistory, refactoring Contact, OnlineService, Profile, etc) and properties, refactoring and cleaning up Address subclass structure, adding specific subclasses of ObservableObject, renaming of non-observable namespace Facet subclasses to include “Facet” at the end, clarifying and normalizing all class definitions to make the ontology more robust and complete, and cleanup of several minor issues and bugs.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.6.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2021-03-25T22:03:24Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.6.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2021-03-25T22:03:24Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="ozfo7YD_wQE6lCR9jR8QgWLWHw6Ld8frhrBP9CHBGbg4jmi7FThtnLOYV-M68BsCB7rrfElKrqFMftA7AoRXhA" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="MDc6UmVsZWFzZTQwNDQ1NTY0">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+  <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2020-11-18T18:51:01Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/2760288?s=40&amp;v=4" alt="@sbarnum" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/sbarnum/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/sbarnum">sbarnum</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/0.5.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            0.5.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/b33433b717dcdbd75635e4690f9e8269548207dd/hovercard" href="/ucoProject/UCO/commit/b33433b717dcdbd75635e4690f9e8269548207dd" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">b33433b</code></a><details class="dropdown dropdown-signed-commit details-reset details-overlay js-dropdown-details d-inline-block ml-1">
+    <summary class="color-fg-success"
+    title="Commit signature" >
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+    </summary>
+
+    <div class="anim-scale-in" style="position: relative; z-index: 200;">
+      <div class="dropdown-menu dropdown-menu-s py-0 color-fg-default text-left">
+
+        <div class="p-3 signed-commit-header d-flex">
+          <div class="pr-1">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified mr-2">
+    <path fill-rule="evenodd" d="M9.585.52a2.678 2.678 0 00-3.17 0l-.928.68a1.178 1.178 0 01-.518.215L3.83 1.59a2.678 2.678 0 00-2.24 2.24l-.175 1.14a1.178 1.178 0 01-.215.518l-.68.928a2.678 2.678 0 000 3.17l.68.928c.113.153.186.33.215.518l.175 1.138a2.678 2.678 0 002.24 2.24l1.138.175c.187.029.365.102.518.215l.928.68a2.678 2.678 0 003.17 0l.928-.68a1.17 1.17 0 01.518-.215l1.138-.175a2.678 2.678 0 002.241-2.241l.175-1.138c.029-.187.102-.365.215-.518l.68-.928a2.678 2.678 0 000-3.17l-.68-.928a1.179 1.179 0 01-.215-.518L14.41 3.83a2.678 2.678 0 00-2.24-2.24l-1.138-.175a1.179 1.179 0 01-.518-.215L9.585.52zM7.303 1.728c.415-.305.98-.305 1.394 0l.928.68c.348.256.752.423 1.18.489l1.136.174c.51.078.909.478.987.987l.174 1.137c.066.427.233.831.489 1.18l.68.927c.305.415.305.98 0 1.394l-.68.928a2.678 2.678 0 00-.489 1.18l-.174 1.136a1.178 1.178 0 01-.987.987l-1.137.174a2.678 2.678 0 00-1.18.489l-.927.68c-.415.305-.98.305-1.394 0l-.928-.68a2.678 2.678 0 00-1.18-.489l-1.136-.174a1.178 1.178 0 01-.987-.987l-.174-1.137a2.678 2.678 0 00-.489-1.18l-.68-.927a1.178 1.178 0 010-1.394l.68-.928c.256-.348.423-.752.489-1.18l.174-1.136c.078-.51.478-.909.987-.987l1.137-.174a2.678 2.678 0 001.18-.489l.927-.68zM11.28 6.78a.75.75 0 00-1.06-1.06L7 8.94 5.78 7.72a.75.75 0 00-1.06 1.06l1.75 1.75a.75.75 0 001.06 0l3.75-3.75z"></path>
+</svg>
+          </div>
+          <div class="flex-1">
+                This commit was created on GitHub.com and signed with GitHub’s <strong class="signed-commit-verified-label">verified signature</strong>.
+          </div>
+        </div>
+
+
+        <div class="signed-commit-footer p-3 rounded-bottom-2">
+            <span class="d-block">GPG key ID: <span class="color-fg-muted">4AEE18F83AFDEB23</span></span>
+            <div class="my-1">
+            </div>
+          <a href="https://docs.github.com/github/authenticating-to-github/displaying-verification-statuses-for-all-of-your-commits">Learn about vigilant mode</a>.
+        </div>
+      </div>
+    </div>
+</details>
+
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7bacd09e-1285-11ed-8b26-21e3fa974487">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7bacd09e-1285-11ed-8b26-21e3fa974487">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="MC41LjA="
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...0.5.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/0.5.0" data-view-component="true" class="Link--primary">UCO 0.5.0</a></h1>
+    
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>UCO 0.5.0 is primarily focused on the removal of the investigation namespace from UCO (that namespace now resides in the CASE ontology) and on the renaming of several classes (Observable subclasses, Facet subclasses) in the observable namespace and a single property (core:facet) to support improved alignment with the CASE ontology and the forthcoming addition of ObservableObject subclasses.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.5.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2020-11-18T18:49:54Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.5.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2020-11-18T18:49:54Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="dtpJHpmdNcHpZMhAf3vkNjNCMyOao77wSvg7TXyOz4LtY8lIDFqZXGBou97IlO-1Vi7HUVie17qANqSCX8uBvg" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="MDc6UmVsZWFzZTM0MTM0NzQ3">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+  <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2020-06-01T21:28:14Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/2760288?s=40&amp;v=4" alt="@sbarnum" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/sbarnum/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/sbarnum">sbarnum</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/0.4.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            0.4.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/e4a146ca332caabc8592130e71f8d3d316995ecd/hovercard" href="/ucoProject/UCO/commit/e4a146ca332caabc8592130e71f8d3d316995ecd" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">e4a146c</code></a>
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7baee19a-1285-11ed-8cc0-cdc67d1f5162">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7baee19a-1285-11ed-8cc0-cdc67d1f5162">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="MC40LjA="
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...0.4.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/0.4.0" data-view-component="true" class="Link--primary">0.4.0</a></h1>
+    
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>UCO Version 0.4.0 is primarily focused on fixing syntax &amp; structural errors, splitting domain assertions into companion files and moving some controlled vocabulary enumerations into a separate vocabulary namespace using a new specification approach.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.4.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2020-06-01T21:24:58Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/0.4.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2020-06-01T21:24:58Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="iW_d0Yv8OG2UqDkrbTABTDmyiVx3hS1k1J9sUbyHFQMS1l2HHjuU8B2kSrXa3wrPXN59LrW4RC4eUfOen8JbPw" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="MDc6UmVsZWFzZTI3MTEyNjkx">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+  <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2019-07-13T18:57:27Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/2760288?s=40&amp;v=4" alt="@sbarnum" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/sbarnum/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/sbarnum">sbarnum</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/v0.3.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            v0.3.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/7ed066161110c2eb3eb85a327bfd6d9f35c45e3d/hovercard" href="/ucoProject/UCO/commit/7ed066161110c2eb3eb85a327bfd6d9f35c45e3d" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">7ed0661</code></a>
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7bb0f002-1285-11ed-99de-e3844bd14baa">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7bb0f002-1285-11ed-99de-e3844bd14baa">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="djAuMy4w"
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...v0.3.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/v0.3.0" data-view-component="true" class="Link--primary">0.3.0</a></h1>
+    
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>The content of v0.3.0 is primarily of fixing lexical, syntactic and semantic reasoning errors present in v0.2.0 and simplifying in some areas. Its content is driven primarily from the initial base requirements of expressing cyber investigation information and is the product of input from the Cyberinvestigation Analysis Standard Expression (CASE) community.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/v0.3.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2019-07-13T18:56:03Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/v0.3.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2019-07-13T18:56:03Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="jOCVOV-jLDTYqqMuZsOgF0CQnJTDhx7Aw1ytvYRdfrYXWRVvymSAqVGm0LDRLKuUJfxo5gG6d4oJkjJypxgwig" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="MDc6UmVsZWFzZTE4NTk2Nzg2">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+  <div class="d-flex flex-column flex-md-row my-5 flex-justify-center">
+    <div class="col-md-2 d-flex flex-md-column flex-row flex-wrap pr-md-6 mb-2 mb-md-0 flex-items-start pt-md-4">
+  <div class="mb-2 f4 mr-3 mr-md-0 col-12">
+    <local-time datetime="2017-01-06T20:23:09Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time>
+  </div>
+
+    <div class="mb-md-2 mr-3 mr-md-0">
+      <img src="https://avatars.githubusercontent.com/u/2760288?s=40&amp;v=4" alt="@sbarnum" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" />
+      <a class="color-fg-muted wb-break-all" data-hovercard-type="user" data-hovercard-url="/users/sbarnum/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/sbarnum">sbarnum</a>
+    </div>
+
+    <div class="mr-3 mr-md-0 d-flex" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a href="/ucoProject/UCO/tree/v0.1.0" data-view-component="true" class="Link--muted">
+        <div data-view-component="true" class="css-truncate css-truncate-target">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag">
+    <path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path>
+</svg>
+          <span class="ml-1 wb-break-all">
+            v0.1.0
+          </span>
+</div></a>      
+    </div>
+    <div style="position: relative; top: 1px;" class="mb-md-2 mr-3 mr-md-0" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      <a data-hovercard-type="commit" data-hovercard-url="/ucoProject/UCO/commit/6b4aae6e293ca5223fbe8f928554a81461ab438d/hovercard" href="/ucoProject/UCO/commit/6b4aae6e293ca5223fbe8f928554a81461ab438d" data-view-component="true" class="Link--muted mb-2">
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit">
+    <path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path>
+</svg>
+        <code class="f5 ml-1 wb-break-all">6b4aae6</code></a>
+    </div>
+    <div class="mb-md-2 mr-3 mr-md-0 hide-sm">
+      
+<details class="details-reset details-overlay " id="tag-select-menu-7bb2c954-1285-11ed-86b9-3a84b25c9546">
+  <summary data-view-component="true" class="btn-sm btn text-left">  <i></i><span data-menu-button="">Compare</span><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down ml-2 mr-n1">
+    <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>
+</svg>
+  
+</summary>
+  <details-menu class="SelectMenu text-md-left " style="z-index: 500">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">Choose a tag to compare</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="tag-select-menu-7bb2c954-1285-11ed-86b9-3a84b25c9546">
+          <svg aria-label="Close menu" aria-hidden="false" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+        </button>
+      </header>
+
+      <div class="SelectMenu-filter">
+        <input
+          aria-label="Find a tag"
+          autofocus
+          class="SelectMenu-input form-control"
+          data-ref-filter
+          placeholder="Find a tag"
+          type="text"
+>
+      </div>
+
+      <ref-selector
+        type="tag"
+        query-endpoint="/ucoProject/UCO/refs"
+        cache-key="v0:1659226584.971136"
+        current-committish="djAuMS4w"
+        default-branch="bWFzdGVy"
+        
+        name-with-owner="dWNvUHJvamVjdC9VQ08="
+        
+        prefetch-on-mouseover
+      >
+        <template data-target="ref-selector.fetchFailedTemplate">
+          <div class="SelectMenu-message" data-index="{{ index }}">Could not load tags</div>
+        </template>
+
+        <template data-target="ref-selector.noMatchTemplate">
+            <div class="SelectMenu-message" data-index="{{ index }}">Nothing to show</div>
+        </template>
+
+          <template data-target="ref-selector.itemTemplate">
+  <a href="/ucoProject/UCO/compare/{{ urlEncodedRefName }}...v0.1.0" class="SelectMenu-item" role="menuitemradio" rel="nofollow" aria-checked="{{ isCurrent }}" data-index="{{ index }}">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check SelectMenu-icon SelectMenu-icon--check">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    <span class="flex-1 css-truncate css-truncate-overflow {{ isFilteringClass }}">{{ refName }}</span>
+    <span hidden="{{ isNotDefault }}" class="Label Label--secondary flex-self-start">default</span>
+  </a>
+</template>
+
+
+        <template data-target="ref-selector.hiddenCurrentItemTemplate">
+          <input hidden="hidden" type="radio" value="{{ refName }}" checked="checked" name="" id="" />
+        </template>
+
+        <div data-target="ref-selector.listContainer" role="menu" class="SelectMenu-list" style="max-height: 330px">
+          <div class="SelectMenu-loading pt-3 pb-0 overflow-hidden" aria-label="Menu is loading">
+            <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>
+          </div>
+        </div>
+          <footer class="SelectMenu-footer"><a href="/ucoProject/UCO/tags">View all tags</a></footer>
+      </ref-selector>
+    </div>
+  </details-menu>
+</details>
+    </div>
+</div>
+
+
+    <div class="col-md-9" data-test-selector="release-card" >
+  <div data-view-component="true" class="Box">
+  
+  <div data-view-component="true" class="Box-body">        <div class="float-right d-none d-md-block">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+
+<div class="d-flex flex-row mb-3 wb-break-word">
+  <div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+    <h1 data-view-component="true" class="d-inline mr-3"><a href="/ucoProject/UCO/releases/tag/v0.1.0" data-view-component="true" class="Link--primary">Initial draft (v0.1.0) release of UCO</a></h1>
+    <span data-view-component="true" class="Label Label--warning Label--large v-align-text-bottom d-none d-md-inline-block">Pre-release</span>
+      <div class="v-align-text-bottom ml-2 d-none d-md-inline">
+          
+      </div>
+  </div>
+
+  <div class="mt-3 d-md-none">
+    <span data-view-component="true" class="Label Label--warning Label--large v-align-text-bottom">Pre-release</span>
+  </div>
+      <div class="ml-2 mt-3 d-md-none">
+        
+      </div>
+</div>
+
+
+  <div class="d-md-none border-bottom mb-4 pb-4">
+                  <div class="d-flex flex-items-center ml-md-5 mt-md-3">
+            </div>
+
+  </div>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body my-3"><p>The content of v0.1.0 is driven primarily from the initial base requirements of expressing cyber investigation information and is the product of input from the <a href="https://github.com/casework/case">Cyberinvestigation Analysis Standard Expression (CASE)</a> community.</p>
+<p>This is an initial draft version of the ontology intended for informal exploration, experimentation, implementation and collaborative feedback from the community.</p>
+<p>As such, v0.1.0 consists of solely of the following simple artifacts:</p>
+<ul>
+<li><a href="https://github.com/ucoProject/uco/blob/master/model/uco-1.0-draft.uml.mdzip">A MagicDraw UML conceptual model of the ontology</a></li>
+<li><a href="https://github.com/ucoProject/uco/tree/master/model/images">A set of UML class diagrams illustrating key portions of the ontology UML conceptual model</a></li>
+<li><a href="https://github.com/ucoProject/uco/blob/master/documentation/uco-v0.1.0-natural-language-glossary.html">An overall natural language glossary autogenerated from the UML conceptual model</a></li>
+</ul>
+<p>Future versions of UCO will not only expand and refine the ontology itself but will also provide more complete and formalized documentation.</p></div>
+</div>
+  <div data-view-component="true" class="Box-footer">
+        <div class="mb-3">
+          <details data-view-component="true">
+  <summary role="button" data-view-component="true">    <h3 class="d-inline">Assets</h3>
+    <span title="2" data-view-component="true" class="Counter ml-1">2</span>
+</summary>
+  <div data-view-component="true">      <div data-view-component="true" class="Box Box--condensed mt-3">
+  
+  
+    <ul>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/v0.1.0.zip" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (zip)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2017-01-05T21:20:02Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+        <li data-view-component="true" class="Box-row d-flex flex-column flex-md-row">            <div data-view-component="true" class="d-flex flex-justify-start col-12 col-lg-9">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-zip color-fg-muted">
+    <path fill-rule="evenodd" d="M3.5 1.75a.25.25 0 01.25-.25h3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h2.086a.25.25 0 01.177.073l2.914 2.914a.25.25 0 01.073.177v8.586a.25.25 0 01-.25.25h-.5a.75.75 0 000 1.5h.5A1.75 1.75 0 0014 13.25V4.664c0-.464-.184-.909-.513-1.237L10.573.513A1.75 1.75 0 009.336 0H3.75A1.75 1.75 0 002 1.75v11.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217V1.75zM8.75 3a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM6 5.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 016 5.25zm2 1.5A.75.75 0 018.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 6.75zm-1.25.75a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM8 9.75A.75.75 0 018.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 018 9.75zm-.75.75a1.75 1.75 0 00-1.75 1.75v3c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-3a1.75 1.75 0 00-1.75-1.75h-.5zM7 12.25a.25.25 0 01.25-.25h.5a.25.25 0 01.25.25v2.25H7v-2.25z"></path>
+</svg>
+              <a href="/ucoProject/UCO/archive/refs/tags/v0.1.0.tar.gz" rel="nofollow" data-skip-pjax>
+                <span class="px-1 text-bold">Source code</span>
+                (tar.gz)
+              </a>
+</div>            <div data-view-component="true" class="d-flex flex-auto flex-justify-end col-md-4 ml-3 ml-md-0 mt-1 mt-md-0 pl-1 pl-md-0">
+                <span style="white-space: nowrap;" data-view-component="true" class="color-fg-muted text-right flex-shrink-0 flex-grow-0 ml-3"><local-time datetime="2017-01-05T21:20:02Z" month="short" day="2-digit" year="numeric" class="no-wrap"></local-time></span>
+</div></li>
+    </ul>
+  
+</div></div>
+</details>
+        </div>
+
+
+          <div class="d-flex flex-row flex-wrap flex-justify-between js-comment">
+              <div data-view-component="true" class="comment-reactions js-reactions-container js-reaction-buttons-container social-reactions reactions-container flex-row-reverse flex-justify-end d-flex">
+    <div data-view-component="true" class="color-fg-muted mt-1"></div>
+  <form class="js-pick-reaction" data-turbo="false" action="/ucoProject/UCO/reactions" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" autocomplete="off" /><input type="hidden" name="authenticity_token" value="VjvntynPsx0n29neyEGaH6r0Kod7KhQSKU4pjlx1KCDNgmfhvAgfgK7XqkB_rpGcz5je9bkXfVjjgLZBfzBmHA" autocomplete="off" />
+    <input type="hidden" name="input[subjectId]" value="MDc6UmVsZWFzZTUwOTE1MjM=">
+    <div  class="js-comment-reactions-options d-flex flex-items-center flex-row flex-wrap">
+      <details hidden="hidden" data-view-component="true" class="js-all-reactions-popover details-overlay details-reset position-relative">
+  <summary role="button" data-view-component="true" class="btn-link btn-sm">  All reactions
+  
+</summary>
+  <details-menu data-view-component="true">          <ul>
+          </ul>
+</details-menu>
+</details>    </div>
+</form>
+</div>
+          </div>
+</div>
+</div></div>
+
+  </div>
+
+
+    <div class="paginate-container d-none d-sm-flex flex-sm-justify-center" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      
+    </div>
+
+    <div class="paginate-container d-sm-none mb-5" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame">
+      
+    </div>
+</div>
+
+</div>
+
+
+  </div>
+
+  </turbo-frame>
+
+
+    </main>
+  </div>
+
+  </div>
+
+          <footer class="footer width-full container-xl p-responsive">
+  <h2 class='sr-only'>Footer</h2>
+
+  <div class="position-relative d-flex flex-items-center pb-2 f6 color-fg-muted border-top color-border-muted flex-column-reverse flex-lg-row flex-wrap flex-lg-nowrap mt-6 pt-6">
+    <div class="list-style-none d-flex flex-wrap col-0 col-lg-2 flex-justify-start flex-lg-justify-between mb-2 mb-lg-0">
+      <div class="mt-2 mt-lg-0 d-flex flex-items-center">
+        <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-2" href="https://github.com">
+          <svg aria-hidden="true" height="24" viewBox="0 0 16 16" version="1.1" width="24" data-view-component="true" class="octicon octicon-mark-github">
+    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+</svg>
+</a>        <span>
+        &copy; 2022 GitHub, Inc.
+        </span>
+      </div>
+    </div>
+
+    <nav aria-label='footer' class="col-12 col-lg-8">
+      <h3 class='sr-only' id='sr-footer-heading'>Footer navigation</h3>
+      <ul class="list-style-none d-flex flex-wrap col-12 flex-justify-center flex-lg-justify-between mb-2 mb-lg-0" aria-labelledby='sr-footer-heading'>
+          <li class="mr-3 mr-lg-0"><a href="https://docs.github.com/en/github/site-policy/github-terms-of-service" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to terms&quot;,&quot;label&quot;:&quot;text:terms&quot;}">Terms</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://docs.github.com/en/github/site-policy/github-privacy-statement" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to privacy&quot;,&quot;label&quot;:&quot;text:privacy&quot;}">Privacy</a></li>
+          <li class="mr-3 mr-lg-0"><a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to security&quot;,&quot;label&quot;:&quot;text:security&quot;}" href="https://github.com/security">Security</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://www.githubstatus.com/" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to status&quot;,&quot;label&quot;:&quot;text:status&quot;}">Status</a></li>
+          <li class="mr-3 mr-lg-0"><a data-ga-click="Footer, go to help, text:Docs" href="https://docs.github.com">Docs</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://support.github.com?tags=dotcom-footer" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to contact&quot;,&quot;label&quot;:&quot;text:contact&quot;}">Contact GitHub</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://github.com/pricing" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to Pricing&quot;,&quot;label&quot;:&quot;text:Pricing&quot;}">Pricing</a></li>
+        <li class="mr-3 mr-lg-0"><a href="https://docs.github.com" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to api&quot;,&quot;label&quot;:&quot;text:api&quot;}">API</a></li>
+        <li class="mr-3 mr-lg-0"><a href="https://services.github.com" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to training&quot;,&quot;label&quot;:&quot;text:training&quot;}">Training</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://github.blog" data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to blog&quot;,&quot;label&quot;:&quot;text:blog&quot;}">Blog</a></li>
+          <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="d-flex flex-justify-center pb-6">
+    <span class="f6 color-fg-muted"></span>
+  </div>
+</footer>
+
+
+
+
+  <div id="ajax-error-message" class="ajax-error-message flash flash-error" hidden>
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
+    <path fill-rule="evenodd" d="M8.22 1.754a.25.25 0 00-.44 0L1.698 13.132a.25.25 0 00.22.368h12.164a.25.25 0 00.22-.368L8.22 1.754zm-1.763-.707c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0114.082 15H1.918a1.75 1.75 0 01-1.543-2.575L6.457 1.047zM9 11a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"></path>
+</svg>
+    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+    </button>
+    You can’t perform that action at this time.
+  </div>
+
+  <div class="js-stale-session-flash flash flash-warn flash-banner" hidden
+    >
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
+    <path fill-rule="evenodd" d="M8.22 1.754a.25.25 0 00-.44 0L1.698 13.132a.25.25 0 00.22.368h12.164a.25.25 0 00.22-.368L8.22 1.754zm-1.763-.707c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0114.082 15H1.918a1.75 1.75 0 01-1.543-2.575L6.457 1.047zM9 11a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"></path>
+</svg>
+    <span class="js-stale-session-flash-signed-in" hidden>You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    <span class="js-stale-session-flash-signed-out" hidden>You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+  </div>
+    <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default color-fg-default hx_rsm" open>
+    <summary role="button" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast hx_rsm-dialog hx_rsm-modal">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+</svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
+
+    <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
+  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box color-shadow-large" style="width:360px;">
+  </div>
+</div>
+
+    <template id="snippet-clipboard-copy-button">
+  <div class="zeroclipboard-container position-absolute right-0 top-0">
+    <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+    <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+</svg>
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+</svg>
+    </clipboard-copy>
+  </div>
+</template>
+
+
+
+
+  </body>
+</html>
+


### PR DESCRIPTION
Added files needed by Protege (Stanford's RDF IDE desktop tool).
Instruction:
1. Run Protege RDF IDE, then
2. use 'Open' -> choose the file root file "UCO/LoadUCO.ttl" (the root UCO ttl file)
3. Then, Protege IDE will automatically load all "UCO ontologies" one-by-one until all UCO ontologies are completed.