### PR TITLE
Issue 432: Add direct import of configuration namespace to uco.ttl

### DIFF
--- a/ontology/uco/master/uco.ttl
+++ b/ontology/uco/master/uco.ttl
@@ -1,6 +1,7 @@
 # imports: https://ontology.unifiedcyberontology.org/co
 # imports: https://ontology.unifiedcyberontology.org/owl
 # imports: https://ontology.unifiedcyberontology.org/uco/action
+# imports: https://ontology.unifiedcyberontology.org/uco/configuration
 # imports: https://ontology.unifiedcyberontology.org/uco/core
 # imports: https://ontology.unifiedcyberontology.org/uco/identity
 # imports: https://ontology.unifiedcyberontology.org/uco/location
@@ -28,6 +29,7 @@
 		<https://ontology.unifiedcyberontology.org/co> ,
 		<https://ontology.unifiedcyberontology.org/owl> ,
 		<https://ontology.unifiedcyberontology.org/uco/action> ,
+		<https://ontology.unifiedcyberontology.org/uco/configuration> ,
 		<https://ontology.unifiedcyberontology.org/uco/core> ,
 		<https://ontology.unifiedcyberontology.org/uco/identity> ,
 		<https://ontology.unifiedcyberontology.org/uco/location> ,


### PR DESCRIPTION
This should have happened as part of resolving [Issue 432](https://github.com/ucoProject/UCO/issues/432).

No effects were observed on Make-managed files within UCO.  The effect that will happen in the [CASE website monolithic ontology builds](https://github.com/casework/casework.github.io/tree/master/ontology) is an additional `owl:imports` triple.  The review checklist for this issue is skipped.