### PR TITLE
Add labels to recent ontology files

### DIFF
--- a/ontology/co/co.ttl
+++ b/ontology/co/co.ttl
@@ -10,6 +10,7 @@
 
 <https://ontology.unifiedcyberontology.org/co>
 	a owl:Ontology ;
+	rdfs:label "uco-co"@en ;
 	rdfs:comment "This ontology defines SHACL shapes to supplement the OWL 2 DL definitions in the Collections Ontology."@en ;
 	owl:imports <http://purl.org/co> ;
 	.

--- a/ontology/owl/owl.ttl
+++ b/ontology/owl/owl.ttl
@@ -7,6 +7,7 @@
 
 <https://ontology.unifiedcyberontology.org/owl>
 	a owl:Ontology ;
+	rdfs:label "uco-owl"@en ;
 	rdfs:comment "This ontology defines SHACL shapes to perform conformance testing of OWL 2 DL.  Some of these shapes follow rules specified from the canonical, subtractive parsing process of Section 3 of the OWL 2 mapping to RDF.  From the last line of that document's Section 3, 'At the end of this process, the graph G MUST be empty,' anything not strictly matching patterns specified in that section cause the input graph to be non-conformant with OWL 2 DL."@en ;
 	rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-mapping-to-rdf-20121211/#Mapping_from_RDF_Graphs_to_the_Structural_Specification> ;
 	.


### PR DESCRIPTION
The SHACL import-review ontologies didn't get `rdfs:label`s assigned
when they were created.  This patch adds them to fit style practice with
other UCO ontology files.

This PR is being submitted as a bugfix with no associated Issue.