### PR TITLE
Remove usage of sh:declare

### DIFF
--- a/ontology/owl/owl.ttl
+++ b/ontology/owl/owl.ttl
@@ -9,16 +9,6 @@
 	a owl:Ontology ;
 	rdfs:comment "This ontology defines SHACL shapes to perform conformance testing of OWL 2 DL.  Some of these shapes follow rules specified from the canonical, subtractive parsing process of Section 3 of the OWL 2 mapping to RDF.  From the last line of that document's Section 3, 'At the end of this process, the graph G MUST be empty,' anything not strictly matching patterns specified in that section cause the input graph to be non-conformant with OWL 2 DL."@en ;
 	rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-mapping-to-rdf-20121211/#Mapping_from_RDF_Graphs_to_the_Structural_Specification> ;
-	sh:declare
-		[
-			sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
-			sh:prefix "owl" ;
-		] ,
-		[
-			sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
-			sh:prefix "sh" ;
-		]
-		;
 	.
 
 uco-owl:Axiom-shape
@@ -28,8 +18,8 @@ uco-owl:Axiom-shape
 		rdfs:comment "This requirement is determined from review of the canonical parsing process in Section 3 of the OWL 2 mapping to RDF.  All references to owl:Axioms are identified as blank nodes.  Therefore, any non-blank node that is an owl:Axiom will not be mapped and consumed by the mapping process."@en ;
 		rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-mapping-to-rdf-20121211/#Mapping_from_RDF_Graphs_to_the_Structural_Specification> ;
 		sh:message "An owl:Axiom must be a blank node."@en ;
-		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:Axiom .
@@ -46,11 +36,9 @@ uco-owl:DatatypeProperty-shacl-constraints-shape
 		[
 			a sh:SPARQLConstraint ;
 			sh:message "An OWL Datatype Property cannot use a SHACL ClassConstraintComponent."@en ;
-			sh:prefixes
-				<http://www.w3.org/1999/02/22-rdf-syntax-ns#> ,
-				<http://www.w3.org/ns/shacl#>
-				;
 			sh:select """
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX sh: <http://www.w3.org/ns/shacl#>
 				SELECT $this
 				WHERE {
 					$value
@@ -63,11 +51,9 @@ uco-owl:DatatypeProperty-shacl-constraints-shape
 		[
 			a sh:SPARQLConstraint ;
 			sh:message "An OWL Datatype Property must not permit a non-Literal value via SHACL constraints."@en ;
-			sh:prefixes
-				<http://www.w3.org/1999/02/22-rdf-syntax-ns#> ,
-				<http://www.w3.org/ns/shacl#>
-				;
 			sh:select """
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX sh: <http://www.w3.org/ns/shacl#>
 				SELECT $this
 				WHERE {
 					$value sh:path / rdf:rest* / rdf:first? $this .
@@ -94,8 +80,8 @@ uco-owl:Disjointedness-AP-DP-shape
 		a sh:SPARQLConstraint ;
 		rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
 		sh:message "An IRI may not be a member of both an owl:AnnotationProperty and owl:DatatypeProperty."@en ;
-		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:DatatypeProperty ;
@@ -111,8 +97,8 @@ uco-owl:Disjointedness-AP-OP-shape
 		a sh:SPARQLConstraint ;
 		rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
 		sh:message "An IRI may not be a member of both an owl:AnnotationProperty and owl:ObjectProperty."@en ;
-		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:ObjectProperty ;
@@ -128,8 +114,8 @@ uco-owl:Disjointedness-C-DT-shape
 		a sh:SPARQLConstraint ;
 		rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
 		sh:message "An IRI may not be a member of both an owl:Class and owl:Datatype."@en ;
-		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:Datatype ;
@@ -145,8 +131,8 @@ uco-owl:Disjointedness-DP-OP-shape
 		a sh:SPARQLConstraint ;
 		rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
 		sh:message "An IRI may not be a member of both owl:DatatypeProperty and owl:ObjectProperty."@en ;
-		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:ObjectProperty ;
@@ -184,8 +170,9 @@ uco-owl:ObjectProperty-shacl-constraints-shape
 		[
 			a sh:SPARQLConstraint ;
 			sh:message "An OWL Object Property cannot use a SHACL DatatypeConstraintComponent."@en ;
-			sh:prefixes <http://www.w3.org/ns/shacl#> ;
 			sh:select """
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX sh: <http://www.w3.org/ns/shacl#>
 				SELECT $this
 				WHERE {
 					$value
@@ -198,8 +185,8 @@ uco-owl:ObjectProperty-shacl-constraints-shape
 		[
 			a sh:SPARQLConstraint ;
 			sh:message "An OWL Object Property must not permit a Literal value via SHACL consraints."@en ;
-			sh:prefixes <http://www.w3.org/ns/shacl#> ;
 			sh:select """
+				PREFIX sh: <http://www.w3.org/ns/shacl#>
 				SELECT $this
 				WHERE {
 					$value sh:path / rdf:rest* / rdf:first? $this ;
@@ -227,8 +214,8 @@ uco-owl:ontologyIRI-shape
 		a sh:SPARQLConstraint ;
 		rdfs:seeAlso <https://www.w3.org/TR/owl2-syntax/#Ontology_IRI_and_Version_IRI> ;
 		sh:message "'If an ontology has an ontology IRI but no version IRI, then a different ontology with the same ontology IRI but no version IRI SHOULD NOT exist.'"@en ;
-		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$value owl:ontologyIRI $this .
@@ -259,8 +246,8 @@ uco-owl:versionIRI-shape
 			a sh:SPARQLConstraint ;
 			rdfs:seeAlso <https://www.w3.org/TR/owl2-syntax/#Ontology_IRI_and_Version_IRI> ;
 			sh:message "'An ontology without an ontology IRI MUST NOT contain a version IRI.'"@en ;
-			sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 			sh:select """
+				PREFIX owl: <http://www.w3.org/2002/07/owl#>
 				SELECT $this
 				WHERE {
 					$value owl:versionIRI $this .
@@ -274,8 +261,8 @@ uco-owl:versionIRI-shape
 			a sh:SPARQLConstraint ;
 			rdfs:seeAlso <https://www.w3.org/TR/owl2-syntax/#Ontology_IRI_and_Version_IRI> ;
 			sh:message "'If an ontology has both an ontology IRI and a version IRI, then a different ontology with the same ontology IRI and the same version IRI SHOULD NOT exist.'"@en ;
-			sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 			sh:select """
+				PREFIX owl: <http://www.w3.org/2002/07/owl#>
 				SELECT $this
 				WHERE {
 					$value

--- a/tests/examples/owl_axiom_XFAIL_validation.ttl
+++ b/tests/examples/owl_axiom_XFAIL_validation.ttl
@@ -18,8 +18,8 @@
 			rdfs:comment "This requirement is determined from review of the canonical parsing process in Section 3 of the OWL 2 mapping to RDF.  All references to owl:Axioms are identified as blank nodes.  Therefore, any non-blank node that is an owl:Axiom will not be mapped and consumed by the mapping process."@en ;
 			rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-mapping-to-rdf-20121211/#Mapping_from_RDF_Graphs_to_the_Structural_Specification> ;
 			sh:message "An owl:Axiom must be a blank node."@en ;
-			sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 			sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:Axiom .

--- a/tests/examples/owl_properties_XFAIL_validation.ttl
+++ b/tests/examples/owl_properties_XFAIL_validation.ttl
@@ -18,8 +18,8 @@
 				a sh:SPARQLConstraint ;
 				rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
 				sh:message "An IRI may not be a member of both an owl:AnnotationProperty and owl:DatatypeProperty."@en ;
-				sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 				sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:DatatypeProperty ;
@@ -39,8 +39,8 @@
 				a sh:SPARQLConstraint ;
 				rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
 				sh:message "An IRI may not be a member of both an owl:AnnotationProperty and owl:ObjectProperty."@en ;
-				sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 				sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:ObjectProperty ;
@@ -60,8 +60,8 @@
 				a sh:SPARQLConstraint ;
 				rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
 				sh:message "An IRI may not be a member of both owl:DatatypeProperty and owl:ObjectProperty."@en ;
-				sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 				sh:select """
+			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
 				$this a owl:ObjectProperty ;


### PR DESCRIPTION
This is filed as a bugfix Pull Request due to a discovery made in Issue #457 .

SHACL Specification Section 5.2.1 specifies a "viral" behavior of `sh:declare` throughout an OWL transitive closure.  This patch removes usage of `sh:declare` as a matter of lack of authority for non-UCO prefixes.  It just so happens the only place this was used was in the introduction of the OWL SHACL review mechanisms of Issue 406.


# Coordination

- Tracking in Jira ticket [OC-268](https://unifiedcyberontology.atlassian.net/browse/OC-268)
- [x] Pull request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in (CASE/UCO) feature branch
- [x] CI passes in (CASE/UCO) current unstable branch ([4a99851](https://github.com/ucoProject/UCO-Archive/commit/4a9985126b7cedf27767773f736ee822feaf5c00))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([8f6ffd4](https://github.com/casework/CASE-Archive/commit/8f6ffd4134bba9ecf2c65127f554261bdb7a36d1))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/6157ffac048392fad2396383af9f702f4cb8f8d2) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/df12cd781a26c1ca4f54235dca1a31d7192db7c9) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Solutions Approval vote logged on corresponding Issue *(N/A under bugfix workflow)*