### PR TITLE
Issue 416: Change name of Event to EventRecord

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -2622,25 +2622,36 @@ observable:EnvironmentVariable
 	sh:targetClass observable:EnvironmentVariable ;
 	.
 
-observable:Event
+observable:EventLog
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf observable:ObservableObject ;
-	rdfs:label "Event"@en ;
-	rdfs:comment "An event is something that happens in a digital context (e.g., operating system events)."@en ;
-	sh:targetClass observable:Event ;
+	rdfs:label "EventLog"@en ;
+	rdfs:comment "An event log is a collection of event records."@en ;
+	sh:targetClass observable:EventLog ;
 	.
 
-observable:EventFacet
+observable:EventRecord
+	a
+		owl:Class ,
+		sh:NodeShape
+		;
+	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:label "EventRecord"@en ;
+	rdfs:comment "An event record is something that happens in a digital context (e.g., operating system events)."@en ;
+	sh:targetClass observable:EventRecord ;
+	.
+
+observable:EventRecordFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf core:Facet ;
-	rdfs:label "EventFacet"@en ;
-	rdfs:comment "An event facet is a grouping of characteristics unique to something that happens in a digital context (e.g., operating system events)."@en ;
+	rdfs:label "EventRecordFacet"@en ;
+	rdfs:comment "An event record facet is a grouping of characteristics unique to something that happens in a digital context (e.g., operating system events)."@en ;
 	sh:property
 		[
 			sh:class observable:ObservableAction ;
@@ -2698,18 +2709,7 @@ observable:EventFacet
 			sh:path observable:eventType ;
 		]
 		;
-	sh:targetClass observable:EventFacet ;
-	.
-
-observable:EventLog
-	a
-		owl:Class ,
-		sh:NodeShape
-		;
-	rdfs:subClassOf observable:ObservableObject ;
-	rdfs:label "EventLog"@en ;
-	rdfs:comment "An event log is a recorded collection of events."@en ;
-	sh:targetClass observable:EventLog ;
+	sh:targetClass observable:EventRecordFacet ;
 	.
 
 observable:ExtInodeFacet


### PR DESCRIPTION
Changed Event to EventRecord, and EventFacet to EventRecordFacet.

This Pull Request changes the EventFacet to EventRecordFacet, which resolves ambiguity raised in discussion of Issues #375 and #396 and #401.


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current `unstable` branch ([f4d3747](https://github.com/ucoProject/UCO-Archive/commit/f4d3747aad9fdbe701f9aa5dfed9f3371a2ebc40))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([2058e66](https://github.com/casework/CASE-Archive/commit/2058e66e9e8042509c151a1d9b722d8badd4aa34))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/eed38ac7ccc82923aa75216a3b0df354abcc0d6d) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A - `Event` not used)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/60e6b424a49fa2efafcd592971fe5e417af28679) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A - `Event` not used)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->