### PR TITLE
Issue 375: For EventRecords, rename device property and finish computer property removal

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -2891,12 +2891,6 @@ observable:EventFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:computerName ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
 			sh:path observable:eventID ;
 		] ,
 		[

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -2867,7 +2867,7 @@ observable:EventFacet
 			sh:class observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path observable:device ;
+			sh:path observable:eventRecordDevice ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
@@ -9983,13 +9983,6 @@ observable:destinationPort
 	rdfs:range xsd:integer ;
 	.
 
-observable:device
-	a owl:ObjectProperty ;
-	rdfs:label "device"@en ;
-	rdfs:comment "The device on which the log entry was generated."@en ;
-	rdfs:range observable:ObservableObject ;
-	.
-
 observable:deviceType
 	a owl:DatatypeProperty ;
 	rdfs:label "deviceType"@en ;
@@ -10242,6 +10235,13 @@ observable:environmentVariables
 	rdfs:label "environmentVariables"@en ;
 	rdfs:comment "A list of environment variables associated with the process. "@en ;
 	rdfs:range types:Dictionary ;
+	.
+
+observable:eventRecordDevice
+	a owl:ObjectProperty ;
+	rdfs:label "device"@en ;
+	rdfs:comment "The device on which the log entry was generated."@en ;
+	rdfs:range observable:ObservableObject ;
 	.
 
 observable:eventRecordID


### PR DESCRIPTION
This Pull Request resolves remaining requirements of Issue #375 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.  *(N/A, but keeping in Draft until external examples are reviewed.)
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current `unstable` branch ([c337a62](https://github.com/ucoProject/UCO-Archive/commit/c337a62fb375eb04d93593b3360b641b8d41bd81))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([d8e81a7](https://github.com/casework/CASE-Archive/commit/d8e81a7b8f52a90321b5c58921034fe1db666473))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/86b3bb6a152f4ad0f484261d82de2a1deada690a) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A - `observable:device` was not used)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/1bfea8117e8866445fa49726066b6dd2bee19865) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A - `observable:device` was not used)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) *(N/A, but keeping in Draft until external examples are reviewed)*