### PR TITLE
Fix typo

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -416,7 +416,7 @@ observable:ApplicationFacet
 		;
 	rdfs:subClassOf core:Facet ;
 	rdfs:label "ApplicationFacet"@en ;
-	rdfs:comment "An application facet is a grouping of characteristics unique to a particular software program designed for ends users."@en ;
+	rdfs:comment "An application facet is a grouping of characteristics unique to a particular software program designed for end users."@en ;
 	sh:property
 		[
 			sh:class observable:ObservableObject ;


### PR DESCRIPTION
This Pull Request is a bug-fix change proposal, believed to be of low risk to the ontology and its downstream resources.

`ApplicationFacet` contains the string "designed for **ends** users" where "designed for **end** users" was likely meant.


# Coordination

- Tracking in Jira ticket [OC-270](https://unifiedcyberontology.atlassian.net/browse/OC-270)
- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed. *(N/A)*
- [x] CI passes in (CASE/UCO) feature branch
- [x] CI passes in UCO current `unstable` branch ([merge-commit](#TODO-commit)) *(N/A for typo fix in comment string)*
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([merge-commit](#TODO-commit)) *(N/A for typo fix in comment string)*
- [x] Impact on SHACL validation [reviewed](#TODO-commit) for CASE-Examples *(N/A for typo fix in comment string)*
- [x] Impact on SHACL validation [remediated](#TODO-commit) for CASE-Examples *(N/A for typo fix in comment string)*
- [x] Impact on SHACL validation [reviewed](#TODO-commit) for casework.github.io *(N/A for typo fix in comment string)*
- [x] Impact on SHACL validation [remediated](#TODO-commit) for casework.github.io *(N/A for typo fix in comment string)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue *(N/A for typo fix in comment string)*