### PR TITLE
Issue 629: Enforce vocabulary pattern revision for UCO 2.0.0

### DIFF
--- a/ontology/uco/action/action.ttl
+++ b/ontology/uco/action/action.ttl
@@ -109,9 +109,9 @@ action:Action
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for action:actionStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path action:actionStatus ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -126,11 +126,6 @@ action:Action
 			sh:message "Value is not member of the vocabulary ActionStatusTypeVocab." ;
 			sh:path action:actionStatus ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path action:actionStatus ;
 		]
 		;
 	sh:targetClass action:Action ;
@@ -238,13 +233,14 @@ action:ActionFrequencyFacet
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:units ;
+			sh:path action:trend ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for action:trend should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path action:trend ;
-			sh:severity sh:Warning ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:minCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path action:units ;
 		] ,
 		[
 			sh:in (
@@ -254,12 +250,6 @@ action:ActionFrequencyFacet
 			sh:message "Value is not member of the vocabulary TrendVocab." ;
 			sh:path action:trend ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path action:trend ;
 		]
 		;
 	sh:targetClass action:ActionFrequencyFacet ;

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -167,9 +167,9 @@ observable:AccountFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:accountType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:accountType ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -185,11 +185,6 @@ observable:AccountFacet
 			sh:message "Value is not member of the vocabulary AccountTypeVocab." ;
 			sh:path observable:accountType ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:accountType ;
 		]
 		;
 	sh:targetClass observable:AccountFacet ;
@@ -636,11 +631,6 @@ observable:AutonomousSystemFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:regionalInternetRegistry should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:regionalInternetRegistry ;
-			sh:severity sh:Warning ;
-		] ,
-		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:regionalInternetRegistry ;
@@ -1415,9 +1405,9 @@ observable:ContactAddress
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactAddressScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:contactAddressScope ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -1428,11 +1418,6 @@ observable:ContactAddress
 			sh:message "Value is not member of the vocabulary ContactAddressScopeVocab." ;
 			sh:path observable:contactAddressScope ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:contactAddressScope ;
 		]
 		;
 	sh:targetClass observable:ContactAddress ;
@@ -1522,9 +1507,9 @@ observable:ContactEmail
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactEmailScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:contactEmailScope ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -1536,11 +1521,6 @@ observable:ContactEmail
 			sh:message "Value is not member of the vocabulary ContactEmailScopeVocab." ;
 			sh:path observable:contactEmailScope ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:contactEmailScope ;
 		]
 		;
 	sh:targetClass observable:ContactEmail ;
@@ -1774,9 +1754,9 @@ observable:ContactPhone
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactPhoneScope in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:contactPhoneScope ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -1792,11 +1772,6 @@ observable:ContactPhone
 			sh:message "Value is not member of the vocabulary ContactPhoneScopeVocab." ;
 			sh:path observable:contactPhoneScope ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:contactPhoneScope ;
 		]
 		;
 	sh:targetClass observable:ContactPhone ;
@@ -1844,9 +1819,9 @@ observable:ContactSIP
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactSIPScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:contactSIPScope ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -1857,11 +1832,6 @@ observable:ContactSIP
 			sh:message "Value is not member of the vocabulary ContactSIPScopeVocab." ;
 			sh:path observable:contactSIPScope ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:contactSIPScope ;
 		]
 		;
 	sh:targetClass observable:ContactSIP ;
@@ -1884,9 +1854,9 @@ observable:ContactURL
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactURLScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:contactURLScope ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -1898,11 +1868,6 @@ observable:ContactURL
 			sh:message "Value is not member of the vocabulary ContactURLScopeVocab." ;
 			sh:path observable:contactURLScope ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:contactURLScope ;
 		]
 		;
 	sh:targetClass observable:ContactURL ;
@@ -1961,6 +1926,12 @@ observable:ContentDataFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
+			sh:path observable:byteOrder ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:dataPayload ;
 		] ,
 		[
@@ -1977,12 +1948,6 @@ observable:ContentDataFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:byteOrder should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:byteOrder ;
-			sh:severity sh:Warning ;
-		] ,
-		[
-			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
 			sh:path observable:mimeType ;
 		] ,
@@ -1995,11 +1960,6 @@ observable:ContentDataFacet
 			sh:message "Value is not member of the vocabulary EndiannessTypeVocab." ;
 			sh:path observable:byteOrder ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:byteOrder ;
 		]
 		;
 	sh:targetClass observable:ContentDataFacet ;
@@ -3987,9 +3947,9 @@ observable:MemoryFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:blockType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:blockType ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -4002,11 +3962,6 @@ observable:MemoryFacet
 			sh:message "Value is not member of the vocabulary MemoryBlockTypeVocab." ;
 			sh:path observable:blockType ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:blockType ;
 		]
 		;
 	sh:targetClass observable:MemoryFacet ;
@@ -5583,21 +5538,21 @@ observable:RecoveredObjectFacet
 	sh:property
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contentRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:contentRecoveredStatus ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:metadataRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:metadataRecoveredStatus ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:nameRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:nameRecoveredStatus ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -5631,21 +5586,6 @@ observable:RecoveredObjectFacet
 			sh:message "Value is not member of the vocabulary RecoveredObjectStatusVocab." ;
 			sh:path observable:contentRecoveredStatus ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:contentRecoveredStatus ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:metadataRecoveredStatus ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:nameRecoveredStatus ;
 		]
 		;
 	sh:targetClass observable:RecoveredObjectFacet ;
@@ -6321,9 +6261,9 @@ observable:TaskActionType
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:actionType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:actionType ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -6335,11 +6275,6 @@ observable:TaskActionType
 			sh:message "Value is not member of the vocabulary TaskActionTypeVocab." ;
 			sh:path observable:actionType ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:actionType ;
 		]
 		;
 	sh:targetClass observable:TaskActionType ;
@@ -6382,6 +6317,12 @@ observable:TriggerType
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
+			sh:path observable:triggerFrequency ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:triggerMaxRunTime ;
 		] ,
 		[
@@ -6392,15 +6333,9 @@ observable:TriggerType
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:triggerFrequency should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:triggerFrequency ;
-			sh:severity sh:Warning ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:triggerType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:triggerType ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -6430,16 +6365,6 @@ observable:TriggerType
 			sh:message "Value is not member of the vocabulary TriggerTypeVocab." ;
 			sh:path observable:triggerType ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerFrequency ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerType ;
 		]
 		;
 	sh:targetClass observable:TriggerType ;
@@ -6926,9 +6851,9 @@ observable:URLVisitFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:urlTransitionType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:urlTransitionType ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -6947,11 +6872,6 @@ observable:URLVisitFacet
 			sh:message "Value is not member of the vocabulary URLTransitionTypeVocab." ;
 			sh:path observable:urlTransitionType ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:urlTransitionType ;
 		]
 		;
 	sh:targetClass observable:URLVisitFacet ;
@@ -7225,6 +7145,12 @@ observable:WhoIsFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
+			sh:path observable:regionalInternetRegistry ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:remarks ;
 		] ,
 		[
@@ -7235,15 +7161,9 @@ observable:WhoIsFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:regionalInternetRegistry should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:regionalInternetRegistry ;
-			sh:severity sh:Warning ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:status should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:status ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
@@ -7281,16 +7201,6 @@ observable:WhoIsFacet
 			sh:message "Value is not member of the vocabulary WhoisStatusTypeVocab." ;
 			sh:path observable:status ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:regionalInternetRegistry ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:status ;
 		]
 		;
 	sh:targetClass observable:WhoIsFacet ;
@@ -7307,9 +7217,9 @@ observable:WhoisContactFacet
 	sh:property
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:whoisContactType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:whoisContactType ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -7320,11 +7230,6 @@ observable:WhoisContactFacet
 			sh:message "Value is not member of the vocabulary WhoisContactTypeVocab." ;
 			sh:path observable:whoisContactType ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:whoisContactType ;
 		]
 		;
 	sh:targetClass observable:WhoisContactFacet ;
@@ -8467,6 +8372,12 @@ observable:WindowsTaskFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
+			sh:path observable:status ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:taskComment ;
 		] ,
 		[
@@ -8477,15 +8388,8 @@ observable:WindowsTaskFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:flags should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:flags ;
-			sh:severity sh:Warning ;
-		] ,
-		[
-			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:status should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:status ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -8540,15 +8444,6 @@ observable:WindowsTaskFacet
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:priority ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:status ;
-		] ,
-		[
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:priority should be xsd:string or xsd:integer.  Not using xsd:string or xsd:integer will be an error in UCO 2.0.0." ;
 			sh:or (
 				[
 					sh:datatype xsd:integer ;
@@ -8558,7 +8453,6 @@ observable:WindowsTaskFacet
 				]
 			) ;
 			sh:path observable:priority ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:message "Value is not member of the vocabulary TaskPriorityVocab." ;
@@ -8579,10 +8473,6 @@ observable:WindowsTaskFacet
 			) ;
 			sh:path observable:priority ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:nodeKind sh:Literal ;
-			sh:path observable:flags ;
 		]
 		;
 	sh:targetClass observable:WindowsTaskFacet ;
@@ -8684,9 +8574,9 @@ observable:WindowsVolumeFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:driveType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:driveType ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype vocabulary:WindowsVolumeAttributeVocab ;
@@ -8707,11 +8597,6 @@ observable:WindowsVolumeFacet
 			sh:message "Value is not member of the vocabulary WindowsDriveTypeVocab." ;
 			sh:path observable:driveType ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:driveType ;
 		]
 		;
 	sh:targetClass observable:WindowsVolumeFacet ;
@@ -8768,9 +8653,9 @@ observable:WirelessNetworkConnectionFacet
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:wirelessNetworkSecurityMode should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path observable:wirelessNetworkSecurityMode ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -8785,11 +8670,6 @@ observable:WirelessNetworkConnectionFacet
 			sh:message "Value is not member of the vocabulary WirelessNetworkSecurityModeVocab." ;
 			sh:path observable:wirelessNetworkSecurityMode ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:wirelessNetworkSecurityMode ;
 		]
 		;
 	sh:targetClass observable:WirelessNetworkConnectionFacet ;

--- a/ontology/uco/types/types.ttl
+++ b/ontology/uco/types/types.ttl
@@ -145,9 +145,10 @@ types:Hash
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:minCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
 			sh:path types:hashMethod ;
-			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:in (
@@ -167,12 +168,6 @@ types:Hash
 			sh:message "Value is not member of the vocabulary HashNameVocab." ;
 			sh:path types:hashMethod ;
 			sh:severity sh:Info ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path types:hashMethod ;
 		]
 		;
 	sh:targetClass types:Hash ;

--- a/tests/examples/hash_PASS.json
+++ b/tests/examples/hash_PASS.json
@@ -26,29 +26,6 @@
                 "@type": "xsd:hexBinary",
                 "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
             }
-        },
-        {
-            "@id": "kb:hash-b7eca8de-142d-4aa9-b546-0796a268afa4",
-            "@type": "types:Hash",
-            "rdfs:comment": "Should trigger an sh:Info from the hashMethod value not having its (literal-)value in the HashNameVocab vocabulary, and also a sh:Warning from not being an xsd:string.",
-            "types:hashMethod": {
-                "@type": "vocabulary:HashNameVocab",
-                "@value": "SHA1"
-            },
-            "types:hashValue": {
-                "@type": "xsd:hexBinary",
-                "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-        },
-        {
-            "@id": "kb:hash-f46c714f-559a-4325-bf8a-4ef60c92c771",
-            "@type": "types:Hash",
-            "rdfs:comment": "This should trigger an sh:Warning from the hashMethod value not being a string, and an sh:Info from not being in the HashNameVocab vocabulary.  (The warning from not being a string is a relaxation from an error, enacted between UCO 1.3.0 and 1.4.0.  It will again be an error in UCO 2.0.0.)",
-            "types:hashMethod": 1,
-            "types:hashValue": {
-                "@type": "xsd:hexBinary",
-                "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
         }
     ]
 }

--- a/tests/examples/hash_PASS_validation.ttl
+++ b/tests/examples/hash_PASS_validation.ttl
@@ -3,7 +3,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -65,92 +64,6 @@
 				sh:severity sh:Info ;
 			] ;
 			sh:value "SHA-1" ;
-		] ,
-		[
-			a sh:ValidationResult ;
-			sh:focusNode <http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4> ;
-			sh:resultMessage "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:resultPath types:hashMethod ;
-			sh:resultSeverity sh:Warning ;
-			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
-			sh:sourceShape [
-				sh:datatype xsd:string ;
-				sh:message "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-				sh:path types:hashMethod ;
-				sh:severity sh:Warning ;
-			] ;
-			sh:value "SHA1"^^vocabulary:HashNameVocab ;
-		] ,
-		[
-			a sh:ValidationResult ;
-			sh:focusNode <http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4> ;
-			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
-			sh:resultPath types:hashMethod ;
-			sh:resultSeverity sh:Info ;
-			sh:sourceConstraintComponent sh:InConstraintComponent ;
-			sh:sourceShape [
-				sh:in (
-					"MD5"
-					"MD6"
-					"SHA1"
-					"SHA224"
-					"SHA256"
-					"SHA3-224"
-					"SHA3-256"
-					"SHA3-384"
-					"SHA3-512"
-					"SHA384"
-					"SHA512"
-					"SSDEEP"
-				) ;
-				sh:message "Value is not member of the vocabulary HashNameVocab." ;
-				sh:path types:hashMethod ;
-				sh:severity sh:Info ;
-			] ;
-			sh:value "SHA1"^^vocabulary:HashNameVocab ;
-		] ,
-		[
-			a sh:ValidationResult ;
-			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
-			sh:resultMessage "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:resultPath types:hashMethod ;
-			sh:resultSeverity sh:Warning ;
-			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
-			sh:sourceShape [
-				sh:datatype xsd:string ;
-				sh:message "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-				sh:path types:hashMethod ;
-				sh:severity sh:Warning ;
-			] ;
-			sh:value "1"^^xsd:integer ;
-		] ,
-		[
-			a sh:ValidationResult ;
-			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
-			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
-			sh:resultPath types:hashMethod ;
-			sh:resultSeverity sh:Info ;
-			sh:sourceConstraintComponent sh:InConstraintComponent ;
-			sh:sourceShape [
-				sh:in (
-					"MD5"
-					"MD6"
-					"SHA1"
-					"SHA224"
-					"SHA256"
-					"SHA3-224"
-					"SHA3-256"
-					"SHA3-384"
-					"SHA3-512"
-					"SHA384"
-					"SHA512"
-					"SSDEEP"
-				) ;
-				sh:message "Value is not member of the vocabulary HashNameVocab." ;
-				sh:path types:hashMethod ;
-				sh:severity sh:Info ;
-			] ;
-			sh:value "1"^^xsd:integer ;
 		]
 		;
 	.

--- a/tests/examples/hash_XFAIL.json
+++ b/tests/examples/hash_XFAIL.json
@@ -12,6 +12,29 @@
             "rdfs:comment": "This should trigger sh:Violation from the hash value not being hexBinary.",
             "types:hashMethod": "SHA1",
             "types:hashValue": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        },
+        {
+            "@id": "kb:hash-b7eca8de-142d-4aa9-b546-0796a268afa4",
+            "@type": "types:Hash",
+            "rdfs:comment": "This should trigger an sh:Info from the hashMethod value not having its (literal-)value in the HashNameVocab vocabulary, and also a sh:Violation from not being an xsd:string.",
+            "types:hashMethod": {
+                "@type": "vocabulary:HashNameVocab",
+                "@value": "SHA1"
+            },
+            "types:hashValue": {
+                "@type": "xsd:hexBinary",
+                "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+        },
+        {
+            "@id": "kb:hash-f46c714f-559a-4325-bf8a-4ef60c92c771",
+            "@type": "types:Hash",
+            "rdfs:comment": "This should trigger a sh:Violation from the hashMethod value not being a string, and an sh:Info from not being in the HashNameVocab vocabulary.",
+            "types:hashMethod": 1,
+            "types:hashValue": {
+                "@type": "xsd:hexBinary",
+                "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
         }
     ]
 }

--- a/tests/examples/hash_XFAIL_validation.ttl
+++ b/tests/examples/hash_XFAIL_validation.ttl
@@ -3,26 +3,117 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
 	a sh:ValidationReport ;
 	sh:conforms "false"^^xsd:boolean ;
-	sh:result [
-		a sh:ValidationResult ;
-		sh:focusNode <http://example.org/kb/hash-66954988-aa9a-4f0d-8ad1-380700c830fc> ;
-		sh:resultMessage "Value is not Literal with datatype xsd:hexBinary" ;
-		sh:resultPath types:hashValue ;
-		sh:resultSeverity sh:Violation ;
-		sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
-		sh:sourceShape [
-			sh:datatype xsd:hexBinary ;
-			sh:maxCount "1"^^xsd:integer ;
-			sh:minCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path types:hashValue ;
-		] ;
-		sh:value "da39a3ee5e6b4b0d3255bfef95601890afd80709" ;
-	] ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/hash-66954988-aa9a-4f0d-8ad1-380700c830fc> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:hexBinary" ;
+			sh:resultPath types:hashValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:hexBinary ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashValue ;
+			] ;
+			sh:value "da39a3ee5e6b4b0d3255bfef95601890afd80709" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA1"^^vocabulary:HashNameVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4> ;
+			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Info ;
+			sh:sourceConstraintComponent sh:InConstraintComponent ;
+			sh:sourceShape [
+				sh:in (
+					"MD5"
+					"MD6"
+					"SHA1"
+					"SHA224"
+					"SHA256"
+					"SHA3-224"
+					"SHA3-256"
+					"SHA3-384"
+					"SHA3-512"
+					"SHA384"
+					"SHA512"
+					"SSDEEP"
+				) ;
+				sh:message "Value is not member of the vocabulary HashNameVocab." ;
+				sh:path types:hashMethod ;
+				sh:severity sh:Info ;
+			] ;
+			sh:value "SHA1"^^vocabulary:HashNameVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "1"^^xsd:integer ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
+			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Info ;
+			sh:sourceConstraintComponent sh:InConstraintComponent ;
+			sh:sourceShape [
+				sh:in (
+					"MD5"
+					"MD6"
+					"SHA1"
+					"SHA224"
+					"SHA256"
+					"SHA3-224"
+					"SHA3-256"
+					"SHA3-384"
+					"SHA3-512"
+					"SHA384"
+					"SHA512"
+					"SSDEEP"
+				) ;
+				sh:message "Value is not member of the vocabulary HashNameVocab." ;
+				sh:path types:hashMethod ;
+				sh:severity sh:Info ;
+			] ;
+			sh:value "1"^^xsd:integer ;
+		]
+		;
 	.
 

--- a/tests/examples/test_validation.py
+++ b/tests/examples/test_validation.py
@@ -286,10 +286,6 @@ def test_hash_PASS() -> None:
       expected_focus_node_severities={
         ("http://example.org/kb/hash-04dcd1dc-6920-4977-a898-e242870249a4", str(NS_SH.Info)),
         ("http://example.org/kb/hash-af4b0c85-b042-4e2d-a213-210b3d7f115c", str(NS_SH.Info)),
-        ("http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4", str(NS_SH.Info)),
-        ("http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4", str(NS_SH.Warning)),
-        ("http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771", str(NS_SH.Info)),
-        ("http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771", str(NS_SH.Warning)),
       }
     )
 
@@ -298,7 +294,11 @@ def test_hash_XFAIL() -> None:
       "hash_XFAIL_validation.ttl",
       False,
       expected_focus_node_severities={
-        ("http://example.org/kb/hash-66954988-aa9a-4f0d-8ad1-380700c830fc", str(NS_SH.Violation))
+        ("http://example.org/kb/hash-66954988-aa9a-4f0d-8ad1-380700c830fc", str(NS_SH.Violation)),
+        ("http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4", str(NS_SH.Info)),
+        ("http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4", str(NS_SH.Violation)),
+        ("http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771", str(NS_SH.Info)),
+        ("http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771", str(NS_SH.Violation)),
       }
     )
 


### PR DESCRIPTION
This Pull Request resolves all backwards-incompatible requirements of Issue #629 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop-2.0.0`
- [x] CI passes in UCO current `unstable-2.0.0` branch ([`d85f002`](https://github.com/ucoProject/UCO-Archive/commit/d85f0027e8f7ef94e9d4c2a3ab41fc1e9161e788))
- [x] CI passes in CASE current `unstable-2.0.0` branch tracking UCO's `unstable-2.0.0` as submodule ([`723ab6a`](https://github.com/casework/CASE-Archive/commit/723ab6a4b496635a46d0865f55a8d0b1f67df3f8))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Corpora/commit/d66904076469b2ac8bc53be7d05b195a48476917) for CASE-Corpora
- [x] Impact on SHACL validation [remediated](https://github.com/casework/CASE-Corpora/commit/4581a5eca6a3e0f0c62b94877d735200e0c8ed50) for CASE-Corpora
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/a9d01d3e2fdc8a2cafe87cbbdb5e141c0147e7ef) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/325/commits/fb44f1e6563fc6976d38766996d7b9b90fdd12c3) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->