### PR TITLE
Issue 488: Fix typos for upstream design vocabularies

### DIFF
--- a/ontology/co/co.ttl
+++ b/ontology/co/co.ttl
@@ -152,8 +152,8 @@ uco-co:size-subjects-shape
 []
 	a owl:Axiom ;
 	rdfs:comment "This triple is repeated from the Collections Ontology."@en ;
-	owl:AnnotatedProperty rdfs:subClassOf ;
-	owl:AnnotatedSource co:ListItem ;
-	owl:AnnotatedTarget co:Item ;
+	owl:annotatedProperty rdfs:subClassOf ;
+	owl:annotatedSource co:ListItem ;
+	owl:annotatedTarget co:Item ;
 	.
 

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -13420,7 +13420,7 @@ observable:wirelessNetworkSecurityMode
 	rdfs:label "wirelessNetworkSecurityMode"@en ;
 	rdfs:comment "Specifies the security mode of a wireless network (None, WEP, WPA, etc)."@en ;
 	rdfs:range [
-		a rdfs:DataType ;
+		a rdfs:Datatype ;
 		owl:unionOf (
 			vocabulary:WirelessNetworkSecurityModeVocab
 			xsd:string


### PR DESCRIPTION
This Pull Request resolves the risk-free elements of Issue #488 - fixing typo'd concepts.  In contrast, [PR 489](https://github.com/ucoProject/UCO/pull/489) adds the low-but-not-no risk new unit test.

After appropriate portions of the review checklist pass, this PR can be merged independent of PR 489.


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current `unstable` branch ([5bbfa90](https://github.com/ucoProject/UCO-Archive/commit/5bbfa907364db07dc466021ae480e772fa4ed395))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([34c137f](https://github.com/casework/CASE-Archive/commit/34c137f174e8d465a6fa6c0467585325f0b6e8ab)) *(Note: This merge is for another UCO PR, but incorporates this feature branch)*
- [x] (All impact on SHACL validation deferred to PR 489.)
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue