### PR TITLE
Issue 602: Warn about key-uniqueness enforcement to types:Dictionary

### DIFF
--- a/ontology/uco/types/types.ttl
+++ b/ontology/uco/types/types.ttl
@@ -60,6 +60,27 @@ types:Dictionary
 	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
 	rdfs:label "Dictionary"@en ;
 	rdfs:comment "A dictionary is list of (term/key, value) pairs with each term/key existing no more than once."@en ;
+	rdfs:seeAlso [
+		a sh:NodeShape ;
+		rdfs:comment "This anonymous shape is attached to types:Dictionary with rdfs:seeAlso in order to associate a warning-severity SPARQL-based shape, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
+		sh:severity sh:Warning ;
+		sh:sparql [
+			a sh:SPARQLConstraint ;
+			sh:message "A key in a dictionary can appear no more than once."@en ;
+			sh:select """
+				PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+				SELECT $this ?value
+				WHERE {
+					$this
+						types:entry/types:key ?value ;
+						.
+				}
+				GROUP BY ?value
+				HAVING (COUNT(?value) > 1)
+			""" ;
+		] ;
+		sh:targetClass types:Dictionary ;
+	] ;
 	sh:property [
 		sh:class types:DictionaryEntry ;
 		sh:minCount "1"^^xsd:integer ;

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -27,6 +27,7 @@ all: \
   configuration_setting_XFAIL_validation.ttl \
   database_records_PASS_validation.ttl \
   database_records_XFAIL_validation.ttl \
+  dictionary_PASS_validation.ttl \
   event_XFAIL_validation.ttl \
   file_url_PASS_validation.ttl \
   has_facet_inverse_functional_PASS_validation.ttl \
@@ -98,6 +99,7 @@ check: \
   configuration_setting_XFAIL_validation.ttl \
   database_records_PASS_validation.ttl \
   database_records_XFAIL_validation.ttl \
+  dictionary_PASS_validation.ttl \
   event_XFAIL_validation.ttl \
   file_url_PASS_validation.ttl \
   has_facet_inverse_functional_PASS_validation.ttl \

--- a/tests/examples/dictionary_PASS.json
+++ b/tests/examples/dictionary_PASS.json
@@ -1,6 +1,7 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
         "types": "https://ontology.unifiedcyberontology.org/uco/types/"
     },
     "@graph": [
@@ -31,7 +32,7 @@
         {
             "@id": "kb:Dictionary-a8e5e8e1-b3de-4ac4-99dd-e36f96beea4d",
             "@type": "types:Dictionary",
-            "rdfs": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
+            "rdfs:comment": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
             "types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-55786f64-534d-4e8c-8a64-616f708ea4d3"
@@ -57,7 +58,7 @@
             "@id": "kb:Dictionary-e9adf6c1-0287-4290-95a9-c94a128d7ff6",
 
             "@type": "types:Dictionary",
-            "rdfs": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
+            "rdfs:comment": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
             "types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-20431f00-64a3-4c0f-94a4-1eb09f8a6b6a"

--- a/tests/examples/dictionary_PASS.json
+++ b/tests/examples/dictionary_PASS.json
@@ -1,0 +1,83 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "types": "https://ontology.unifiedcyberontology.org/uco/types/"
+    },
+    "@graph": [
+        {
+            "@id": "kb:Dictionary-eaded28e-0bf8-4df1-aee8-84d22c09702c",
+            "@type": "types:Dictionary",
+            "types:entry": [
+                {
+                    "@id": "kb:DictionaryEntry-314212eb-39c4-4bf3-be3a-f07c38f0eae8"
+                },
+                {
+                    "@id": "kb:DictionaryEntry-9ec24a1a-7e99-41c9-ba7d-9d23f11babb4"
+                }
+            ]
+        },
+        {
+            "@id": "kb:DictionaryEntry-314212eb-39c4-4bf3-be3a-f07c38f0eae8",
+            "@type": "types:DictionaryEntry",
+            "types:key": "x",
+            "types:value": "1"
+        },
+        {
+            "@id": "kb:DictionaryEntry-9ec24a1a-7e99-41c9-ba7d-9d23f11babb4",
+            "@type": "types:DictionaryEntry",
+            "types:key": "y",
+            "types:value": "2"
+        },
+        {
+            "@id": "kb:Dictionary-a8e5e8e1-b3de-4ac4-99dd-e36f96beea4d",
+            "@type": "types:Dictionary",
+            "rdfs": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
+            "types:entry": [
+                {
+                    "@id": "kb:DictionaryEntry-55786f64-534d-4e8c-8a64-616f708ea4d3"
+                },
+                {
+                    "@id": "kb:DictionaryEntry-d1a83c3d-cbe6-40b0-bb26-3527c47a01d8"
+                }
+            ]
+        },
+        {
+            "@id": "kb:DictionaryEntry-55786f64-534d-4e8c-8a64-616f708ea4d3",
+            "@type": "types:DictionaryEntry",
+            "types:key": "x",
+            "types:value": "1"
+        },
+        {
+            "@id": "kb:DictionaryEntry-d1a83c3d-cbe6-40b0-bb26-3527c47a01d8",
+            "@type": "types:DictionaryEntry",
+            "types:key": "x",
+            "types:value": "2"
+        },
+        {
+            "@id": "kb:Dictionary-e9adf6c1-0287-4290-95a9-c94a128d7ff6",
+
+            "@type": "types:Dictionary",
+            "rdfs": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
+            "types:entry": [
+                {
+                    "@id": "kb:DictionaryEntry-20431f00-64a3-4c0f-94a4-1eb09f8a6b6a"
+                },
+                {
+                    "@id": "kb:DictionaryEntry-f187ee7f-12fb-4580-966d-47bf1afd4975"
+                }
+            ]
+        },
+        {
+            "@id": "kb:DictionaryEntry-20431f00-64a3-4c0f-94a4-1eb09f8a6b6a",
+            "@type": "types:DictionaryEntry",
+            "types:key": "x",
+            "types:value": "1"
+        },
+        {
+            "@id": "kb:DictionaryEntry-f187ee7f-12fb-4580-966d-47bf1afd4975",
+            "@type": "types:DictionaryEntry",
+            "types:key": "x",
+            "types:value": "1"
+        }
+    ]
+}

--- a/tests/examples/dictionary_PASS.json
+++ b/tests/examples/dictionary_PASS.json
@@ -10,24 +10,18 @@
             "@type": "types:Dictionary",
             "types:entry": [
                 {
-                    "@id": "kb:DictionaryEntry-314212eb-39c4-4bf3-be3a-f07c38f0eae8"
+                    "@id": "kb:DictionaryEntry-314212eb-39c4-4bf3-be3a-f07c38f0eae8",
+                    "@type": "types:DictionaryEntry",
+                    "types:key": "x",
+                    "types:value": "1"
                 },
                 {
-                    "@id": "kb:DictionaryEntry-9ec24a1a-7e99-41c9-ba7d-9d23f11babb4"
+                    "@id": "kb:DictionaryEntry-9ec24a1a-7e99-41c9-ba7d-9d23f11babb4",
+                    "@type": "types:DictionaryEntry",
+                    "types:key": "y",
+                    "types:value": "2"
                 }
             ]
-        },
-        {
-            "@id": "kb:DictionaryEntry-314212eb-39c4-4bf3-be3a-f07c38f0eae8",
-            "@type": "types:DictionaryEntry",
-            "types:key": "x",
-            "types:value": "1"
-        },
-        {
-            "@id": "kb:DictionaryEntry-9ec24a1a-7e99-41c9-ba7d-9d23f11babb4",
-            "@type": "types:DictionaryEntry",
-            "types:key": "y",
-            "types:value": "2"
         },
         {
             "@id": "kb:Dictionary-a8e5e8e1-b3de-4ac4-99dd-e36f96beea4d",
@@ -35,24 +29,18 @@
             "rdfs:comment": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
             "types:entry": [
                 {
-                    "@id": "kb:DictionaryEntry-55786f64-534d-4e8c-8a64-616f708ea4d3"
+                    "@id": "kb:DictionaryEntry-55786f64-534d-4e8c-8a64-616f708ea4d3",
+                    "@type": "types:DictionaryEntry",
+                    "types:key": "x",
+                    "types:value": "1"
                 },
                 {
-                    "@id": "kb:DictionaryEntry-d1a83c3d-cbe6-40b0-bb26-3527c47a01d8"
+                    "@id": "kb:DictionaryEntry-d1a83c3d-cbe6-40b0-bb26-3527c47a01d8",
+                    "@type": "types:DictionaryEntry",
+                    "types:key": "x",
+                    "types:value": "2"
                 }
             ]
-        },
-        {
-            "@id": "kb:DictionaryEntry-55786f64-534d-4e8c-8a64-616f708ea4d3",
-            "@type": "types:DictionaryEntry",
-            "types:key": "x",
-            "types:value": "1"
-        },
-        {
-            "@id": "kb:DictionaryEntry-d1a83c3d-cbe6-40b0-bb26-3527c47a01d8",
-            "@type": "types:DictionaryEntry",
-            "types:key": "x",
-            "types:value": "2"
         },
         {
             "@id": "kb:Dictionary-e9adf6c1-0287-4290-95a9-c94a128d7ff6",
@@ -61,24 +49,18 @@
             "rdfs:comment": "This dictionary will trigger a warning from having two entries keyed with value 'x'.",
             "types:entry": [
                 {
-                    "@id": "kb:DictionaryEntry-20431f00-64a3-4c0f-94a4-1eb09f8a6b6a"
+                    "@id": "kb:DictionaryEntry-20431f00-64a3-4c0f-94a4-1eb09f8a6b6a",
+                    "@type": "types:DictionaryEntry",
+                    "types:key": "x",
+                    "types:value": "1"
                 },
                 {
-                    "@id": "kb:DictionaryEntry-f187ee7f-12fb-4580-966d-47bf1afd4975"
+                    "@id": "kb:DictionaryEntry-f187ee7f-12fb-4580-966d-47bf1afd4975",
+                    "@type": "types:DictionaryEntry",
+                    "types:key": "x",
+                    "types:value": "1"
                 }
             ]
-        },
-        {
-            "@id": "kb:DictionaryEntry-20431f00-64a3-4c0f-94a4-1eb09f8a6b6a",
-            "@type": "types:DictionaryEntry",
-            "types:key": "x",
-            "types:value": "1"
-        },
-        {
-            "@id": "kb:DictionaryEntry-f187ee7f-12fb-4580-966d-47bf1afd4975",
-            "@type": "types:DictionaryEntry",
-            "types:key": "x",
-            "types:value": "1"
         }
     ]
 }

--- a/tests/examples/dictionary_PASS_validation.ttl
+++ b/tests/examples/dictionary_PASS_validation.ttl
@@ -1,0 +1,102 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "true"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/Dictionary-a8e5e8e1-b3de-4ac4-99dd-e36f96beea4d> ;
+			sh:resultMessage "A key in a dictionary can appear no more than once." ;
+			sh:resultSeverity sh:Warning ;
+			sh:sourceConstraint [
+				a sh:SPARQLConstraint ;
+				sh:message "A key in a dictionary can appear no more than once."@en ;
+				sh:select """
+				PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+				SELECT $this ?value
+				WHERE {
+					$this
+						types:entry/types:key ?value ;
+						.
+				}
+				GROUP BY ?value
+				HAVING (COUNT(?value) > 1)
+			""" ;
+			] ;
+			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+			sh:sourceShape [
+				a sh:NodeShape ;
+				rdfs:comment "This anonymous shape is attached to types:Dictionary with rdfs:seeAlso in order to associate a warning-severity SPARQL-based shape, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
+				sh:severity sh:Warning ;
+				sh:sparql [
+					a sh:SPARQLConstraint ;
+					sh:message "A key in a dictionary can appear no more than once."@en ;
+					sh:select """
+				PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+				SELECT $this ?value
+				WHERE {
+					$this
+						types:entry/types:key ?value ;
+						.
+				}
+				GROUP BY ?value
+				HAVING (COUNT(?value) > 1)
+			""" ;
+				] ;
+				sh:targetClass types:Dictionary ;
+			] ;
+			sh:value "x" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/Dictionary-e9adf6c1-0287-4290-95a9-c94a128d7ff6> ;
+			sh:resultMessage "A key in a dictionary can appear no more than once." ;
+			sh:resultSeverity sh:Warning ;
+			sh:sourceConstraint [
+				a sh:SPARQLConstraint ;
+				sh:message "A key in a dictionary can appear no more than once."@en ;
+				sh:select """
+				PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+				SELECT $this ?value
+				WHERE {
+					$this
+						types:entry/types:key ?value ;
+						.
+				}
+				GROUP BY ?value
+				HAVING (COUNT(?value) > 1)
+			""" ;
+			] ;
+			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+			sh:sourceShape [
+				a sh:NodeShape ;
+				rdfs:comment "This anonymous shape is attached to types:Dictionary with rdfs:seeAlso in order to associate a warning-severity SPARQL-based shape, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
+				sh:severity sh:Warning ;
+				sh:sparql [
+					a sh:SPARQLConstraint ;
+					sh:message "A key in a dictionary can appear no more than once."@en ;
+					sh:select """
+				PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+				SELECT $this ?value
+				WHERE {
+					$this
+						types:entry/types:key ?value ;
+						.
+				}
+				GROUP BY ?value
+				HAVING (COUNT(?value) > 1)
+			""" ;
+				] ;
+				sh:targetClass types:Dictionary ;
+			] ;
+			sh:value "x" ;
+		]
+		;
+	.
+

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -207,6 +207,16 @@ def test_database_records_XFAIL() -> None:
       }
     )
 
+def test_dictionary_PASS() -> None:
+    confirm_validation_results(
+      "dictionary_PASS_validation.ttl",
+      True,
+      expected_focus_node_severities={
+        ("http://example.org/kb/Dictionary-a8e5e8e1-b3de-4ac4-99dd-e36f96beea4d", str(NS_SH.Warning)),
+        ('http://example.org/kb/Dictionary-e9adf6c1-0287-4290-95a9-c94a128d7ff6', str(NS_SH.Warning)),
+      }
+    )
+
 def test_event_XFAIL() -> None:
     confirm_validation_results(
         "event_XFAIL_validation.ttl",


### PR DESCRIPTION
This Pull Request will resolve all requirements of Issue #602 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([`0a6de6f`](https://github.com/ucoProject/UCO-Archive/commit/0a6de6f25bd3df766a36f9c534a8a5c6ce995771))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`0210da1`](https://github.com/casework/CASE-Archive/commit/0210da11b4c049385b787d0c1f54018fe34a132c))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Corpora/commit/e36b18a64f17f05137b819f2d76ff39b36c038f7) for CASE-Corpora
- [x] Impact on SHACL validation remediated for CASE-Corpora *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/65e23018f6aee44ccef855691375b77e92d359f7) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/295/commits/c8ed517606952e10dac6c0aa1e12d0e2fa45e530) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status)