### PR TITLE
Issue 584: Replace errant reference to non-existent concept owl:Datatype

### DIFF
--- a/ontology/owl/owl.ttl
+++ b/ontology/owl/owl.ttl
@@ -149,12 +149,12 @@ uco-owl:Disjointedness-C-DT-shape
 	sh:sparql [
 		a sh:SPARQLConstraint ;
 		rdfs:seeAlso <https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Typing_Constraints_of_OWL_2_DL> ;
-		sh:message "An IRI may not be a member of both an owl:Class and owl:Datatype."@en ;
+		sh:message "An IRI may not be a member of both an owl:Class and rdfs:Datatype."@en ;
 		sh:select """
 			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this
 			WHERE {
-				$this a owl:Datatype ;
+				$this a rdfs:Datatype ;
 			}
 		""" ;
 	] ;


### PR DESCRIPTION
This Pull Request resolves all requirements of Issue #584 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([`bb6bee3`](https://github.com/ucoProject/UCO-Archive/commit/bb6bee38e9d7128061d5059563f690516b44f43e))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`4663451`](https://github.com/casework/CASE-Archive/commit/4663451fba4fc5495a09e1ba9b0765b8a9eec2d4))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Corpora/commit/d83bfb798392139ab50a1cf6fc6b9c1f056013ab) for CASE-Corpora
- [x] Impact on SHACL validation remediated for CASE-Corpora
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/d9a8a60deea996976f1c84368a3ff6108be648cf) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/282/commits/d3cc62dfe9614353d4d619821e4495ca2d82b4e4) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue *(N/A)*