### PR TITLE
Issue 435 and CP 43: Backport datatype syntax fix to recoverability vocabulary

### DIFF
--- a/ontology/uco/vocabulary/vocabulary.ttl
+++ b/ontology/uco/vocabulary/vocabulary.ttl
@@ -881,15 +881,18 @@ vocabulary:ProcessorArchVocab
 
 vocabulary:RecoveredObjectStatusVocab
 	a rdfs:Datatype ;
-	rdfs:subClassOf rdfs:Resource ;
 	rdfs:label "Recovered Object Status Vocabulary"@en-US ;
 	rdfs:comment "Defines the vocabulary for Recovered Object status of data."@en ;
-	owl:oneOf (
-		"recovered"^^vocabulary:RecoveredObjectStatusVocab
-		"partially recovered"^^vocabulary:RecoveredObjectStatusVocab
-		"overwritten"^^vocabulary:RecoveredObjectStatusVocab
-		"unknown"^^vocabulary:RecoveredObjectStatusVocab
-	) ;
+	owl:equivalentClass [
+		a rdfs:Datatype ;
+		owl:onDatatype xsd:string ;
+		owl:oneOf (
+			"recovered"^^vocabulary:RecoveredObjectStatusVocab
+			"partially recovered"^^vocabulary:RecoveredObjectStatusVocab
+			"overwritten"^^vocabulary:RecoveredObjectStatusVocab
+			"unknown"^^vocabulary:RecoveredObjectStatusVocab
+		) ;
+	] ;
 	.
 
 vocabulary:RegionalRegistryTypeVocab


### PR DESCRIPTION
The solution of [Issue 435](https://github.com/ucoProject/UCO/issues/435) was known to have an effect on [PR 408](https://github.com/ucoProject/UCO/pull/408).  We had missed doing a catch-up merge after 435's PR was merged prematurely.

This bugfix PR resolves a conflict between the PRs, and should be merged as soon as the CIs in the checklist finish.  Also, should the vote for issue 435 not pass, this PR will need to be reverted.  It will not be necessary to post documentation to the 1.0.0 release page for this PR.


# Coordination

- Tracking in Jira ticket [OC-269](https://unifiedcyberontology.atlassian.net/browse/OC-269)
- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in (CASE/UCO) feature branch
- [x] CI passes in UCO current `unstable` branch ([0fb5c9b](https://github.com/ucoProject/UCO-Archive/commit/0fb5c9b53a8d97715039f8e727b692b45d3d7fce))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([91cc9d0](https://github.com/casework/CASE-Archive/commit/91cc9d0c41e3ebb585ffabff22d649804fe7b79e))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/0c244fec01cb0d6d5c81d7df6c9a52d4b3b00de6) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/619e052a50e0ba34186d5e47be1e5b964b19e31f) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue *(N/A for bugfix)*