### PR TITLE
Issue 487: Property Type Updates

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -9639,6 +9639,7 @@ observable:byteStringValue
 	a owl:DatatypeProperty ;
 	rdfs:label "byteStringValue"@en ;
 	rdfs:comment "Specifies the raw, byte-string representation of the extracted string."@en ;
+	rdfs:range xsd:string ;
 	.
 
 observable:callType
@@ -10171,8 +10172,8 @@ observable:destination
 observable:destinationFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "destinationFlags"@en ;
-	rdfs:comment """Specifies the destination TCP flags.
-          """@en ;
+	rdfs:comment "Specifies the destination TCP flags."@en ;
+	rdfs:range xsd:string ;
 	.
 
 observable:destinationPort

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -3135,6 +3135,12 @@ observable:ExtractedString
 	rdfs:comment "An extracted string is a grouping of characteristics unique to a series of characters pulled from an observable object."@en ;
 	sh:property
 		[
+			sh:datatype xsd:base64Binary ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:byteStringValue ;
+		] ,
+		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
@@ -3163,11 +3169,6 @@ observable:ExtractedString
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:stringValue ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:byteStringValue ;
 		]
 		;
 	sh:targetClass observable:ExtractedString ;
@@ -6266,11 +6267,12 @@ observable:TCPConnectionFacet
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sourceFlags ;
+			sh:path observable:destinationFlags ;
 		] ,
 		[
+			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:destinationFlags ;
+			sh:path observable:sourceFlags ;
 		]
 		;
 	sh:targetClass observable:TCPConnectionFacet ;
@@ -9639,7 +9641,7 @@ observable:byteStringValue
 	a owl:DatatypeProperty ;
 	rdfs:label "byteStringValue"@en ;
 	rdfs:comment "Specifies the raw, byte-string representation of the extracted string."@en ;
-	rdfs:range xsd:string ;
+	rdfs:range xsd:base64Binary ;
 	.
 
 observable:callType
@@ -10173,7 +10175,7 @@ observable:destinationFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "destinationFlags"@en ;
 	rdfs:comment "Specifies the destination TCP flags."@en ;
-	rdfs:range xsd:string ;
+	rdfs:range xsd:hexBinary ;
 	.
 
 observable:destinationPort


### PR DESCRIPTION
Addresses #487

Originally added the `xsd:string` types to the following properties:
- [uco-observable:destinationFlags](https://github.com/ucoProject/UCO/blob/master/ontology/uco/observable/observable.ttl#L10171)
 - [uco-observable:byteStringValue](https://github.com/ucoProject/UCO/blob/master/ontology/uco/observable/observable.ttl#L9638)

A follow-on patch revised the added types to be `xsd:hexBinary` for `destinationFlags` (to match `sourceFlags`), and `xsd:base64Binary` for `byteStringValue` (to distinguish from `stringValue`).


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current `unstable` branch ([202d76b](https://github.com/ucoProject/UCO-Archive/commit/202d76b48f92d193e9668f804e6e1f83df7136d2))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([2769fa8](https://github.com/casework/CASE-Archive/commit/2769fa8fd8868daaa77ae115263c941ff2bf5391))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/273cd15bb51c37abf73a4c551798dca54f61b36c) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/commit/675ad05d61e2a9a8e39e0cd6a1dca4f6a88d6714) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->