### PR TITLE
UCO-415 Database Record Representation

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -6190,12 +6190,6 @@ observable:TableFieldFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:recordFieldValue ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
 			sh:path observable:recordRowID ;
 		] ,
 		[
@@ -6209,9 +6203,57 @@ observable:TableFieldFacet
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:tableSchema ;
+		] ,
+		[
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:or (
+				[
+					sh:datatype xsd:base64Binary ;
+				]
+				[
+					sh:datatype xsd:decimal ;
+				]
+				[
+					sh:datatype xsd:integer ;
+				]
+				[
+					sh:datatype xsd:string ;
+				]
+			) ;
+			sh:path observable:recordFieldValue ;
 		]
 		;
-	sh:targetClass observable:DatabaseRecordFacet ;
+	sh:targetClass observable:TableFieldFacet ;
+	sh:xone (
+		[
+			a sh:NodeShape ;
+			sh:property [
+				sh:hasValue "false"^^xsd:boolean ;
+				sh:path observable:recordFieldIsNull ;
+			] ;
+		]
+		[
+			a sh:NodeShape ;
+			sh:property
+				[
+					sh:hasValue "true"^^xsd:boolean ;
+					sh:path observable:recordFieldIsNull ;
+				] ,
+				[
+					sh:maxCount "0"^^xsd:integer ;
+					sh:path observable:recordFieldValue ;
+				]
+				;
+		]
+		[
+			a sh:NodeShape ;
+			sh:property [
+				sh:maxCount "0"^^xsd:integer ;
+				sh:path observable:recordFieldIsNull ;
+			] ;
+		]
+	) ;
 	.
 
 observable:TaskActionType

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -12467,7 +12467,7 @@ observable:recordFieldValue
 observable:recordRowID
 	a owl:DatatypeProperty ;
 	rdfs:label "recordRowID"@en ;
-	rdfs:comment "The unique ID that identifies a database record."@en ;
+	rdfs:comment "The unique ID that identifies a database record, supplied by the originating database engine."@en ;
 	rdfs:range xsd:string ;
 	.
 

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -6154,6 +6154,66 @@ observable:TCPConnectionFacet
 	sh:targetClass observable:TCPConnectionFacet ;
 	.
 
+observable:TableField
+	a
+		owl:Class ,
+		sh:NodeShape
+		;
+	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:label "TableField"@en ;
+	rdfs:comment "A database table field and its associated value contained within a relational database."@en ;
+	sh:targetClass observable:TableField ;
+	.
+
+observable:TableFieldFacet
+	a
+		owl:Class ,
+		sh:NodeShape
+		;
+	rdfs:subClassOf core:Facet ;
+	rdfs:label "TableFieldFacet"@en ;
+	rdfs:comment "A database record facet contains properties associated with a specific table record value from a database."@en ;
+	sh:property
+		[
+			sh:datatype xsd:boolean ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:recordFieldIsNull ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:recordFieldName ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:recordFieldValue ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:recordRowID ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:tableName ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:tableSchema ;
+		]
+		;
+	sh:targetClass observable:DatabaseRecordFacet ;
+	.
+
 observable:TaskActionType
 	a
 		owl:Class ,
@@ -12175,6 +12235,42 @@ observable:receivedTime
 	rdfs:range xsd:dateTime ;
 	.
 
+observable:recordFieldIsNull
+	a owl:DatatypeProperty ;
+	rdfs:label "recordFieldIsNull"@en ;
+	rdfs:comment "Whether the specified database record field is null."@en ;
+	rdfs:range xsd:boolean ;
+	.
+
+observable:recordFieldName
+	a owl:DatatypeProperty ;
+	rdfs:label "recordFieldName"@en ;
+	rdfs:comment "A field name of a database record value being identified."@en ;
+	rdfs:range xsd:string ;
+	.
+
+observable:recordFieldValue
+	a owl:DatatypeProperty ;
+	rdfs:label "recordFieldValue"@en ;
+	rdfs:comment "The field value of a specified database record."@en ;
+	rdfs:range [
+		a rdfs:Datatype ;
+		owl:unionOf (
+			xsd:base64Binary
+			xsd:decimal
+			xsd:integer
+			xsd:string
+		) ;
+	] ;
+	.
+
+observable:recordRowID
+	a owl:DatatypeProperty ;
+	rdfs:label "recordRowID"@en ;
+	rdfs:comment "The unique ID that identifies a database record."@en ;
+	rdfs:range xsd:string ;
+	.
+
 observable:recurrence
 	a owl:DatatypeProperty ;
 	rdfs:label "recurrence"@en ;
@@ -12875,6 +12971,14 @@ observable:systemTime
 observable:tableName
 	a owl:DatatypeProperty ;
 	rdfs:label "tableName"@en ;
+	rdfs:comment "The table containing a specified database record."@en ;
+	rdfs:range xsd:string ;
+	.
+
+observable:tableSchema
+	a owl:DatatypeProperty ;
+	rdfs:label "tableSchema"@en ;
+	rdfs:comment "The schema that contains the identified database record."@en ;
 	rdfs:range xsd:string ;
 	.
 

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -6312,12 +6312,6 @@ observable:TableFieldFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:recordRowID ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
 			sh:path observable:tableName ;
 		] ,
 		[
@@ -6344,6 +6338,19 @@ observable:TableFieldFacet
 				]
 			) ;
 			sh:path observable:recordFieldValue ;
+		] ,
+		[
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:or (
+				[
+					sh:datatype xsd:integer ;
+				]
+				[
+					sh:datatype xsd:string ;
+				]
+			) ;
+			sh:path observable:recordRowID ;
 		]
 		;
 	sh:targetClass observable:TableFieldFacet ;
@@ -12468,7 +12475,13 @@ observable:recordRowID
 	a owl:DatatypeProperty ;
 	rdfs:label "recordRowID"@en ;
 	rdfs:comment "The unique ID that identifies a database record, supplied by the originating database engine."@en ;
-	rdfs:range xsd:string ;
+	rdfs:range [
+		a rdfs:Datatype ;
+		owl:unionOf (
+			xsd:integer
+			xsd:string
+		) ;
+	] ;
 	.
 
 observable:recurrence

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -25,6 +25,8 @@ all: \
   co_XFAIL_validation.ttl \
   configuration_setting_PASS_validation.ttl \
   configuration_setting_XFAIL_validation.ttl \
+  database_records_PASS_validation.ttl \
+  database_records_XFAIL_validation.ttl \
   has_facet_inverse_functional_PASS_validation.ttl \
   has_facet_inverse_functional_XFAIL_validation.ttl \
   hash_PASS_validation.ttl \
@@ -91,6 +93,8 @@ check: \
   co_XFAIL_validation.ttl \
   configuration_setting_PASS_validation.ttl \
   configuration_setting_XFAIL_validation.ttl \
+  database_records_PASS_validation.ttl \
+  database_records_XFAIL_validation.ttl \
   has_facet_inverse_functional_PASS_validation.ttl \
   has_facet_inverse_functional_XFAIL_validation.ttl \
   hash_PASS_validation.ttl \

--- a/tests/examples/database_records_PASS.json
+++ b/tests/examples/database_records_PASS.json
@@ -8,6 +8,26 @@
     },
     "@graph": [
         {
+            "@id": "kb:sqlite-record-102119a5-29f2-49fc-80a7-adbafd03aa46",
+            "@type": "observable:TableField",
+            "core:hasFacet": {
+                "@id": "kb:table-field-facet-25254866-21bd-441d-bf2a-3373f7d17df6",
+                "@type": "observable:TableFieldFacet",
+                "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
+                "observable:recordRowID": 1
+            }
+        },
+        {
+            "@id": "kb:sqlite-record-63a3229a-a1bd-4c91-b45a-704fbf5e43d3",
+            "@type": "observable:TableField",
+            "core:hasFacet": {
+                "@id": "kb:table-field-facet-32c5e881-f6a7-4ac8-89ec-4ea2e53e6d56",
+                "@type": "observable:TableFieldFacet",
+                "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
+                "observable:recordRowID": "A"
+            }
+        },
+        {
             "@id": "kb:sqlite-record-8186208e-a27a-4025-9fb7-e697d044786d",
             "@type": "observable:TableField",
             "core:hasFacet": {
@@ -35,7 +55,6 @@
                 }
             }
         },
-
         {
             "@id": "kb:sqlite-record-2892f411-3bab-4998-8af1-b8a5dff92bac",
             "@type": "observable:TableField",

--- a/tests/examples/database_records_PASS.json
+++ b/tests/examples/database_records_PASS.json
@@ -22,6 +22,21 @@
             }
         },
         {
+            "@id": "kb:sqlite-record-ff678274-ab0f-4671-9a9b-da1828326fb8",
+            "@type": "observable:TableField",
+            "core:hasFacet": {
+                "@id": "kb:table-field-facet-c30848ac-6c64-43eb-a081-cddf01c37085",
+                "@type": "observable:TableFieldFacet",
+                "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
+                "observable:recordFieldIsNull": false,
+                "observable:recordFieldValue": {
+                    "@type": "xsd:base64Binary",
+                    "@value": "2jmj7l5rSw0yVb/vlWAYkK/YBwk="
+                }
+            }
+        },
+
+        {
             "@id": "kb:sqlite-record-2892f411-3bab-4998-8af1-b8a5dff92bac",
             "@type": "observable:TableField",
             "core:hasFacet": {

--- a/tests/examples/database_records_PASS.json
+++ b/tests/examples/database_records_PASS.json
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "kb": "http://example.org/kb/",
+        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:sqlite-record-8186208e-a27a-4025-9fb7-e697d044786d",
+            "@type": "observable:TableField",
+            "core:hasFacet": {
+                "@id": "kb:table-field-facet-fbe52d33-7448-48de-9d1c-f6ab9e2757e0",
+                "@type": "observable:TableFieldFacet",
+                "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
+                "observable:recordFieldIsNull": false,
+                "observable:recordFieldValue": {
+                    "@type": "xsd:decimal",
+                    "@value": "87.65"
+                }
+            }
+        },
+        {
+            "@id": "kb:sqlite-record-2892f411-3bab-4998-8af1-b8a5dff92bac",
+            "@type": "observable:TableField",
+            "core:hasFacet": {
+                "@id": "kb:table-field-facet-44843015-9916-43e9-8f02-3e20874f461d",
+                "@type": "observable:TableFieldFacet",
+                "rdfs:comment": "This node is intentionally sparse, to show that no SHACL validation issues are triggered."
+            }
+        }
+    ]
+}

--- a/tests/examples/database_records_PASS_validation.ttl
+++ b/tests/examples/database_records_PASS_validation.ttl
@@ -1,0 +1,11 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "true"^^xsd:boolean ;
+	.
+

--- a/tests/examples/database_records_XFAIL.json
+++ b/tests/examples/database_records_XFAIL.json
@@ -1,0 +1,35 @@
+{
+    "@context": {
+        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "kb": "http://example.org/kb/",
+        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:sqlite-record-c1d91148-754f-41b9-b3e8-000a31102205",
+            "@type": "observable:TableField",
+            "core:hasFacet": {
+                "@id": "kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314",
+                "@type": "observable:TableFieldFacet",
+                "rdfs:comment": "This node is intended to trigger a SHACL validation issue, and will be migrated to a XFAIL test in UCO.",
+                "observable:recordFieldIsNull": [
+                    false,
+                    true
+                ]
+            }
+        },
+        {
+            "@id": "kb:sqlite-record-f150b810-503c-426b-b8f9-0c66325ea3b0",
+            "@type": "observable:TableField",
+            "core:hasFacet": {
+                "@id": "kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29",
+                "@type": "observable:TableFieldFacet",
+                "rdfs:comment": "This node is intended to trigger a SHACL validation issue about a field being designated NULL and value-bearing.",
+                "observable:recordFieldIsNull": true,
+                "observable:recordFieldValue": 6789
+            }
+        }
+    ]
+}

--- a/tests/examples/database_records_XFAIL_validation.ttl
+++ b/tests/examples/database_records_XFAIL_validation.ttl
@@ -1,0 +1,46 @@
+@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29> ;
+			sh:resultMessage 'Node kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
+			sh:sourceShape observable:TableFieldFacet ;
+			sh:value <http://example.org/kb/table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
+			sh:resultMessage "More than 1 values on kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314->observable:recordFieldIsNull" ;
+			sh:resultPath observable:recordFieldIsNull ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:boolean ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:recordFieldIsNull ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
+			sh:resultMessage 'Node kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
+			sh:sourceShape observable:TableFieldFacet ;
+			sh:value <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
+		]
+		;
+	.
+

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -191,6 +191,22 @@ def test_configuration_setting_XFAIL_validation() -> None:
       }
 )
 
+def test_database_records_PASS() -> None:
+    confirm_validation_results(
+      "database_records_PASS_validation.ttl",
+      True
+    )
+
+def test_database_records_XFAIL() -> None:
+    confirm_validation_results(
+      "database_records_XFAIL_validation.ttl",
+      False,
+      expected_focus_node_severities={
+        ("http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314", str(NS_SH.Violation)),
+        ("http://example.org/kb/table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29", str(NS_SH.Violation)),
+      }
+    )
+
 def test_has_facet_inverse_functional_PASS() -> None:
     confirm_validation_results(
       "has_facet_inverse_functional_PASS_validation.ttl",


### PR DESCRIPTION
Addresses UCO-415 by adding database representation.


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current `unstable` branch ([9d3054f](https://github.com/ucoProject/UCO-Archive/commit/9d3054f29a2a8f634a38f795da8d898d5ec8f438))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([b52db3a](https://github.com/casework/CASE-Archive/commit/b52db3aa2ad4b69099be9be139e9d819e0622c86))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/85637c03ad0a4bcbc6f34dc707b1b447b8d42697) for CASE-Examples
- [x] Impact on SHACL validation [remediated](https://github.com/casework/CASE-Examples/commit/e29f84dd8e6de61470ff78b41ec303a1c150e98a) for CASE-Examples
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/1072d27a6cf09cab4c0c8c8ab43b7edaaeb8f760) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->
- [x] English definition of `recordRowId` updated.
- [x] Range of `recordRowId` set to union of `xsd:integer` and `xsd:string`, and appropriate SHACL adjustment made.