### PR TITLE
fix(value): corrected classname reference

### DIFF
--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -409,7 +409,7 @@ core:UcoThing
 	rdfs:subClassOf owl:Thing ;
 	rdfs:label "UcoThing"@en ;
 	rdfs:comment "UcoThing is the top-level class within UCO."@en ;
-	rdfs:seeAlso core:UcoThing-identifier-shape ;
+	rdfs:seeAlso core:UcoThing-identifier-regex-shape ;
 	sh:sparql [
 		a sh:SPARQLConstraint ;
 		sh:message "UcoThings are required to not be blank nodes."@en ;


### PR DESCRIPTION
This Pull Request is a bug-fix change proposal, believed to be of low risk to the ontology and its downstream resources.

There is no element named `UcoThing-identifier-shape` in core, nearest match is `UcoThing-identifier-regex-shape` so that is probably intended value.


# Coordination

- Tracking in Jira ticket [OC-286](https://unifiedcyberontology.atlassian.net/browse/OC-286)
- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in UCO feature branch
- [x] CI passes in UCO current `unstable` branch ([e4341ae](https://github.com/ucoProject/UCO-Archive/commit/e4341aee09d7469283895095c4f7e1fa761a663e))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([1162f6a](https://github.com/casework/CASE-Archive/commit/1162f6a7c533c692753c90031c5c9b96de0f8c9e))
- [x] Impact on SHACL validation reviewed for CASE-Examples *(skipped; will just test on CASE website for any case-utils effects)*
- [x] Impact on SHACL validation remediated for CASE-Examples *(skipped)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/229/commits/f9eb1ac1fd60ef05bf6c44f866ba784e9ed5fcbc) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) *(N/A)*
- [ ] Documentation logged in pending release page
