### PR TITLE
Issue 509: Test UCO for disjointedness of core:UcoObject and co:Collection

### DIFF
--- a/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL.ttl
+++ b/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL.ttl
@@ -1,0 +1,57 @@
+@prefix co: <http://purl.org/co/> .
+@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix ex: <http://example.org/ontology/> .
+@prefix observable: <https://ontology.unifiedcyberontology.org/uco/obserable/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:IPAddressRoute
+	a owl:Class ;
+	rdfs:comment "This is expected to trigger a disjointed-classes violation, once subclass expansion occurs.  This example copies subclass axioms from co:, core:, and observable:."@en ;
+	rdfs:subClassOf
+		co:List ,
+		observable:ObservableObject
+		;
+	.
+
+co:Bag
+	a owl:Class ;
+	rdfs:subClassOf co:Collection ;
+	.
+
+co:List
+	a owl:Class ;
+	rdfs:comment "This definition is excerpted from co:."@en ;
+	rdfs:subClassOf [
+		a owl:Class ;
+		owl:intersectionOf (
+			co:Bag
+			[
+				a owl:Restriction ;
+				owl:onProperty co:item ;
+				owl:allValuesFrom co:ListItem ;
+			]
+		) ;
+	] ;
+	.
+
+core:Item
+	a owl:Class ;
+	rdfs:subClassOf core:UcoObject ;
+	.
+
+observable:ObservableObject
+	a owl:Class ;
+	rdfs:subClassOf
+		core:Item ,
+		observable:Observable
+		;
+	.
+
+observable:Observable
+	a owl:Class ;
+	rdfs:subClassOf core:UcoObject ;
+	.
+

--- a/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL_validation.ttl
+++ b/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL_validation.ttl
@@ -1,0 +1,38 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-qc: <urn:example:uco:qc:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result [
+		a sh:ValidationResult ;
+		sh:focusNode <http://example.org/ontology/IPAddressRoute> ;
+		sh:resultMessage "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and core:UcoObject.  See Issue 509 for suggested implementation alterations." ;
+		sh:resultSeverity sh:Violation ;
+		sh:sourceConstraint [
+			a sh:SPARQLConstraint ;
+			rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/509> ;
+			sh:message "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and core:UcoObject.  See Issue 509 for suggested implementation alterations."@en ;
+			sh:select """
+			PREFIX co: <http://purl.org/co/>
+			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+			SELECT $this
+			WHERE {
+				$this
+					rdfs:subClassOf*/(owl:intersectionOf/rdf:rest*/rdf:first)?/rdfs:subClassOf* co:Collection ;
+					rdfs:subClassOf* core:UcoObject ;
+					.
+			}
+		""" ;
+		] ;
+		sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+		sh:sourceShape uco-qc:disjointedness-co-collection-core-uco-object ;
+		sh:value <http://example.org/ontology/IPAddressRoute> ;
+	] ;
+	.
+

--- a/tests/shapes/test_qc_shapes.py
+++ b/tests/shapes/test_qc_shapes.py
@@ -25,6 +25,16 @@ NS_UCO_OWL = Namespace("https://ontology.unifiedcyberontology.org/owl/")
     ["filename", "expected_validation_result", "expected_focus_values"],
     [
         (
+            "examples_uco_qc/co_Collection_core_UcoObject_XFAIL_validation.ttl",
+            False,
+            {
+                (
+                    URIRef("http://example.org/ontology/IPAddressRoute"),
+                    URIRef("http://example.org/ontology/IPAddressRoute"),
+                )
+            }
+        ),
+        (
             "examples_uco_owl/owl_incompatibleWith_shape_PASS_validation.ttl",
             True,
             {

--- a/tests/shapes/uco-qc.ttl
+++ b/tests/shapes/uco-qc.ttl
@@ -10,6 +10,28 @@
 	rdfs:comment "This ontology contains shapes meant to be used against the transitive closure of UCO, excluding imported, externally-developed ontologies."@en ;
 	.
 
+uco-qc:disjointedness-co-collection-core-uco-object
+	a sh:NodeShape ;
+	sh:sparql [
+		a sh:SPARQLConstraint ;
+		rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/509> ;
+		sh:message "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and core:UcoObject.  See Issue 509 for suggested implementation alterations."@en ;
+		sh:select """
+			PREFIX co: <http://purl.org/co/>
+			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+			SELECT $this
+			WHERE {
+				$this
+					rdfs:subClassOf*/(owl:intersectionOf/rdf:rest*/rdf:first)?/rdfs:subClassOf* co:Collection ;
+					rdfs:subClassOf* core:UcoObject ;
+					.
+			}
+		""" ;
+	] ;
+	sh:targetClass owl:Class ;
+	.
+
 uco-qc:owl-Ontology-shape
 	a sh:NodeShape ;
 	sh:property [


### PR DESCRIPTION
This Pull Request resolves backwards-compatible requirements of Issue #509 .


# Coordination

- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([4bdb2b5](https://github.com/ucoProject/UCO-Archive/commit/4bdb2b5e30bedc56f31f46a0334671c24494addc))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([6233392](https://github.com/casework/CASE-Archive/commit/6233392e110ebaa04c9252b24a3e6d6ba995643a))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/pull/124/commits/298937f172b110e94773077aa57af9f06f2e1951) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/231/commits/144111ae63c2b6f581a43a1115b437c4e84bc1ef) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->