### PR TITLE
Issue 593: Remove owl:onDatatype from vocabulary definitions

### DIFF
--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -322,7 +322,6 @@ core:ObjectStatusVocab
 	rdfs:label "Object Status Vocabulary"@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Draft"^^core:ObjectStatusVocab
 			"Final"^^core:ObjectStatusVocab

--- a/ontology/uco/vocabulary/vocabulary.ttl
+++ b/ontology/uco/vocabulary/vocabulary.ttl
@@ -17,7 +17,6 @@ vocabulary:AccountTypeVocab
 	rdfs:label "Account Type Vocabulary"@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"ldap"^^vocabulary:AccountTypeVocab
 			"nis"^^vocabulary:AccountTypeVocab
@@ -37,7 +36,6 @@ vocabulary:ActionArgumentNameVocab
 	rdfs:comment "Defines an open-vocabulary for common arguments of cyber actions."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"APC Address"^^vocabulary:ActionArgumentNameVocab
 			"APC Mode"^^vocabulary:ActionArgumentNameVocab
@@ -100,7 +98,6 @@ vocabulary:ActionNameVocab
 	rdfs:comment "Defines an open-vocabulary of common specific cyber action names."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Accept Socket Connection"^^vocabulary:ActionNameVocab
 			"Add Connection to Network Share"^^vocabulary:ActionNameVocab
@@ -293,7 +290,6 @@ vocabulary:ActionRelationshipTypeVocab
 	rdfs:comment "Defines an open-vocabulary for capturing types of relationships between actions."@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Dependent_On"^^vocabulary:ActionRelationshipTypeVocab
 			"Equivalent_To"^^vocabulary:ActionRelationshipTypeVocab
@@ -312,7 +308,6 @@ vocabulary:ActionStatusTypeVocab
 	rdfs:comment "Defines an open-vocabulary of action status types."@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Complete/Finish"^^vocabulary:ActionStatusTypeVocab
 			"Error"^^vocabulary:ActionStatusTypeVocab
@@ -331,7 +326,6 @@ vocabulary:ActionTypeVocab
 	rdfs:comment "Defines an open-vocabulary of common general action types."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Accept"^^vocabulary:ActionTypeVocab
 			"Access"^^vocabulary:ActionTypeVocab
@@ -454,7 +448,6 @@ vocabulary:BitnessVocab
 	rdfs:comment "Defines an open-vocabulary of word sizes that define classes of operating systems."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"32"^^vocabulary:BitnessVocab
 			"64"^^vocabulary:BitnessVocab
@@ -468,7 +461,6 @@ vocabulary:CharacterEncodingVocab
 	rdfs:comment "Defines an open-vocabulary of character encodings."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"ASCII"^^vocabulary:CharacterEncodingVocab
 			"UTF-16"^^vocabulary:CharacterEncodingVocab
@@ -493,7 +485,6 @@ vocabulary:ContactAddressScopeVocab
 	rdfs:comment "Defines an open-vocabulary of scopes for address entries of digital contacts."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"home"^^vocabulary:ContactAddressScopeVocab
 			"work"^^vocabulary:ContactAddressScopeVocab
@@ -508,7 +499,6 @@ vocabulary:ContactEmailScopeVocab
 	rdfs:comment "Defines an open-vocabulary of scopes for email entries of digital contacts."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"home"^^vocabulary:ContactEmailScopeVocab
 			"work"^^vocabulary:ContactEmailScopeVocab
@@ -524,7 +514,6 @@ vocabulary:ContactPhoneScopeVocab
 	rdfs:comment "Defines an open-vocabulary of scopes for phone entries of digital contacts."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"home"^^vocabulary:ContactPhoneScopeVocab
 			"work"^^vocabulary:ContactPhoneScopeVocab
@@ -544,7 +533,6 @@ vocabulary:ContactSIPScopeVocab
 	rdfs:comment "Defines an open-vocabulary of scopes for Session Initiation Protocol (SIP) entries of digital contacts."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"home"^^vocabulary:ContactSIPScopeVocab
 			"work"^^vocabulary:ContactSIPScopeVocab
@@ -559,7 +547,6 @@ vocabulary:ContactURLScopeVocab
 	rdfs:comment "Defines an open-vocabulary of scopes for URL entries of digital contacts."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"home"^^vocabulary:ContactURLScopeVocab
 			"work"^^vocabulary:ContactURLScopeVocab
@@ -575,7 +562,6 @@ vocabulary:DiskTypeVocab
 	rdfs:comment "Defines an open-vocabulary of disk types."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"CDRom"^^vocabulary:DiskTypeVocab
 			"Fixed"^^vocabulary:DiskTypeVocab
@@ -592,7 +578,6 @@ vocabulary:EndiannessTypeVocab
 	rdfs:comment "Defines an open-vocabulary of byte ordering methods."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Big-endian"^^vocabulary:EndiannessTypeVocab
 			"Little-endian"^^vocabulary:EndiannessTypeVocab
@@ -607,7 +592,6 @@ vocabulary:HashNameVocab
 	rdfs:comment "Defines an open-vocabulary of hashing algorithm names."@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"MD5"^^vocabulary:HashNameVocab
 			"MD6"^^vocabulary:HashNameVocab
@@ -631,7 +615,6 @@ vocabulary:LibraryTypeVocab
 	rdfs:comment "Defines an open-vocabulary of library types."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Dynamic"^^vocabulary:LibraryTypeVocab
 			"Other"^^vocabulary:LibraryTypeVocab
@@ -648,7 +631,6 @@ vocabulary:MemoryBlockTypeVocab
 	rdfs:comment "Defines an open-vocabulary of types of memory blocks."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Bit-mapped"^^vocabulary:MemoryBlockTypeVocab
 			"Byte-mapped"^^vocabulary:MemoryBlockTypeVocab
@@ -665,7 +647,6 @@ vocabulary:ObservableObjectRelationshipVocab
 	rdfs:comment "Defines an open-vocabulary of inter-observable object relationships."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Allocated"^^vocabulary:ObservableObjectRelationshipVocab
 			"Allocated_By"^^vocabulary:ObservableObjectRelationshipVocab
@@ -816,7 +797,6 @@ vocabulary:ObservableObjectStateVocab
 	rdfs:comment "Defines an open-vocabulary of observable object states."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Active"^^vocabulary:ObservableObjectStateVocab
 			"Closed"^^vocabulary:ObservableObjectStateVocab
@@ -838,7 +818,6 @@ vocabulary:PartitionTypeVocab
 	rdfs:comment "Defines an open-vocabulary of partition types. See http://www.win.tue.nl/~aeb/partitions/partition_types-1.html for more information about the various partition types."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"PARTITION_ENTRY_UNUSED"^^vocabulary:PartitionTypeVocab
 			"PARTITION_EXTENDED"^^vocabulary:PartitionTypeVocab
@@ -869,7 +848,6 @@ vocabulary:ProcessorArchVocab
 	rdfs:comment "Defines an open-vocabulary of computer processor architectures."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"ARM"^^vocabulary:ProcessorArchVocab
 			"Alpha"^^vocabulary:ProcessorArchVocab
@@ -893,7 +871,6 @@ vocabulary:RecoveredObjectStatusVocab
 	rdfs:comment "Defines the vocabulary for Recovered Object status of data."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"recovered"^^vocabulary:RecoveredObjectStatusVocab
 			"partially recovered"^^vocabulary:RecoveredObjectStatusVocab
@@ -909,7 +886,6 @@ vocabulary:RegionalRegistryTypeVocab
 	rdfs:comment "Defines an open-vocabulary of Regional Internet Registries (RIRs) names, represented via their respective acronyms."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"APNIC"^^vocabulary:RegionalRegistryTypeVocab
 			"ARIN"^^vocabulary:RegionalRegistryTypeVocab
@@ -925,7 +901,6 @@ vocabulary:RegistryDatatypeVocab
 	rdfs:label "Registry Datatype Vocabulary"@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"reg_binary"^^vocabulary:RegistryDatatypeVocab
 			"reg_dword"^^vocabulary:RegistryDatatypeVocab
@@ -950,7 +925,6 @@ vocabulary:SIMFormVocab
 	rdfs:comment "Defines an open-vocabulary of common SIM card form factors."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Full-size SIM"^^vocabulary:SIMFormVocab
 			"Micro SIM"^^vocabulary:SIMFormVocab
@@ -965,7 +939,6 @@ vocabulary:SIMTypeVocab
 	rdfs:comment "Defines an open-vocabulary of common SIM card types."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"SIM"^^vocabulary:SIMTypeVocab
 			"UICC"^^vocabulary:SIMTypeVocab
@@ -980,7 +953,6 @@ vocabulary:TaskActionTypeVocab
 	rdfs:comment "Defines an open-vocabulary of task action types. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380596(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"TASK_ACTION_COM_HANDLER"^^vocabulary:TaskActionTypeVocab
 			"TASK_ACTION_EXEC"^^vocabulary:TaskActionTypeVocab
@@ -996,7 +968,6 @@ vocabulary:TaskFlagVocab
 	rdfs:comment "Defines an open-vocabulary of the run flags for a task scheduler task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx See Also: http://msdn.microsoft.com/en-us/library/microsoft.office.excel.server.addins.computecluster.taskscheduler.taskflags(v=office.12).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"TASK_FLAG_DELETE_WHEN_DONE"^^vocabulary:TaskFlagVocab
 			"TASK_FLAG_DISABLED"^^vocabulary:TaskFlagVocab
@@ -1021,7 +992,6 @@ vocabulary:TaskPriorityVocab
 	rdfs:comment "Defines an open-vocabulary of the priority levels of task scheduler tasks. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383512(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"ABOVE_NORMAL_PRIORITY_CLASS"^^vocabulary:TaskPriorityVocab
 			"BELOW_NORMAL_PRIORITY_CLASS"^^vocabulary:TaskPriorityVocab
@@ -1039,7 +1009,6 @@ vocabulary:TaskStatusVocab
 	rdfs:comment "Defines an open-vocabulary of the possible statuses of a scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383604(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381263(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381833(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383617(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"SCHED_E_ACCOUNT_DBASE_CORRUPT"^^vocabulary:TaskStatusVocab
 			"SCHED_E_ACCOUNT_INFORMATION_NOT_SET"^^vocabulary:TaskStatusVocab
@@ -1075,7 +1044,6 @@ vocabulary:ThreadRunningStatusVocab
 	rdfs:comment "Defines an open-vocabulary of the various states that a thread may be in before, during, or after execution. See http://msdn.microsoft.com/en-us/library/system.diagnostics.threadstate(v=vs.110).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Initialized"^^vocabulary:ThreadRunningStatusVocab
 			"Ready"^^vocabulary:ThreadRunningStatusVocab
@@ -1095,7 +1063,6 @@ vocabulary:TimestampPrecisionVocab
 	rdfs:comment "Defines an open-vocabulary of timestamp precision granularities."@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"day"^^vocabulary:TimestampPrecisionVocab
 			"hour"^^vocabulary:TimestampPrecisionVocab
@@ -1113,7 +1080,6 @@ vocabulary:TrendVocab
 	rdfs:comment "Defines an open-vocabulary of trend values."@en-US ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Decreasing"^^vocabulary:TrendVocab
 			"Increasing"^^vocabulary:TrendVocab
@@ -1127,7 +1093,6 @@ vocabulary:TriggerFrequencyVocab
 	rdfs:comment "Defines an open-vocabulary of the frequency types that a trigger may use. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383620(v=vs.85).aspx and http://msdn.microsoft.com/en-us/library/windows/desktop/aa383987(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"TASK_EVENT_TRIGGER_AT_LOGON"^^vocabulary:TriggerFrequencyVocab
 			"TASK_EVENT_TRIGGER_AT_SYSTEMSTART"^^vocabulary:TriggerFrequencyVocab
@@ -1147,7 +1112,6 @@ vocabulary:TriggerTypeVocab
 	rdfs:comment "Defines an open-vocabulary of the types of triggers associated with a task."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"TASK_TRIGGER_BOOT"^^vocabulary:TriggerTypeVocab
 			"TASK_TRIGGER_EVENT"^^vocabulary:TriggerTypeVocab
@@ -1166,7 +1130,6 @@ vocabulary:URLTransitionTypeVocab
 	rdfs:comment "Defines an open-vocabulary of types of URL transitions."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"link"^^vocabulary:URLTransitionTypeVocab
 			"typed"^^vocabulary:URLTransitionTypeVocab
@@ -1189,7 +1152,6 @@ vocabulary:UnixProcessStateVocab
 	rdfs:comment "Defines an open-vocabulary of Unix process states"@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Dead"^^vocabulary:UnixProcessStateVocab
 			"InterruptibleSleep"^^vocabulary:UnixProcessStateVocab
@@ -1208,7 +1170,6 @@ vocabulary:WhoisContactTypeVocab
 	rdfs:comment "Defines an open-vocabulary of types of registrar contacts listed in a whois entry."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"ADMIN"^^vocabulary:WhoisContactTypeVocab
 			"BILLING"^^vocabulary:WhoisContactTypeVocab
@@ -1223,7 +1184,6 @@ vocabulary:WhoisDNSSECTypeVocab
 	rdfs:comment "Defines an open-vocabulary of acceptable values for the DNSSEC field in a Whois entry."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Signed"^^vocabulary:WhoisDNSSECTypeVocab
 			"Unsigned"^^vocabulary:WhoisDNSSECTypeVocab
@@ -1237,7 +1197,6 @@ vocabulary:WhoisStatusTypeVocab
 	rdfs:comment "Defines an open-vocabulary of all valid statuses for a domain within a whois entry."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"ADD_PERIOD"^^vocabulary:WhoisStatusTypeVocab
 			"AUTO_RENEW_PERIOD"^^vocabulary:WhoisStatusTypeVocab
@@ -1268,7 +1227,6 @@ vocabulary:WindowsDriveTypeVocab
 	rdfs:comment "Defines an open-vocabulary of possible drive types, as enumerated by the WINAPI GetDriveType function: http://msdn.microsoft.com/en-us/library/windows/desktop/aa364939(v=vs.85).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"DRIVE_CDROM"^^vocabulary:WindowsDriveTypeVocab
 			"DRIVE_FIXED"^^vocabulary:WindowsDriveTypeVocab
@@ -1287,7 +1245,6 @@ vocabulary:WindowsVolumeAttributeVocab
 	rdfs:comment "Defines an open-vocabulary of attributes that may be returned by the diskpart attributes command: http://technet.microsoft.com/en-us/library/cc766465(v=ws.10).aspx."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"Hidden"^^vocabulary:WindowsVolumeAttributeVocab
 			"NoDefaultDriveLetter"^^vocabulary:WindowsVolumeAttributeVocab
@@ -1303,7 +1260,6 @@ vocabulary:WirelessNetworkSecurityModeVocab
 	rdfs:comment "Defines an open-vocabulary of security modes that may be configured for wireless network connections."@en ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
 		owl:oneOf (
 			"None"^^vocabulary:WirelessNetworkSecurityModeVocab
 			"WEP"^^vocabulary:WirelessNetworkSecurityModeVocab


### PR DESCRIPTION
This Pull Request resolves all requirements of Issue #593 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([`78c3bb4`](https://github.com/ucoProject/UCO-Archive/commit/78c3bb481cc3040aab594b5ef334050f847c840b))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`5c608e4`](https://github.com/casework/CASE-Archive/commit/5c608e482fb924f2aefb0d68e8201ab245c4e638))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Corpora/commit/e7bc1becb707e4bbf376da0f0d1347c3f290b157) for CASE-Corpora
- [x] Impact on SHACL validation remediated for CASE-Corpora *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/48b5842d43f98c1e4711582bc698d025ebb25ffe) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/303/commits/54077b66b5874f765938851cc5cd6942c9ea8b97) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status)