### PR TITLE
Clarify synchronization test output

### DIFF
--- a/tests/test_uco_monolithic.py
+++ b/tests/test_uco_monolithic.py
@@ -220,16 +220,18 @@ WHERE {
 
         shacl_list = rdf_list_to_member_list(graph, n_shacl_list)
         rdfs_list = rdf_list_to_member_list(graph, n_rdfs_list)
-        if rdfs_list == shacl_list:
-            logging.debug("Match")
-        else:
-            logging.debug(n_shacl_list)
-            logging.debug(n_rdfs_list)
+        if rdfs_list != shacl_list:
             shacl_tuple = tuple(shacl_list)
             rdfs_tuple = tuple(rdfs_list)
             computed.add((test_case[0], test_case[1], shacl_tuple, rdfs_tuple))
 
-    assert expected == computed
+    try:
+        assert expected == computed
+    except AssertionError:
+        logging.error("Semi-open vocabulary lists are out of sync.  See:")
+        for computed_result in computed:
+            logging.error("* %s", str(computed_result[0]))
+        raise
 
 
 def test_only_one_uco_class_is_owl_thing_direct_subclass(graph: Graph) -> None:


### PR DESCRIPTION
[PR 527](https://github.com/ucoProject/UCO/pull/527) stumbled on a code synchronization issue that we'd left a unit test to catch, back in [Issue 435](https://github.com/ucoProject/UCO/issues/435).  On reviewing the debug output against a freshly encountered error, the original implementer (myself) deems it ...

```
test_uco_monolithic.py:232: AssertionError
-------------------- Captured log call --------------------
DEBUG    root:test_uco_monolithic.py:224 Match
DEBUG    root:test_uco_monolithic.py:224 Match
DEBUG    root:test_uco_monolithic.py:224 Match
[...snip...]
DEBUG    root:test_uco_monolithic.py:224 Match
DEBUG    root:test_uco_monolithic.py:224 Match
DEBUG    root:test_uco_monolithic.py:226 n2ecb5139feab4fe88096d056f9ba80cab1564
DEBUG    root:test_uco_monolithic.py:227 n2ecb5139feab4fe88096d056f9ba80cab2022
DEBUG    root:test_uco_monolithic.py:224 Match
DEBUG    root:test_uco_monolithic.py:224 Match
[...snip...]
DEBUG    root:test_uco_monolithic.py:224 Match
DEBUG    root:test_uco_monolithic.py:224 Match
=============== short test summary info ==================
FAILED test_uco_monolithic.py::test_semi_open_vocabulary_owl_shacl_alignment - AssertionError: assert set() == {(rdflib.term...cab')), ...))}
```

... unhelpful.

This patch series changes the output on encountering a synchronization issue to the following, as encountered in PR 527:

```
-------------------- Captured log call --------------------
ERROR    root:test_uco_monolithic.py:235 Semi-open vocabulary lists are out of sync.  See:
ERROR    root:test_uco_monolithic.py:237 * https://ontology.unifiedcyberontology.org/uco/types/Hash
=============== short test summary info ==================
FAILED test_uco_monolithic.py::test_semi_open_vocabulary_owl_shacl_alignment - AssertionError: assert set() == {(rdflib.term...cab')), ...))}
```

This is filed as an independent Pull Request into `develop` as a bugfix PR, but will be merged into PR 527 rather than `develop`.  All testing is delegated to PR 527.


# Coordination

- Tracking in Jira ticket [OC-290](https://unifiedcyberontology.atlassian.net/browse/OC-290)
- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([`0571345`](https://github.com/ucoProject/UCO-Archive/commit/0571345db476f1d773a4d42ca316f215591bdda9))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`1c35bd9`](https://github.com/casework/CASE-Archive/commit/1c35bd9072fecba76cfe90f3c830a300f0691bb7))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/pull/124/commits/150c793bde5b34b0b133f9f5eebd0cf0d2ec7b31) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/236/commits/1b84181f9970f2c5c0b1a1091915d51982b52c53) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) *(N/A)*