### PR TITLE
Issue 521: Unrestrict Cardinality IMEI

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -4478,7 +4478,6 @@ observable:MobileDeviceFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:IMEI ;
 		] ,

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -4478,11 +4478,6 @@ observable:MobileDeviceFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:IMEI ;
-		] ,
-		[
-			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:bluetoothDeviceName ;
@@ -4498,6 +4493,11 @@ observable:MobileDeviceFacet
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:network ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:IMEI ;
 		]
 		;
 	sh:targetClass observable:MobileDeviceFacet ;


### PR DESCRIPTION
Removes the [`sh:maxCount`](https://github.com/ucoProject/UCO/blob/master/ontology/uco/observable/observable.ttl#L4481) from the `observable:IMEI` property of the `observable:MobileDeviceFacet`. 

This Pull Request resolves all requirements of #521 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([`2045b93`](https://github.com/ucoProject/UCO-Archive/commit/2045b935ba7272690703884a80085750398c44e1))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`235246a`](https://github.com/casework/CASE-Archive/commit/235246a9c0fc5eb14b54f7fc415fa1c5c102eca8))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/pull/124/commits/a73b3ac3c9efc1a331b5a2ca6594d20a88f822b2) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples (*N/A*)
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/236/commits/f34ad1e2728b922733d63780a9335d8d869e10f3) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io (*N/A*)
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->
