### PR TITLE
Issue 379: Designate and test core:hasFacet as an inverse-functional property

### DIFF
--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -475,7 +475,10 @@ core:externalReference
 	.
 
 core:hasFacet
-	a owl:ObjectProperty ;
+	a
+		owl:ObjectProperty ,
+		owl:InverseFunctionalProperty
+		;
 	rdfs:label "hasFacet"@en ;
 	rdfs:comment "Further sets of properties characterizing a concept based on the particular context of the class and of the particular instance of the concept being characterized."@en ;
 	rdfs:range core:Facet ;

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -484,6 +484,29 @@ core:hasFacet
 	rdfs:range core:Facet ;
 	.
 
+core:hasFacet-shape
+	a sh:PropertyShape ;
+	sh:path core:hasFacet ;
+	sh:sparql [
+		a sh:SPARQLConstraint ;
+		sh:message "hasFacet must not be used to link two objects to one Facet."@en ;
+		sh:select """
+			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
+			SELECT $this ?value
+			WHERE {
+				?value core:hasFacet $this .
+				?nOtherValue core:hasFacet $this .
+				FILTER ( ?value != ?nOtherValue )
+				FILTER NOT EXISTS {
+					?value owl:sameAs|^owl:sameAs ?nOtherValue .
+				}
+			}
+			""" ;
+	] ;
+	sh:targetObjectsOf core:hasFacet ;
+	.
+
 core:id
 	a owl:DatatypeProperty ;
 	rdfs:label "id"@en ;

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -23,6 +23,8 @@ all: \
   action_result_PASS_validation.ttl \
   co_PASS_validation.ttl \
   co_XFAIL_validation.ttl \
+  has_facet_inverse_functional_PASS_validation.ttl \
+  has_facet_inverse_functional_XFAIL_validation.ttl \
   hash_PASS_validation.ttl \
   hash_XFAIL_validation.ttl \
   location_PASS_validation.ttl \
@@ -84,6 +86,8 @@ check: \
   action_result_PASS_validation.ttl \
   co_PASS_validation.ttl \
   co_XFAIL_validation.ttl \
+  has_facet_inverse_functional_PASS_validation.ttl \
+  has_facet_inverse_functional_XFAIL_validation.ttl \
   hash_PASS_validation.ttl \
   hash_XFAIL_validation.ttl \
   location_PASS_validation.ttl \

--- a/tests/examples/has_facet_inverse_functional_PASS.json
+++ b/tests/examples/has_facet_inverse_functional_PASS.json
@@ -1,0 +1,30 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "owl": "http://www.w3.org/2002/07/owl#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:facet-1",
+            "@type": "core:Facet"
+        },
+        {
+            "@id": "kb:object-1",
+            "@type": "core:UcoObject",
+            "core:hasFacet": {
+                "@id": "kb:facet-1"
+            },
+            "owl:sameAs": {
+                "@id": "kb:object-2"
+            }
+        },
+        {
+            "@id": "kb:object-2",
+            "@type": "core:UcoObject",
+            "core:hasFacet": {
+                "@id": "kb:facet-1"
+            }
+        }
+    ]
+}

--- a/tests/examples/has_facet_inverse_functional_PASS_validation.ttl
+++ b/tests/examples/has_facet_inverse_functional_PASS_validation.ttl
@@ -1,0 +1,11 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "true"^^xsd:boolean ;
+	.
+

--- a/tests/examples/has_facet_inverse_functional_XFAIL.json
+++ b/tests/examples/has_facet_inverse_functional_XFAIL.json
@@ -1,0 +1,26 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "core": "https://ontology.unifiedcyberontology.org/uco/core/"
+    },
+    "@graph": [
+        {
+            "@id": "kb:facet-1",
+            "@type": "core:Facet"
+        },
+        {
+            "@id": "kb:object-1",
+            "@type": "core:UcoObject",
+            "core:hasFacet": {
+                "@id": "kb:facet-1"
+            }
+        },
+        {
+            "@id": "kb:object-2",
+            "@type": "core:UcoObject",
+            "core:hasFacet": {
+                "@id": "kb:facet-1"
+            }
+        }
+    ]
+}

--- a/tests/examples/has_facet_inverse_functional_XFAIL_validation.ttl
+++ b/tests/examples/has_facet_inverse_functional_XFAIL_validation.ttl
@@ -1,0 +1,68 @@
+@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/facet-1> ;
+			sh:resultMessage "hasFacet must not be used to link two objects to one Facet." ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraint [
+				a sh:SPARQLConstraint ;
+				sh:message "hasFacet must not be used to link two objects to one Facet."@en ;
+				sh:select """
+			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
+			SELECT $this ?value
+			WHERE {
+				?value core:hasFacet $this .
+				?nOtherValue core:hasFacet $this .
+				FILTER ( ?value != ?nOtherValue )
+				FILTER NOT EXISTS {
+					?value owl:sameAs|^owl:sameAs ?nOtherValue .
+				}
+			}
+			""" ;
+			] ;
+			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+			sh:sourceShape core:hasFacet-shape ;
+			sh:value <http://example.org/kb/object-1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/facet-1> ;
+			sh:resultMessage "hasFacet must not be used to link two objects to one Facet." ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraint [
+				a sh:SPARQLConstraint ;
+				sh:message "hasFacet must not be used to link two objects to one Facet."@en ;
+				sh:select """
+			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
+			SELECT $this ?value
+			WHERE {
+				?value core:hasFacet $this .
+				?nOtherValue core:hasFacet $this .
+				FILTER ( ?value != ?nOtherValue )
+				FILTER NOT EXISTS {
+					?value owl:sameAs|^owl:sameAs ?nOtherValue .
+				}
+			}
+			""" ;
+			] ;
+			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+			sh:sourceShape core:hasFacet-shape ;
+			sh:value <http://example.org/kb/object-2> ;
+		]
+		;
+	.
+

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -177,6 +177,21 @@ def test_action_result_PASS_validation():
     g = load_validation_graph("action_result_PASS_validation.ttl", True)
     assert isinstance(g, rdflib.Graph)
 
+def test_has_facet_inverse_functional_PASS() -> None:
+    confirm_validation_results(
+      "has_facet_inverse_functional_PASS_validation.ttl",
+      True
+    )
+
+def test_has_facet_inverse_functional_XFAIL() -> None:
+    confirm_validation_results(
+      "has_facet_inverse_functional_XFAIL_validation.ttl",
+      False,
+      expected_focus_node_severities={
+        ("http://example.org/kb/facet-1", str(NS_SH.Violation))
+      }
+    )
+
 def test_hash_PASS() -> None:
     g = load_validation_graph("hash_PASS_validation.ttl", True)
     assert isinstance(g, rdflib.Graph)


### PR DESCRIPTION
This Pull Request resolves all requirements of Issue #379 .


# Coordination

- [x] Pull request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current unstable branch ([fa3da83](https://github.com/ucoProject/UCO-Archive/commit/fa3da83a1e5448a5008c8f5563ff0a6533462086))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([ea8a0ad](https://github.com/casework/CASE-Archive/commit/ea8a0ad88a8fc74fbe95f67d4a6646661393ea5d)) *(This was not the precise commit introducing the review, but the `unstable` UCO state is incorporated before this point)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/6e34a85d05420904e99019a65e5dfeb25e8ae006) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/84426cbf6ec6d85d4e3e8bcdc14de7e186cecf83) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Solutions Approval vote logged on corresponding Issue