### PR TITLE
Issue 590: Warn if an AlternateDataStream instance is not also a FileSystemObject

### DIFF
--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -239,6 +239,14 @@ observable:AlternateDataStream
 	rdfs:subClassOf observable:ObservableObject ;
 	rdfs:label "AlternateDataStream"@en ;
 	rdfs:comment "An alternate data stream is data content stored within an NTFS file that is independent of the standard content stream of the file and is hidden from access by default NTFS file viewing mechanisms."@en ;
+	rdfs:seeAlso [
+		a sh:NodeShape ;
+		rdfs:comment "This anonymous shape is attached with rdfs:seeAlso in order to associate a warning-severity class constraint, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
+		sh:class observable:FileSystemObject ;
+		sh:message "In UCO 2.0.0, uco-observable:AlternateDataStream will be a subclass of uco-observable:FileSystemObject.  In preparation for UCO 2.0.0, the additional type uco-observable:FileSystemObject should be assigned to this node."@en ;
+		sh:severity sh:Warning ;
+		sh:targetClass observable:AlternateDataStream ;
+	] ;
 	sh:targetClass observable:AlternateDataStream ;
 	.
 

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -21,6 +21,7 @@ all: \
   action_inheritance_PASS_validation.ttl \
   action_inheritance_XFAIL_validation.ttl \
   action_result_PASS_validation.ttl \
+  alternate_data_stream_PASS_validation.ttl \
   co_PASS_validation.ttl \
   co_XFAIL_validation.ttl \
   configuration_setting_PASS_validation.ttl \
@@ -92,6 +93,7 @@ check: \
   action_inheritance_PASS_validation.ttl \
   action_inheritance_XFAIL_validation.ttl \
   action_result_PASS_validation.ttl \
+  alternate_data_stream_PASS_validation.ttl \
   co_PASS_validation.ttl \
   co_XFAIL_validation.ttl \
   configuration_setting_PASS_validation.ttl \

--- a/tests/examples/alternate_data_stream_PASS.json
+++ b/tests/examples/alternate_data_stream_PASS.json
@@ -1,0 +1,21 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:AlternateDataStream-07b3c41a-080c-4916-8375-c18148763e13",
+            "@type": "observable:AlternateDataStream",
+            "rdfs:comment": "This node should trigger a sh:Warning from not being a observable:FileSystemObject"
+        },
+        {
+            "@id": "kb:AlternateDataStream-b2d4968b-4490-4b44-a56b-832058834454",
+            "@type": [
+                "observable:AlternateDataStream",
+                "observable:FileSystemObject"
+            ]
+        }
+    ]
+}

--- a/tests/examples/alternate_data_stream_PASS_validation.ttl
+++ b/tests/examples/alternate_data_stream_PASS_validation.ttl
@@ -1,0 +1,28 @@
+@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "true"^^xsd:boolean ;
+	sh:result [
+		a sh:ValidationResult ;
+		sh:focusNode <http://example.org/kb/AlternateDataStream-07b3c41a-080c-4916-8375-c18148763e13> ;
+		sh:resultMessage "In UCO 2.0.0, uco-observable:AlternateDataStream will be a subclass of uco-observable:FileSystemObject.  In preparation for UCO 2.0.0, the additional type uco-observable:FileSystemObject should be assigned to this node."@en ;
+		sh:resultSeverity sh:Warning ;
+		sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+		sh:sourceShape [
+			a sh:NodeShape ;
+			rdfs:comment "This anonymous shape is attached with rdfs:seeAlso in order to associate a warning-severity class constraint, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
+			sh:class observable:FileSystemObject ;
+			sh:message "In UCO 2.0.0, uco-observable:AlternateDataStream will be a subclass of uco-observable:FileSystemObject.  In preparation for UCO 2.0.0, the additional type uco-observable:FileSystemObject should be assigned to this node."@en ;
+			sh:severity sh:Warning ;
+			sh:targetClass observable:AlternateDataStream ;
+		] ;
+		sh:value <http://example.org/kb/AlternateDataStream-07b3c41a-080c-4916-8375-c18148763e13> ;
+	] ;
+	.
+

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -177,6 +177,15 @@ def test_action_result_PASS_validation() -> None:
     g = load_validation_graph("action_result_PASS_validation.ttl", True)
     assert isinstance(g, rdflib.Graph)
 
+def test_alternate_data_stream_PASS_validation() -> None:
+    confirm_validation_results(
+      "alternate_data_stream_PASS_validation.ttl",
+      True,
+      expected_focus_node_severities={
+        ("http://example.org/kb/AlternateDataStream-07b3c41a-080c-4916-8375-c18148763e13", str(NS_SH.Warning)),
+      }
+    )
+
 def test_configuration_setting_PASS_validation() -> None:
     g = load_validation_graph("configuration_setting_PASS_validation.ttl", True)
     assert isinstance(g, rdflib.Graph)


### PR DESCRIPTION
This Pull Request resolves all backwards-compatible requirements of Issue #590 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([`afb1aab`](https://github.com/ucoProject/UCO-Archive/commit/afb1aab8c24f80fc16aa614f3c4dc24db54a10ff))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`5e28bdd`](https://github.com/casework/CASE-Archive/commit/5e28bdda5eba5ead3618f4f335b8c1b97944f8c0))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Corpora/commit/7be2467e932e426d3f0ab2f9c801e7f3934345a8) for CASE-Corpora
- [x] Impact on SHACL validation remediated for CASE-Corpora *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/5fb8dfb35e23520494ae92276600766b3bce8394) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/289/commits/e4c7a250c5980e3f9765b05ed24b0480e7c3dd67) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue