### PR TITLE
Issue 549: Add objectStatus

### DIFF
--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -725,7 +725,7 @@ core:objectMarking
 
 core:objectStatus
 	a owl:AnnotationProperty ;
-	rdfs:label "Object Status"@en-US ;
+	rdfs:label "objectStatus"@en ;
 	rdfs:comment "The current state of formality and acceptance for a UCO object."@en-US ;
 	rdfs:range core:ObjectStatusVocab ;
 	.

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -724,7 +724,7 @@ core:objectMarking
 	.
 
 core:objectStatus
-	a owl:DatatypeProperty ;
+	a owl:AnnotationProperty ;
 	rdfs:label "Object Status"@en-US ;
 	rdfs:comment "The current state of formality and acceptance for a UCO object."@en-US ;
 	rdfs:range core:ObjectStatusVocab ;

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -726,7 +726,7 @@ core:objectMarking
 core:objectStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "Object Status"@en-US ;
-	rdfs:comment "The current state of formality and acceptance for a UCO object ."@en-US ;
+	rdfs:comment "The current state of formality and acceptance for a UCO object."@en-US ;
 	rdfs:range core:ObjectStatusVocab ;
 	.
 

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -5,7 +5,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/core>
@@ -318,6 +317,20 @@ core:ModusOperandi
 	sh:targetClass core:ModusOperandi ;
 	.
 
+core:ObjectStatusVocab
+	a rdfs:Datatype ;
+	rdfs:label "Object Status Vocabulary"@en-US ;
+	owl:equivalentClass [
+		a rdfs:Datatype ;
+		owl:onDatatype xsd:string ;
+		owl:oneOf (
+			"Draft"^^core:ObjectStatusVocab
+			"Final"^^core:ObjectStatusVocab
+			"Deprecated"^^core:ObjectStatusVocab
+		) ;
+	] ;
+	.
+
 core:Relationship
 	a
 		owl:Class ,
@@ -454,7 +467,7 @@ core:UcoObject
 			sh:path core:tag ;
 		] ,
 		[
-			sh:datatype vocabulary:ObjectStatusVocab ;
+			sh:datatype core:ObjectStatusVocab ;
 			sh:message "Value is outside the default vocabulary ObjectStatusVocab." ;
 			sh:path core:objectStatus ;
 			sh:severity sh:Info ;
@@ -464,7 +477,7 @@ core:UcoObject
 			sh:nodeKind sh:Literal ;
 			sh:or (
 				[
-					sh:datatype vocabulary:ObjectStatusVocab ;
+					sh:datatype core:ObjectStatusVocab ;
 				]
 				[
 					sh:datatype xsd:string ;
@@ -476,11 +489,11 @@ core:UcoObject
 			sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
 			sh:or (
 				[
-					sh:datatype vocabulary:ObjectStatusVocab ;
+					sh:datatype core:ObjectStatusVocab ;
 					sh:in (
-						"Draft"^^vocabulary:ObjectStatusVocab
-						"Final"^^vocabulary:ObjectStatusVocab
-						"Deprecated"^^vocabulary:ObjectStatusVocab
+						"Draft"^^core:ObjectStatusVocab
+						"Final"^^core:ObjectStatusVocab
+						"Deprecated"^^core:ObjectStatusVocab
 					) ;
 				]
 				[
@@ -742,7 +755,7 @@ core:objectStatus
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:ObjectStatusVocab
+			core:ObjectStatusVocab
 		) ;
 	] ;
 	.

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -468,38 +468,14 @@ core:UcoObject
 		] ,
 		[
 			sh:datatype core:ObjectStatusVocab ;
-			sh:message "Value is outside the default vocabulary ObjectStatusVocab." ;
-			sh:path core:objectStatus ;
-			sh:severity sh:Info ;
-		] ,
-		[
+			sh:in (
+				"Draft"^^core:ObjectStatusVocab
+				"Final"^^core:ObjectStatusVocab
+				"Deprecated"^^core:ObjectStatusVocab
+			) ;
 			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:or (
-				[
-					sh:datatype core:ObjectStatusVocab ;
-				]
-				[
-					sh:datatype xsd:string ;
-				]
-			) ;
-			sh:path core:objectStatus ;
-		] ,
-		[
 			sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
-			sh:or (
-				[
-					sh:datatype core:ObjectStatusVocab ;
-					sh:in (
-						"Draft"^^core:ObjectStatusVocab
-						"Final"^^core:ObjectStatusVocab
-						"Deprecated"^^core:ObjectStatusVocab
-					) ;
-				]
-				[
-					sh:datatype xsd:string ;
-				]
-			) ;
+			sh:nodeKind sh:Literal ;
 			sh:path core:objectStatus ;
 		]
 		;
@@ -751,13 +727,7 @@ core:objectStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "Object Status"@en-US ;
 	rdfs:comment "The current state of formality and acceptance for a UCO object ."@en-US ;
-	rdfs:range [
-		a rdfs:Datatype ;
-		owl:unionOf (
-			xsd:string
-			core:ObjectStatusVocab
-		) ;
-	] ;
+	rdfs:range core:ObjectStatusVocab ;
 	.
 
 core:referenceURL

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -403,8 +403,8 @@ core:UcoObject
 			sh:message "Value is outside the default vocabulary ObjectStatusVocab." ;
 			sh:path core:objectStatus ;
 			sh:severity sh:Info ;
-  		] ,
-  		[
+		] ,
+		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:or (
@@ -416,8 +416,8 @@ core:UcoObject
 				]
 			) ;
 			sh:path core:objectStatus ;
-  		] ,
-  		[
+		] ,
+		[
 			sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
 			sh:or (
 				[
@@ -433,7 +433,7 @@ core:UcoObject
 				]
 			) ;
 			sh:path core:objectStatus ;
-  		]
+		]
 		;
 	sh:targetClass core:UcoObject ;
 	.
@@ -660,9 +660,9 @@ core:objectMarking
 
 core:objectStatus
 	a owl:DatatypeProperty ;
-  	rdfs:comment "The current state of formality and acceptance for a UCO object ."@en-US ;
-  	rdfs:label "Object Status"@en-US ;
-  	rdfs:range [
+	rdfs:label "Object Status"@en-US ;
+	rdfs:comment "The current state of formality and acceptance for a UCO object ."@en-US ;
+	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -396,7 +396,44 @@ core:UcoObject
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
 			sh:path core:tag ;
-		]
+		] ,
+		[
+			sh:datatype vocabulary:ObjectStatusVocab ;
+			sh:message "Value is outside the default vocabulary ObjectStatusVocab." ;
+			sh:path core:objectStatus ;
+			sh:severity sh:Info ;
+  		] ,
+  		[
+			sh:minCount "1"^^xsd:integer ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:or (
+				[
+					sh:datatype vocabulary:ObjectStatusVocab ;
+				]
+				[
+					sh:datatype xsd:string ;
+				]
+			) ;
+			sh:path core:objectStatus ;
+  		] ,
+  		[
+			sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
+			sh:or (
+				[
+					sh:datatype vocabulary:ObjectStatusVocab ;
+					sh:in (
+						"Draft"^^vocabulary:ObjectStatusVocab
+						"Final"^^vocabulary:ObjectStatusVocab
+						"Deprecated"^^vocabulary:ObjectStatusVocab
+					) ;
+				]
+				[
+					sh:datatype xsd:string ;
+				]
+			) ;
+			sh:path core:objectStatus ;
+  		]
 		;
 	sh:targetClass core:UcoObject ;
 	.
@@ -619,6 +656,19 @@ core:objectMarking
 	rdfs:label "objectMarking"@en ;
 	rdfs:comment "Marking definitions to be applied to a particular concept characterization in its entirety."@en ;
 	rdfs:range core:MarkingDefinitionAbstraction ;
+	.
+
+core:objectStatus
+	a owl:DatatypeProperty ;
+  	rdfs:comment "The current state of formality and acceptance for a UCO object ."@en-US ;
+  	rdfs:label "Object Status"@en-US ;
+  	rdfs:range [
+		a rdfs:Datatype ;
+		owl:unionOf (
+			xsd:string
+			vocabulary:ObjectStatusVocab
+		) ;
+	] ;
 	.
 
 core:referenceURL

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -474,7 +474,6 @@ core:UcoObject
 				"Deprecated"^^core:ObjectStatusVocab
 			) ;
 			sh:maxCount "1"^^xsd:integer ;
-			sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
 			sh:nodeKind sh:Literal ;
 			sh:path core:objectStatus ;
 		]

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/core>

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -405,7 +405,6 @@ core:UcoObject
 			sh:severity sh:Info ;
   		] ,
   		[
-			sh:minCount "1"^^xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:or (

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -730,6 +730,12 @@ core:objectStatus
 	rdfs:range core:ObjectStatusVocab ;
 	.
 
+core:objectStatus-subjects-shape
+	a sh:NodeShape ;
+	sh:class core:UcoObject ;
+	sh:targetSubjectsOf core:objectStatus ;
+	.
+
 core:referenceURL
 	a owl:DatatypeProperty ;
 	rdfs:label "referenceURL"@en ;

--- a/ontology/uco/vocabulary/vocabulary.ttl
+++ b/ontology/uco/vocabulary/vocabulary.ttl
@@ -659,6 +659,20 @@ vocabulary:MemoryBlockTypeVocab
 	] ;
 	.
 
+vocabulary:ObjectStatusVocab
+	a rdfs:Datatype ;
+	rdfs:label "Object Status Vocabulary"@en-US ;
+	owl:equivalentClass [
+		a rdfs:Datatype ;
+		owl:onDatatype xsd:string ;
+		owl:oneOf (
+			"Draft"^^vocabulary:ObjectStatusVocab
+			"Final"^^vocabulary:ObjectStatusVocab
+			"Deprecated"^^vocabulary:ObjectStatusVocab
+		) ;
+	] ;
+	.
+
 vocabulary:ObservableObjectRelationshipVocab
 	a rdfs:Datatype ;
 	rdfs:label "Cyber Item Relationship Vocabulary"@en-US ;

--- a/ontology/uco/vocabulary/vocabulary.ttl
+++ b/ontology/uco/vocabulary/vocabulary.ttl
@@ -659,20 +659,6 @@ vocabulary:MemoryBlockTypeVocab
 	] ;
 	.
 
-vocabulary:ObjectStatusVocab
-	a rdfs:Datatype ;
-	rdfs:label "Object Status Vocabulary"@en-US ;
-	owl:equivalentClass [
-		a rdfs:Datatype ;
-		owl:onDatatype xsd:string ;
-		owl:oneOf (
-			"Draft"^^vocabulary:ObjectStatusVocab
-			"Final"^^vocabulary:ObjectStatusVocab
-			"Deprecated"^^vocabulary:ObjectStatusVocab
-		) ;
-	] ;
-	.
-
 vocabulary:ObservableObjectRelationshipVocab
 	a rdfs:Datatype ;
 	rdfs:label "Cyber Item Relationship Vocabulary"@en-US ;

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -41,6 +41,8 @@ all: \
   location_XFAIL_validation.ttl \
   message_thread_PASS_validation.ttl \
   message_thread_XFAIL_validation.ttl \
+  object_status_PASS_validation.ttl \
+  object_status_XFAIL_validation.ttl \
   observable_creation_time_PASS_validation.ttl \
   owl_axiom_PASS_validation.ttl \
   owl_axiom_XFAIL_validation.ttl \
@@ -116,6 +118,8 @@ check: \
   location_XFAIL_validation.ttl \
   message_thread_PASS_validation.ttl \
   message_thread_XFAIL_validation.ttl \
+  object_status_PASS_validation.ttl \
+  object_status_XFAIL_validation.ttl \
   observable_creation_time_PASS_validation.ttl \
   owl_axiom_PASS_validation.ttl \
   owl_axiom_XFAIL_validation.ttl \

--- a/tests/examples/object_status_PASS.json
+++ b/tests/examples/object_status_PASS.json
@@ -1,0 +1,16 @@
+{
+    "@context": {
+        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "kb": "http://example.org/kb/"
+    },
+    "@graph": [
+        {
+            "@id": "kb:UcoObject-f86c567d-374a-4873-b9bc-a746ca2bf360",
+            "@type": "core:UcoObject",
+            "core:objectStatus": {
+                "@type": "core:ObjectStatusVocab",
+                "@value": "Draft"
+            }
+        }
+    ]
+}

--- a/tests/examples/object_status_PASS_validation.ttl
+++ b/tests/examples/object_status_PASS_validation.ttl
@@ -1,0 +1,11 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "true"^^xsd:boolean ;
+	.
+

--- a/tests/examples/object_status_XFAIL.json
+++ b/tests/examples/object_status_XFAIL.json
@@ -1,0 +1,15 @@
+{
+    "@context": {
+        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "kb": "http://example.org/kb/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351",
+            "@type": "core:UcoObject",
+            "rdfs:comment": "This will trigger an error from using a value outside of the required vocabulary.",
+            "core:objectStatus": "Initial draft"
+        }
+    ]
+}

--- a/tests/examples/object_status_XFAIL.json
+++ b/tests/examples/object_status_XFAIL.json
@@ -10,6 +10,17 @@
             "@type": "core:UcoObject",
             "rdfs:comment": "This will trigger an error from using a value outside of the required vocabulary.",
             "core:objectStatus": "Initial draft"
+        },
+        {
+            "@id": "kb:File-c9c36379-8eca-4a85-887c-b51f7721edfd",
+            "@type": "observable:File",
+            "core:hasFacet": {
+                "@id": "kb:ArchiveFileFacet-5884ca1c-2f5e-4e66-bdc6-7d48606f9fbc",
+                "@type": "observable:ArchiveFileFacet",
+                "rdfs:comment": "This will trigger an error from using objectStatus on a non-UcoObject thing.",
+                "core:objectStatus": "Draft",
+                "observable:archiveType": "Currently-unknown compressing-and-encrypting type seen multiple places, further research needed"
+            }
         }
     ]
 }

--- a/tests/examples/object_status_XFAIL_validation.ttl
+++ b/tests/examples/object_status_XFAIL_validation.ttl
@@ -1,0 +1,56 @@
+@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
+			sh:resultMessage "Value is not member of the vocabulary ObjectStatusVocab." ;
+			sh:resultPath core:objectStatus ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype core:ObjectStatusVocab ;
+				sh:in (
+					"Draft"^^core:ObjectStatusVocab
+					"Final"^^core:ObjectStatusVocab
+					"Deprecated"^^core:ObjectStatusVocab
+				) ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:objectStatus ;
+			] ;
+			sh:value "Initial draft" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
+			sh:resultMessage "Value is not member of the vocabulary ObjectStatusVocab." ;
+			sh:resultPath core:objectStatus ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:InConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype core:ObjectStatusVocab ;
+				sh:in (
+					"Draft"^^core:ObjectStatusVocab
+					"Final"^^core:ObjectStatusVocab
+					"Deprecated"^^core:ObjectStatusVocab
+				) ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:objectStatus ;
+			] ;
+			sh:value "Initial draft" ;
+		]
+		;
+	.
+

--- a/tests/examples/object_status_XFAIL_validation.ttl
+++ b/tests/examples/object_status_XFAIL_validation.ttl
@@ -11,6 +11,15 @@
 	sh:result
 		[
 			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/ArchiveFileFacet-5884ca1c-2f5e-4e66-bdc6-7d48606f9fbc> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape core:objectStatus-subjects-shape ;
+			sh:value <http://example.org/kb/ArchiveFileFacet-5884ca1c-2f5e-4e66-bdc6-7d48606f9fbc> ;
+		] ,
+		[
+			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
 			sh:resultMessage "Value is not member of the vocabulary ObjectStatusVocab." ;
 			sh:resultPath core:objectStatus ;

--- a/tests/examples/object_status_XFAIL_validation.ttl
+++ b/tests/examples/object_status_XFAIL_validation.ttl
@@ -21,7 +21,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
-			sh:resultMessage "Value Literal(\"Initial draft\") not in list ['Literal(\"Final\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Draft\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Deprecated\" = None, datatype=core:ObjectStatusVocab)']" ;
+			sh:resultMessage "Value Literal(\"Initial draft\") not in list ['Literal(\"Draft\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Final\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Deprecated\" = None, datatype=core:ObjectStatusVocab)']" ;
 			sh:resultPath core:objectStatus ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;

--- a/tests/examples/object_status_XFAIL_validation.ttl
+++ b/tests/examples/object_status_XFAIL_validation.ttl
@@ -21,28 +21,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
-			sh:resultMessage "Value is not member of the vocabulary ObjectStatusVocab." ;
-			sh:resultPath core:objectStatus ;
-			sh:resultSeverity sh:Violation ;
-			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
-			sh:sourceShape [
-				sh:datatype core:ObjectStatusVocab ;
-				sh:in (
-					"Draft"^^core:ObjectStatusVocab
-					"Final"^^core:ObjectStatusVocab
-					"Deprecated"^^core:ObjectStatusVocab
-				) ;
-				sh:maxCount "1"^^xsd:integer ;
-				sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
-				sh:nodeKind sh:Literal ;
-				sh:path core:objectStatus ;
-			] ;
-			sh:value "Initial draft" ;
-		] ,
-		[
-			a sh:ValidationResult ;
-			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
-			sh:resultMessage "Value is not member of the vocabulary ObjectStatusVocab." ;
+			sh:resultMessage "Value Literal(\"Initial draft\") not in list ['Literal(\"Final\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Draft\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Deprecated\" = None, datatype=core:ObjectStatusVocab)']" ;
 			sh:resultPath core:objectStatus ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;
@@ -54,7 +33,26 @@
 					"Deprecated"^^core:ObjectStatusVocab
 				) ;
 				sh:maxCount "1"^^xsd:integer ;
-				sh:message "Value is not member of the vocabulary ObjectStatusVocab." ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:objectStatus ;
+			] ;
+			sh:value "Initial draft" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
+			sh:resultMessage "Value is not Literal with datatype core:ObjectStatusVocab" ;
+			sh:resultPath core:objectStatus ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype core:ObjectStatusVocab ;
+				sh:in (
+					"Draft"^^core:ObjectStatusVocab
+					"Final"^^core:ObjectStatusVocab
+					"Deprecated"^^core:ObjectStatusVocab
+				) ;
+				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
 				sh:path core:objectStatus ;
 			] ;

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -440,6 +440,10 @@ def test_object_status_XFAIL() -> None:
           "http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351",
           str(NS_SH.Violation)
         ),
+        (
+          "http://example.org/kb/ArchiveFileFacet-5884ca1c-2f5e-4e66-bdc6-7d48606f9fbc",
+          str(NS_SH.Violation)
+        ),
       }
     )
 

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -425,6 +425,24 @@ def test_message_thread_PASS_validation() -> None:
 def test_message_thread_XFAIL_validation() -> None:
     confirm_validation_results("message_thread_XFAIL_validation.ttl", False)
 
+def test_object_status_PASS() -> None:
+    confirm_validation_results(
+      "object_status_PASS_validation.ttl",
+      True,
+    )
+
+def test_object_status_XFAIL() -> None:
+    confirm_validation_results(
+      "object_status_XFAIL_validation.ttl",
+      False,
+      expected_focus_node_severities={
+        (
+          "http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351",
+          str(NS_SH.Violation)
+        ),
+      }
+    )
+
 def test_observable_creation_time_PASS() -> None:
     confirm_validation_results(
       "observable_creation_time_PASS_validation.ttl",


### PR DESCRIPTION
This Pull Request resolves all requirements of Issue #549 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [x] CI passes in UCO current `unstable` branch ([`71dab8f`](https://github.com/ucoProject/UCO-Archive/commit/71dab8f6e04f4d95a7553080c01dbd88a627b4ef))
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`ae08b73`](https://github.com/casework/CASE-Archive/commit/ae08b7311c498b88a5481afbf6915f3381e524e2))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Corpora/commit/dabfef8c45237e1007d0ce8004caf7b205bec6ba) for CASE-Corpora
- [x] Impact on SHACL validation remediated for CASE-Corpora *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/8a7488479844f8c9da69d183dda416ade651728c) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/301/commits/79151781dc432768d1ccb35fe2cd70fbe0ffd096) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status)