### PR TITLE
Rename ToolConfigurationFacet from ToolConfigurationTypeFacet in Update tool.ttl

### DIFF
--- a/ontology/tool/tool.ttl
+++ b/ontology/tool/tool.ttl
@@ -356,14 +356,14 @@ tool:Tool
 	sh:targetClass tool:Tool ;
 	.
 
-tool:ToolConfigurationTypeFacet
+tool:ToolConfigurationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf core:Facet ;
-	rdfs:label "ToolConfigurationTypeFacet"@en ;
-	rdfs:comment "A tool configuration type facet is a grouping of characteristics unique to the instantial settings and setup of a tool."@en ;
+	rdfs:label "ToolConfigurationFacet"@en ;
+	rdfs:comment "A tool configuration facet is a grouping of characteristics unique to the instantial settings and setup of a tool."@en ;
 	sh:property
 		[
 			sh:class tool:DependencyType ;
@@ -376,7 +376,7 @@ tool:ToolConfigurationTypeFacet
 			sh:path tool:usageContextAssumptions ;
 		]
 		;
-	sh:targetClass tool:ToolConfigurationTypeFacet ;
+	sh:targetClass tool:ToolConfigurationFacet ;
 	.
 
 tool:buildConfiguration


### PR DESCRIPTION
This pull request relates to [Issue #451](https://github.com/ucoProject/UCO/issues/451), and the updating of the turtle file tool.ttl

Renaming of old Facet ToolConfigurationTypeFacet to ToolConfigurationFacet, which required changes to four (4) lines to within  the turtle file **_tool.ttl_**.

The changes made are:
1. Remove the text "Type" from the facet "ToolConfigurationTypeFacet", so that it becomes "**ToolConfigurationFacet**" (changes on lines 359, 365, 379), and 
2. Update the comment by replacing "A tool configuration type facet...." with "A **tool configuration facet**...." (line 366).

The change is expected to be low risk


# Coordination

- [ ] Pull Request is against correct branch
- [ ] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [ ] CI passes in (CASE/UCO) feature branch
- [ ] CI passes in UCO current `unstable` branch ([merge-commit](#TODO-commit))
- [ ] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([merge-commit](#TODO-commit))
- [ ] Impact on SHACL validation [reviewed](#TODO-commit) for CASE-Examples
- [ ] Impact on SHACL validation [remediated](#TODO-commit) for CASE-Examples <!--In primary or feature branch, no ...validation-unstable.ttl files show negative impact from PR.-->
- [ ] Impact on SHACL validation [reviewed](#TODO-commit) for casework.github.io
- [ ] Impact on SHACL validation [remediated](#TODO-commit) for casework.github.io <!--In primary or feature branch, no ...validation-unstable.ttl files show negative impact from PR.-->
- [ ] Milestone linked
- [ ] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->