### PR TITLE
Issue 469: Make ControlledDictionary a subclass of Dictionary

### DIFF
--- a/ontology/uco/types/types.ttl
+++ b/ontology/uco/types/types.ttl
@@ -27,12 +27,11 @@ types:ControlledDictionary
 		owl:Class ,
 		sh:NodeShape
 		;
+	rdfs:subClassOf types:Dictionary ;
 	rdfs:label "ControlledDictionary"@en ;
 	rdfs:comment "A controlled dictionary is a list of (term/key, value) pairs where each term/key exists no more than once and is constrained to an explicitly defined set of values."@en ;
 	sh:property [
 		sh:class types:ControlledDictionaryEntry ;
-		sh:minCount "1"^^xsd:integer ;
-		sh:nodeKind sh:BlankNodeOrIRI ;
 		sh:path types:entry ;
 	] ;
 	sh:targetClass types:ControlledDictionary ;
@@ -43,24 +42,9 @@ types:ControlledDictionaryEntry
 		owl:Class ,
 		sh:NodeShape
 		;
+	rdfs:subClassOf types:DictionaryEntry ;
 	rdfs:label "ControlledDictionaryEntry"@en ;
 	rdfs:comment "A controlled dictionary entry is a single (term/key, value) pair where the term/key is constrained to an explicitly defined set of values."@en ;
-	sh:property
-		[
-			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path types:key ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path types:value ;
-		]
-		;
 	sh:targetClass types:ControlledDictionaryEntry ;
 	.
 
@@ -222,13 +206,7 @@ types:entry
 	a owl:ObjectProperty ;
 	rdfs:label "entry"@en ;
 	rdfs:comment "A dictionary entry."@en ;
-	rdfs:range [
-		a rdfs:Datatype ;
-		owl:unionOf (
-			types:ControlledDictionaryEntry
-			types:DictionaryEntry
-		) ;
-	] ;
+	rdfs:range types:DictionaryEntry ;
 	.
 
 types:hashMethod


### PR DESCRIPTION
This Pull Request will resolve all requirements of [Issue 469](https://github.com/ucoProject/UCO/issues/469).


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.  *(N/A under bugfix workflow)*
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current `unstable` branch ([6d44914](https://github.com/ucoProject/UCO-Archive/commit/6d44914112ef82ef65a378770bb09cc4acc69a4a))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([8d1032c](https://github.com/casework/CASE-Archive/commit/8d1032c0eadf6697011de7c50021a4f8ff751c2e)) <!--If this is a purely additive change, this box may be checked with a note of "*(skipped - additive change)*" -->
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/3774b4f85b8eb57a4a7a23327c8af4804dcefd04) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/f51d4405a0d4bd49402ee10a489f72d77f1bd62b) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue *(N/A under bugfix workflow)*