### PR TITLE
Regenerate example-validation files

### DIFF
--- a/tests/examples/co_XFAIL_validation.ttl
+++ b/tests/examples/co_XFAIL_validation.ttl
@@ -78,7 +78,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/list-item-4361eb9c-a1c2-40e7-ba83-92802554392a> ;
-			sh:resultMessage 'Node kb:list-item-4361eb9c-a1c2-40e7-ba83-92802554392a conforms to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
+			sh:resultMessage 'Node kb:list-item-4361eb9c-a1c2-40e7-ba83-92802554392a must not conform to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NotConstraintComponent ;
 			sh:sourceShape uco-co:itemContent-subjects-shape ;

--- a/tests/examples/configuration_setting_XFAIL_validation.ttl
+++ b/tests/examples/configuration_setting_XFAIL_validation.ttl
@@ -13,7 +13,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c> ;
-			sh:resultMessage 'Node kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c does not conform to exactly one shape in [ sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemObject ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemValue ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemObject ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemValue ] ]' ;
+			sh:resultMessage 'Node kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c must conform to exactly one shape in [ sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemObject ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemValue ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemObject ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemValue ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 			sh:sourceShape configuration:ConfigurationEntry ;

--- a/tests/examples/database_records_XFAIL_validation.ttl
+++ b/tests/examples/database_records_XFAIL_validation.ttl
@@ -12,7 +12,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29> ;
-			sh:resultMessage 'Node kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultMessage 'Node kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 			sh:sourceShape observable:TableFieldFacet ;
@@ -35,7 +35,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
-			sh:resultMessage 'Node kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultMessage 'Node kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 			sh:sourceShape observable:TableFieldFacet ;

--- a/tests/examples/hash_XFAIL_validation.ttl
+++ b/tests/examples/hash_XFAIL_validation.ttl
@@ -78,7 +78,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
-			sh:resultMessage 'Node Literal("1", datatype=xsd:integer) does not conform to one or more shapes in [ sh:datatype vocabulary:HashNameVocab ] , [ sh:datatype xsd:string ]' ;
+			sh:resultMessage 'Node Literal("1", datatype=xsd:integer) must conform to one or more shapes in [ sh:datatype vocabulary:HashNameVocab ] , [ sh:datatype xsd:string ]' ;
 			sh:resultPath types:hashMethod ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;

--- a/tests/examples/object_status_XFAIL_validation.ttl
+++ b/tests/examples/object_status_XFAIL_validation.ttl
@@ -21,7 +21,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
-			sh:resultMessage "Value Literal(\"Initial draft\") not in list ['Literal(\"Draft\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Final\" = None, datatype=core:ObjectStatusVocab)', 'Literal(\"Deprecated\" = None, datatype=core:ObjectStatusVocab)']" ;
+			sh:resultMessage "Value Literal(\"Initial draft\") not in list ['Literal(\"Draft\", datatype=core:ObjectStatusVocab)', 'Literal(\"Final\", datatype=core:ObjectStatusVocab)', 'Literal(\"Deprecated\", datatype=core:ObjectStatusVocab)']" ;
 			sh:resultPath core:objectStatus ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;

--- a/tests/examples/rdf_list_XFAIL_validation.ttl
+++ b/tests/examples/rdf_list_XFAIL_validation.ttl
@@ -14,7 +14,7 @@
 			sh:detail [
 				a sh:ValidationResult ;
 				sh:focusNode <http://example.org/kb/list-1> ;
-				sh:resultMessage 'Node kb:list-1 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
+				sh:resultMessage 'Node kb:list-1 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 				sh:sourceShape uco-owl:Sequence-shape ;
@@ -40,7 +40,7 @@
 			sh:detail [
 				a sh:ValidationResult ;
 				sh:focusNode <http://example.org/ontology/someDatatypeProperty> ;
-				sh:resultMessage 'Node ex:someDatatypeProperty does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
+				sh:resultMessage 'Node ex:someDatatypeProperty must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 				sh:sourceShape uco-owl:Sequence-shape ;
@@ -66,7 +66,7 @@
 					<http://example.org/kb/concept-7>
 					<http://example.org/kb/concept-8>
 				) ;
-				sh:resultMessage 'Node ( kb:concept-7 kb:concept-8 ) does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
+				sh:resultMessage 'Node ( kb:concept-7 kb:concept-8 ) must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 				sh:sourceShape uco-owl:Sequence-shape ;

--- a/tests/examples/thread_XFAIL_validation.ttl
+++ b/tests/examples/thread_XFAIL_validation.ttl
@@ -48,7 +48,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987> ;
-			sh:resultMessage 'Node kb:thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987 conforms to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
+			sh:resultMessage 'Node kb:thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987 must not conform to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NotConstraintComponent ;
 			sh:sourceShape uco-co:itemContent-subjects-shape ;


### PR DESCRIPTION
This is a maintenance Pull Request, incorporating no new features.  Make-managed files that demonstrate validation results are regenerated.  Recent updates to the SHACL validation tool include adjusted result message template strings, so all test results going forward will reflect new templating.

Once CI passes, this PR can be merged.