### PR TITLE
Cut errant rdf:List artifact

### DIFF
--- a/tests/examples/hash_XFAIL_validation.ttl
+++ b/tests/examples/hash_XFAIL_validation.ttl
@@ -7,17 +7,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
-	rdf:first "SHA1"^^vocabulary:HashNameVocab ;
-	rdf:rest (
-		"SHA224"^^vocabulary:HashNameVocab
-		"SHA256"^^vocabulary:HashNameVocab
-		"SHA384"^^vocabulary:HashNameVocab
-		"SHA512"^^vocabulary:HashNameVocab
-		"SSDEEP"^^vocabulary:HashNameVocab
-	) ;
-	.
-
-[]
 	a sh:ValidationReport ;
 	sh:conforms "false"^^xsd:boolean ;
 	sh:result


### PR DESCRIPTION
This Pull Request is a cleanup to side effects from what is currently suspected to have come from either Issue #406 , from an unrealized effect in the release of `rdflib` 6.2.0, or both.  The submitter believes risk from adoption, to UCO and downstream ontologies, is zero.

Somewhere in the chain between core `rdflib`, `pyshacl`, and `rdf-toolkit.jar`, the normalized Turtle content sometimes picks up redundant `rdf:List` artifacts that vary between runs.  The anonymous list cut in this patch has been seen to waver in how much of it is left as a detached blank node, here and in other CASE examples.

The first patch in this PR removes the orphaned list.  Guidance needs to be provided that, as long as this bug in the tool stack persists, the Make-managed generated output should not have it Git-tracked.


Review steps taken:

- Tracking in Jira ticket [OC-266](https://unifiedcyberontology.atlassian.net/browse/OC-266)
- [x] Pull request is against correct branch
- [x] CI passes in (CASE/UCO) feature branch
- [x] CI passes in (CASE/UCO) current unstable branch ([a5691aa](https://github.com/ucoProject/UCO-Archive/commit/a5691aa33949ca306ffd7607e0fc29cdb25e5b4e))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/bb2858d02fc86b442b1024bad4c83930f23a0d86) for CASE-Examples
- [x] Impact on SHACL validation [remediated](https://github.com/casework/CASE-Examples/commit/bb2858d02fc86b442b1024bad4c83930f23a0d86) for CASE-Examples
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/2556f05ff8226856a4947a35bc0dd59ce4935077) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*