### PR TITLE
Issue 508: Deprecate observable:creationTime, replacing with observableCreatedTime

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -8866,6 +8866,12 @@ observable:WindowsThreadFacet
 			sh:path observable:creationTime ;
 		] ,
 		[
+			sh:datatype xsd:dateTime ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:observableCreatedTime ;
+		] ,
+		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:parameterAddress ;
@@ -10191,9 +10197,24 @@ observable:creationFlags
 	.
 
 observable:creationTime
-	a owl:DatatypeProperty ;
+	a
+		owl:DatatypeProperty ,
+		owl:DeprecatedProperty
+		;
 	rdfs:label "creationTime"@en ;
 	rdfs:range xsd:dateTime ;
+	.
+
+observable:creationTime-deprecation-shape
+	a sh:NodeShape ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:maxCount "0"^^xsd:integer ;
+		sh:message "observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  observable:observableCreatedTime should be used instead."@en ;
+		sh:path observable:creationTime ;
+		sh:severity sh:Warning ;
+	] ;
+	sh:targetSubjectsOf observable:creationTime ;
 	.
 
 observable:creator

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -35,6 +35,7 @@ all: \
   location_XFAIL_validation.ttl \
   message_thread_PASS_validation.ttl \
   message_thread_XFAIL_validation.ttl \
+  observable_creation_time_PASS_validation.ttl \
   owl_axiom_PASS_validation.ttl \
   owl_axiom_XFAIL_validation.ttl \
   owl_properties_PASS_validation.ttl \
@@ -103,6 +104,7 @@ check: \
   location_XFAIL_validation.ttl \
   message_thread_PASS_validation.ttl \
   message_thread_XFAIL_validation.ttl \
+  observable_creation_time_PASS_validation.ttl \
   owl_axiom_PASS_validation.ttl \
   owl_axiom_XFAIL_validation.ttl \
   owl_properties_PASS_validation.ttl \

--- a/tests/examples/observable_creation_time_PASS.json
+++ b/tests/examples/observable_creation_time_PASS.json
@@ -1,0 +1,24 @@
+{
+    "@context": {
+        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "kb": "http://example.org/kb/",
+        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:windows-thread-da52a01e-41cc-42d5-85be-ca14bfa10fd6",
+            "@type": "observable:WindowsThread",
+            "core:hasFacet": {
+                "@id": "kb:windows-thread-facet-4967ae35-f00b-49c8-9dd2-38e3bdf851e1",
+                "@type": "observable:WindowsThreadFacet",
+                "rdfs:comment": "In UCO 1.2.0, this will raise a warning.  In UCO 2.0.0, this will raise an error.",
+                "observable:creationTime": {
+                    "@type": "xsd:dateTime",
+                    "@value": "2023-01-01T01:23:45Z"
+                }
+            }
+        }
+    ]
+}

--- a/tests/examples/observable_creation_time_PASS_validation.ttl
+++ b/tests/examples/observable_creation_time_PASS_validation.ttl
@@ -1,0 +1,27 @@
+@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "true"^^xsd:boolean ;
+	sh:result [
+		a sh:ValidationResult ;
+		sh:focusNode <http://example.org/kb/windows-thread-facet-4967ae35-f00b-49c8-9dd2-38e3bdf851e1> ;
+		sh:resultMessage "observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  observable:observableCreatedTime should be used instead."@en ;
+		sh:resultPath observable:creationTime ;
+		sh:resultSeverity sh:Warning ;
+		sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+		sh:sourceShape [
+			a sh:PropertyShape ;
+			sh:maxCount "0"^^xsd:integer ;
+			sh:message "observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  observable:observableCreatedTime should be used instead."@en ;
+			sh:path observable:creationTime ;
+			sh:severity sh:Warning ;
+		] ;
+	] ;
+	.
+

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -365,6 +365,18 @@ def test_message_thread_PASS_validation() -> None:
 def test_message_thread_XFAIL_validation() -> None:
     confirm_validation_results("message_thread_XFAIL_validation.ttl", False)
 
+def test_observable_creation_time_PASS() -> None:
+    confirm_validation_results(
+      "observable_creation_time_PASS_validation.ttl",
+      True,
+      expected_focus_node_severities={
+        (
+          "http://example.org/kb/windows-thread-facet-4967ae35-f00b-49c8-9dd2-38e3bdf851e1",
+          str(NS_SH.Warning)
+        )
+      }
+    )
+
 def test_owl_axiom_PASS() -> None:
     confirm_validation_results(
       "owl_axiom_PASS_validation.ttl",


### PR DESCRIPTION
This Pull Request is part of the resolution of Issue #508 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed 
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([7a772de](https://github.com/ucoProject/UCO-Archive/commit/7a772de49deac2db81c8cdb5591edde6060c98c3))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([0e7db01](https://github.com/casework/CASE-Archive/commit/0e7db0106d74498a25de27b383ea43c421fe76ba))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/b561491b6d0dbbe95485dbbbfe61326727e5b8e5) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/231/commits/019c5ce9e58fed21d58f93edce5f47108b8325f2) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->
