### PR TITLE
Issue 651: Add support for time relations, including global prefix changes

### DIFF
--- a/ontology/uco/action/action.ttl
+++ b/ontology/uco/action/action.ttl
@@ -4,126 +4,126 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/types/1.3.0
 # imports: https://ontology.unifiedcyberontology.org/uco/vocabulary/1.3.0
 
-@prefix action: <https://ontology.unifiedcyberontology.org/uco/action/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
-@prefix location: <https://ontology.unifiedcyberontology.org/uco/location/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix pattern: <https://ontology.unifiedcyberontology.org/uco/pattern/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-location: <https://ontology.unifiedcyberontology.org/uco/location/> .
+@prefix uco-pattern: <https://ontology.unifiedcyberontology.org/uco/pattern/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/action>
 	a owl:Ontology ;
 	rdfs:label "uco-action"@en ;
 	rdfs:comment "This ontology defines classes and properties for characterizing actions."@en-US ;
-	owl:backwardCompatibleWith action:1.2.0 ;
+	owl:backwardCompatibleWith uco-action:1.2.0 ;
 	owl:imports
-		core:1.3.0 ,
-		location:1.3.0 ,
-		pattern:1.3.0 ,
-		types:1.3.0 ,
-		vocabulary:1.3.0
+		uco-core:1.3.0 ,
+		uco-location:1.3.0 ,
+		uco-pattern:1.3.0 ,
+		uco-types:1.3.0 ,
+		uco-vocabulary:1.3.0
 		;
-	owl:priorVersion action:1.2.0 ;
-	owl:versionIRI action:1.3.0 ;
+	owl:priorVersion uco-action:1.2.0 ;
+	owl:versionIRI uco-action:1.3.0 ;
 	.
 
-action:Action
+uco-action:Action
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Action"@en ;
 	rdfs:comment "An action is something that may be done or performed."@en ;
-	owl:disjointWith core:Event ;
+	owl:disjointWith uco-core:Event ;
 	sh:property
-		action:Action-actionStatus-in-shape ,
+		uco-action:Action-actionStatus-in-shape ,
 		[
-			sh:class action:Action ;
+			sh:class uco-action:Action ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:subaction ;
+			sh:path uco-action:subaction ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:environment ;
+			sh:path uco-action:environment ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:performer ;
+			sh:path uco-action:performer ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:error ;
+			sh:path uco-action:error ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:instrument ;
+			sh:path uco-action:instrument ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:object ;
+			sh:path uco-action:object ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:participant ;
+			sh:path uco-action:participant ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:result ;
+			sh:path uco-action:result ;
 		] ,
 		[
-			sh:class location:Location ;
+			sh:class uco-location:Location ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:location ;
+			sh:path uco-action:location ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:endTime ;
+			sh:path uco-action:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:startTime ;
+			sh:path uco-action:startTime ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:actionCount ;
+			sh:path uco-action:actionCount ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for action:actionStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path action:actionStatus ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-action:actionStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-action:actionStatus ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:actionStatus ;
+			sh:path uco-action:actionStatus ;
 		]
 		;
-	sh:targetClass action:Action ;
+	sh:targetClass uco-action:Action ;
 	.
 
-action:Action-actionStatus-in-shape
+uco-action:Action-actionStatus-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"Complete/Finish"
@@ -135,26 +135,26 @@ action:Action-actionStatus-in-shape
 		"Unknown"
 	) ;
 	sh:message "Value is not member of the vocabulary ActionStatusTypeVocab." ;
-	sh:path action:actionStatus ;
+	sh:path uco-action:actionStatus ;
 	sh:severity sh:Info ;
 	.
 
-action:Action-disjointWith-Event-shape
+uco-action:Action-disjointWith-Event-shape
 	a sh:NodeShape ;
-	sh:message "action:Action and core:Event are disjoint classes."@en ;
+	sh:message "uco-action:Action and uco-core:Event are disjoint classes."@en ;
 	sh:not [
 		a sh:NodeShape ;
-		sh:class core:Event ;
+		sh:class uco-core:Event ;
 	] ;
-	sh:targetClass action:Action ;
+	sh:targetClass uco-action:Action ;
 	.
 
-action:ActionArgumentFacet
+uco-action:ActionArgumentFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ActionArgumentFacet"@en ;
 	rdfs:comment "An action argument facet is a grouping of characteristics unique to a single parameter of an action."@en ;
 	sh:property
@@ -163,25 +163,25 @@ action:ActionArgumentFacet
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:argumentName ;
+			sh:path uco-action:argumentName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:value ;
+			sh:path uco-action:value ;
 		]
 		;
-	sh:targetClass action:ActionArgumentFacet ;
+	sh:targetClass uco-action:ActionArgumentFacet ;
 	.
 
-action:ActionEstimationFacet
+uco-action:ActionEstimationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ActionEstimationFacet"@en ;
 	rdfs:comment "An action estimation facet is a grouping of characteristics unique to decision-focused approximation aspects for an action that may potentially be performed."@en ;
 	sh:property
@@ -189,349 +189,349 @@ action:ActionEstimationFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:estimatedCost ;
+			sh:path uco-action:estimatedCost ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:estimatedEfficacy ;
+			sh:path uco-action:estimatedEfficacy ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:estimatedImpact ;
+			sh:path uco-action:estimatedImpact ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:objective ;
+			sh:path uco-action:objective ;
 		]
 		;
-	sh:targetClass action:ActionEstimationFacet ;
+	sh:targetClass uco-action:ActionEstimationFacet ;
 	.
 
-action:ActionFrequencyFacet
+uco-action:ActionFrequencyFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ActionFrequencyFacet"@en ;
 	rdfs:comment "An action frequency facet is a grouping of characteristics unique to the frequency of occurrence for an action."@en ;
 	sh:property
-		action:ActionFrequencyFacet-trend-in-shape ,
+		uco-action:ActionFrequencyFacet-trend-in-shape ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:rate ;
+			sh:path uco-action:rate ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:scale ;
+			sh:path uco-action:scale ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:units ;
+			sh:path uco-action:units ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for action:trend should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path action:trend ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-action:trend should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-action:trend ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:trend ;
+			sh:path uco-action:trend ;
 		]
 		;
-	sh:targetClass action:ActionFrequencyFacet ;
+	sh:targetClass uco-action:ActionFrequencyFacet ;
 	.
 
-action:ActionFrequencyFacet-trend-in-shape
+uco-action:ActionFrequencyFacet-trend-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"Decreasing"
 		"Increasing"
 	) ;
 	sh:message "Value is not member of the vocabulary TrendVocab." ;
-	sh:path action:trend ;
+	sh:path uco-action:trend ;
 	sh:severity sh:Info ;
 	.
 
-action:ActionLifecycle
+uco-action:ActionLifecycle
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf action:Action ;
+	rdfs:subClassOf uco-action:Action ;
 	rdfs:label "ActionLifecycle"@en ;
 	rdfs:comment "An action lifecycle is an action pattern consisting of an ordered set of multiple actions or subordinate action lifecycles."@en ;
 	sh:property
 		[
-			sh:class action:ArrayOfAction ;
+			sh:class uco-action:ArrayOfAction ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:phase ;
+			sh:path uco-action:phase ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path action:error ;
+			sh:path uco-action:error ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:endTime ;
+			sh:path uco-action:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:startTime ;
+			sh:path uco-action:startTime ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path action:actionCount ;
+			sh:path uco-action:actionCount ;
 		] ,
 		[
 			sh:maxCount "0"^^xsd:integer ;
-			sh:path action:actionStatus ;
+			sh:path uco-action:actionStatus ;
 		]
 		;
-	sh:targetClass action:ActionLifecycle ;
+	sh:targetClass uco-action:ActionLifecycle ;
 	.
 
-action:ActionPattern
+uco-action:ActionPattern
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		action:Action ,
-		pattern:Pattern
+		uco-action:Action ,
+		uco-pattern:Pattern
 		;
 	rdfs:label "ActionPattern"@en ;
 	rdfs:comment "An action pattern is a grouping of characteristics unique to a combination of actions forming a consistent or characteristic arrangement."@en ;
-	sh:targetClass action:ActionPattern ;
+	sh:targetClass uco-action:ActionPattern ;
 	.
 
-action:ArrayOfAction
+uco-action:ArrayOfAction
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ArrayOfAction"@en ;
 	rdfs:comment "An array of action is an ordered list of references to things that may be done or performed."@en ;
 	sh:property [
-		sh:class action:Action ;
+		sh:class uco-action:Action ;
 		sh:minCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path action:action ;
+		sh:path uco-action:action ;
 	] ;
-	sh:targetClass action:ArrayOfAction ;
+	sh:targetClass uco-action:ArrayOfAction ;
 	.
 
-action:action
+uco-action:action
 	a owl:ObjectProperty ;
 	rdfs:label "action"@en ;
 	rdfs:comment "A characterization of a single action."@en ;
-	rdfs:range action:Action ;
+	rdfs:range uco-action:Action ;
 	.
 
-action:actionCount
+uco-action:actionCount
 	a owl:DatatypeProperty ;
 	rdfs:label "actionCount"@en ;
 	rdfs:comment "The number of times that the action was performed."@en ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-action:actionStatus
+uco-action:actionStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "actionStatus"@en ;
 	rdfs:comment "The current state of the action."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:ActionStatusTypeVocab
+			uco-vocabulary:ActionStatusTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-action:argumentName
+uco-action:argumentName
 	a owl:DatatypeProperty ;
 	rdfs:label "argumentName"@en ;
 	rdfs:comment "The identifying label of an argument."@en ;
 	rdfs:range xsd:string ;
 	.
 
-action:endTime
+uco-action:endTime
 	a owl:DatatypeProperty ;
 	rdfs:label "endTime"@en ;
 	rdfs:comment "The time at which performance of the action ended."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-action:environment
+uco-action:environment
 	a owl:ObjectProperty ;
 	rdfs:label "environment"@en ;
 	rdfs:comment "The environment wherein an action occurs."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-action:error
+uco-action:error
 	a owl:ObjectProperty ;
 	rdfs:label "error"@en ;
 	rdfs:comment "A characterization of the differences between the expected and the actual performance of the action."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-action:estimatedCost
+uco-action:estimatedCost
 	a owl:DatatypeProperty ;
 	rdfs:label "estimatedCost"@en ;
 	rdfs:comment "An estimation of the cost if the action is performed."@en ;
 	rdfs:range xsd:string ;
 	.
 
-action:estimatedEfficacy
+uco-action:estimatedEfficacy
 	a owl:DatatypeProperty ;
 	rdfs:label "estimatedEfficacy"@en ;
 	rdfs:comment "An estimation of the effectiveness of the action at achieving its objective if the action is performed."@en ;
 	rdfs:range xsd:string ;
 	.
 
-action:estimatedImpact
+uco-action:estimatedImpact
 	a owl:DatatypeProperty ;
 	rdfs:label "estimatedImpact"@en ;
 	rdfs:comment "An estimation of the impact if the action is performed."@en ;
 	rdfs:range xsd:string ;
 	.
 
-action:instrument
+uco-action:instrument
 	a owl:ObjectProperty ;
 	rdfs:label "instrument"@en ;
 	rdfs:comment "The things used to perform an action."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-action:location
+uco-action:location
 	a owl:ObjectProperty ;
 	rdfs:label "location"@en ;
 	rdfs:comment "The locations where an action occurs."@en ;
-	rdfs:range location:Location ;
+	rdfs:range uco-location:Location ;
 	.
 
-action:object
+uco-action:object
 	a owl:ObjectProperty ;
 	rdfs:label "object"@en ;
 	rdfs:comment "The things that the action is performed on/against."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-action:objective
+uco-action:objective
 	a owl:DatatypeProperty ;
 	rdfs:label "objective"@en ;
 	rdfs:comment "The intended purpose for performing the action."@en ;
 	rdfs:range xsd:string ;
 	.
 
-action:participant
+uco-action:participant
 	a owl:ObjectProperty ;
 	rdfs:label "participant"@en ;
 	rdfs:comment "The supporting (non-primary) performers of an action."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-action:performer
+uco-action:performer
 	a owl:ObjectProperty ;
 	rdfs:label "performer"@en ;
 	rdfs:comment "The primary performer of an action."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-action:phase
+uco-action:phase
 	a owl:ObjectProperty ;
-	rdfs:subPropertyOf action:subaction ;
+	rdfs:subPropertyOf uco-action:subaction ;
 	rdfs:label "phase"@en ;
 	rdfs:comment "The ordered set of actions or sub action-lifecycles that represent the action lifecycle."@en ;
-	rdfs:range action:ArrayOfAction ;
+	rdfs:range uco-action:ArrayOfAction ;
 	.
 
-action:rate
+uco-action:rate
 	a owl:DatatypeProperty ;
 	rdfs:label "rate"@en ;
 	rdfs:comment "The frequency rate for the occurence of an action."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-action:result
+uco-action:result
 	a owl:ObjectProperty ;
 	rdfs:label "result"@en ;
 	rdfs:comment "The things resulting from performing an action."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-action:scale
+uco-action:scale
 	a owl:DatatypeProperty ;
 	rdfs:label "scale"@en ;
 	rdfs:comment "The time scale utilized for the frequency rate count for the occurence of an action."@en ;
 	rdfs:range xsd:string ;
 	.
 
-action:startTime
+uco-action:startTime
 	a owl:DatatypeProperty ;
 	rdfs:label "startTime"@en ;
 	rdfs:comment "The time at which performance of the action began."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-action:subaction
+uco-action:subaction
 	a owl:ObjectProperty ;
 	rdfs:label "subaction"@en ;
 	rdfs:comment "References to other actions that make up part of a larger more complex action."@en ;
-	rdfs:range action:Action ;
+	rdfs:range uco-action:Action ;
 	.
 
-action:trend
+uco-action:trend
 	a owl:DatatypeProperty ;
 	rdfs:label "trend"@en ;
 	rdfs:comment "A characterization of the frequency trend for the occurence of an action."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:TrendVocab
+			uco-vocabulary:TrendVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-action:units
+uco-action:units
 	a owl:DatatypeProperty ;
 	rdfs:label "units"@en ;
 	rdfs:comment "The units of measure utilized for the frequency rate count for the occurence of an action."@en ;
 	rdfs:range xsd:string ;
 	.
 
-action:value
+uco-action:value
 	a owl:DatatypeProperty ;
 	rdfs:label "value"@en ;
 	rdfs:comment "The value of an action parameter."@en ;

--- a/ontology/uco/analysis/analysis.ttl
+++ b/ontology/uco/analysis/analysis.ttl
@@ -1,12 +1,12 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/action/1.3.0
 
-@prefix action: <https://ontology.unifiedcyberontology.org/uco/action/> .
-@prefix analysis: <https://ontology.unifiedcyberontology.org/uco/analysis/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
+@prefix uco-analysis: <https://ontology.unifiedcyberontology.org/uco/analysis/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/analysis>
@@ -14,64 +14,64 @@
 	rdfs:label "uco-analysis"@en ;
 	rdfs:comment "This ontology defines classes and properties for characterizing analytic actions and results."@en-US ;
 	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/400> ;
-	owl:backwardCompatibleWith analysis:1.2.0 ;
-	owl:imports action:1.3.0 ;
-	owl:priorVersion analysis:1.2.0 ;
-	owl:versionIRI analysis:1.3.0 ;
+	owl:backwardCompatibleWith uco-analysis:1.2.0 ;
+	owl:imports uco-action:1.3.0 ;
+	owl:priorVersion uco-analysis:1.2.0 ;
+	owl:versionIRI uco-analysis:1.3.0 ;
 	.
 
-analysis:Analysis
+uco-analysis:Analysis
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf action:Action ;
+	rdfs:subClassOf uco-action:Action ;
 	rdfs:label "Analysis"@en ;
 	rdfs:comment "An analysis is an action of detailed examination of something in order to understand its nature, context or essential features."@en ;
-	sh:targetClass action:Analysis ;
+	sh:targetClass uco-action:Analysis ;
 	.
 
-analysis:AnalyticResult
+uco-analysis:AnalyticResult
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Assertion ;
+	rdfs:subClassOf uco-core:Assertion ;
 	rdfs:label "AnalyticResult"@en ;
 	rdfs:comment "An analytic result is a characterization of the understanding resulting from an analysis action."@en ;
 	sh:property
 		[
-			sh:class analysis:Analysis ;
+			sh:class uco-analysis:Analysis ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path analysis:originatingAnalysis ;
+			sh:path uco-analysis:originatingAnalysis ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path analysis:resultContent ;
+			sh:path uco-analysis:resultContent ;
 		]
 		;
-	sh:targetClass analysis:AnalysicResult ;
+	sh:targetClass uco-analysis:AnalysicResult ;
 	.
 
-analysis:AnalyticResultFacet
+uco-analysis:AnalyticResultFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AnalyticResultFacet"@en ;
 	rdfs:comment "An analytic result facet is a grouping of characteristics unique to the results of an analysis action."@en ;
-	sh:targetClass analysis:AnalyticResultFacet ;
+	sh:targetClass uco-analysis:AnalyticResultFacet ;
 	.
 
-analysis:ArtifactClassification
+uco-analysis:ArtifactClassification
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ArtifactClassification"@en ;
 	rdfs:comment "An artifact classification is a single specific assertion that a particular class of a classification taxonomy applies to something."@en ;
 	sh:property
@@ -79,66 +79,66 @@ analysis:ArtifactClassification
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path analysis:classificationConfidence ;
+			sh:path uco-analysis:classificationConfidence ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path analysis:class ;
+			sh:path uco-analysis:class ;
 		]
 		;
-	sh:targetClass analysis:ArtifactClassification ;
+	sh:targetClass uco-analysis:ArtifactClassification ;
 	.
 
-analysis:ArtifactClassificationResultFacet
+uco-analysis:ArtifactClassificationResultFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf analysis:AnalyticResultFacet ;
+	rdfs:subClassOf uco-analysis:AnalyticResultFacet ;
 	rdfs:label "ArtifactClassificationResultFacet"@en ;
 	rdfs:comment "An artifact classification result facet is a grouping of characteristics unique to the results of an artifact classification analysis action."@en ;
 	sh:property [
-		sh:class analysis:ArtifactClassification ;
+		sh:class uco-analysis:ArtifactClassification ;
 		sh:nodeKind sh:IRI ;
-		sh:path analysis:classification ;
+		sh:path uco-analysis:classification ;
 	] ;
-	sh:targetClass analysis:ArtifactClassificationResultFacet ;
+	sh:targetClass uco-analysis:ArtifactClassificationResultFacet ;
 	.
 
-analysis:class
+uco-analysis:class
 	a owl:DatatypeProperty ;
 	rdfs:label "class"@en ;
 	rdfs:comment "A specific classification class."@en ;
 	rdfs:range xsd:string ;
 	.
 
-analysis:classification
+uco-analysis:classification
 	a owl:ObjectProperty ;
 	rdfs:label "classification"@en ;
 	rdfs:comment "An asserted classification of an analyzed artifact resulting from the analysis."@en ;
-	rdfs:range analysis:ArtifactClassification ;
+	rdfs:range uco-analysis:ArtifactClassification ;
 	.
 
-analysis:classificationConfidence
+uco-analysis:classificationConfidence
 	a owl:DatatypeProperty ;
 	rdfs:label "classificationConfidence"@en ;
 	rdfs:comment "The level of confidence that a classification assertion is correct."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-analysis:originatingAnalysis
+uco-analysis:originatingAnalysis
 	a owl:ObjectProperty ;
 	rdfs:label "originatingAnalysis"@en ;
 	rdfs:comment "The analysis action that resulted in an analytic result."@en ;
-	rdfs:range analysis:Analysis ;
+	rdfs:range uco-analysis:Analysis ;
 	.
 
-analysis:resultContent
+uco-analysis:resultContent
 	a owl:ObjectProperty ;
 	rdfs:label "resultContent"@en ;
 	rdfs:comment "Structured content expressing the results of an analysis action."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 

--- a/ontology/uco/configuration/configuration.ttl
+++ b/ontology/uco/configuration/configuration.ttl
@@ -1,11 +1,11 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/core/1.3.0
 
-@prefix configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/configuration>
@@ -13,114 +13,114 @@
 	rdfs:label "uco-configuration"@en ;
 	rdfs:comment "This ontology defines classes and properties for characterizing configurations."@en-US ;
 	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/432> ;
-	owl:backwardCompatibleWith configuration:1.2.0 ;
-	owl:imports core:1.3.0 ;
-	owl:priorVersion configuration:1.2.0 ;
-	owl:versionIRI configuration:1.3.0 ;
+	owl:backwardCompatibleWith uco-configuration:1.2.0 ;
+	owl:imports uco-core:1.3.0 ;
+	owl:priorVersion uco-configuration:1.2.0 ;
+	owl:versionIRI uco-configuration:1.3.0 ;
 	.
 
-configuration:Configuration
+uco-configuration:Configuration
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Configuration"@en ;
 	rdfs:comment "A configuration is a grouping of characteristics unique to a set of parameters or initial settings for the use of a tool, application, software, or other cyber object."@en ;
 	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/432> ;
 	sh:property
 		[
-			sh:class configuration:ConfigurationEntry ;
+			sh:class uco-configuration:ConfigurationEntry ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path configuration:configurationEntry ;
+			sh:path uco-configuration:configurationEntry ;
 		] ,
 		[
-			sh:class configuration:Dependency ;
+			sh:class uco-configuration:Dependency ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path configuration:dependencies ;
+			sh:path uco-configuration:dependencies ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path configuration:usageContextAssumptions ;
+			sh:path uco-configuration:usageContextAssumptions ;
 		]
 		;
-	sh:targetClass configuration:Configuration ;
+	sh:targetClass uco-configuration:Configuration ;
 	.
 
-configuration:ConfigurationEntry
+uco-configuration:ConfigurationEntry
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ConfigurationEntry"@en ;
 	rdfs:comment "A configuration entry is a grouping of characteristics unique to a particular parameter or initial setting for the use of a tool, application, software, or other cyber object."@en ;
 	sh:property
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path configuration:itemObject ;
+			sh:path uco-configuration:itemObject ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path configuration:itemDescription ;
+			sh:path uco-configuration:itemDescription ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path configuration:itemName ;
+			sh:path uco-configuration:itemName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path configuration:itemType ;
+			sh:path uco-configuration:itemType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path configuration:itemValue ;
+			sh:path uco-configuration:itemValue ;
 		]
 		;
-	sh:targetClass configuration:ConfigurationEntry ;
+	sh:targetClass uco-configuration:ConfigurationEntry ;
 	sh:xone (
 		[
 			sh:property
 				[
 					sh:maxCount "0"^^xsd:integer ;
-					sh:path configuration:itemObject ;
+					sh:path uco-configuration:itemObject ;
 				] ,
 				[
 					sh:maxCount "0"^^xsd:integer ;
-					sh:path configuration:itemValue ;
+					sh:path uco-configuration:itemValue ;
 				]
 				;
 		]
 		[
 			sh:property [
 				sh:minCount "1"^^xsd:integer ;
-				sh:path configuration:itemObject ;
+				sh:path uco-configuration:itemObject ;
 			] ;
 		]
 		[
 			sh:property [
 				sh:minCount "1"^^xsd:integer ;
-				sh:path configuration:itemValue ;
+				sh:path uco-configuration:itemValue ;
 			] ;
 		]
 	) ;
 	.
 
-configuration:Dependency
+uco-configuration:Dependency
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "Dependency"@en ;
 	rdfs:comment "A dependency is a grouping of characteristics unique to something that a tool or other software relies on to function as intended."@en ;
 	sh:property
@@ -128,104 +128,104 @@ configuration:Dependency
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path configuration:dependencyDescription ;
+			sh:path uco-configuration:dependencyDescription ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path configuration:dependencyType ;
+			sh:path uco-configuration:dependencyType ;
 		]
 		;
-	sh:targetClass configuration:Dependency ;
+	sh:targetClass uco-configuration:Dependency ;
 	.
 
-configuration:configurationEntry
+uco-configuration:configurationEntry
 	a owl:ObjectProperty ;
 	rdfs:comment "A single configuration setting entry item for a tool or other software."@en ;
-	rdfs:range configuration:ConfigurationEntry ;
+	rdfs:range uco-configuration:ConfigurationEntry ;
 	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/432> ;
 	.
 
-configuration:dependencies
+uco-configuration:dependencies
 	a owl:ObjectProperty ;
 	rdfs:label "dependencies"@en ;
 	rdfs:comment "The relevant configuration dependencies for a tool, application, software, or other cyber object."@en ;
-	rdfs:range configuration:Dependency ;
+	rdfs:range uco-configuration:Dependency ;
 	.
 
-configuration:dependencyDescription
+uco-configuration:dependencyDescription
 	a owl:DatatypeProperty ;
 	rdfs:label "dependencyDescription"@en ;
 	rdfs:comment "A description of a tool or other software dependency."@en ;
 	rdfs:range xsd:string ;
 	.
 
-configuration:dependencyType
+uco-configuration:dependencyType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "dependencyType"@en ;
 	rdfs:comment "The type of a tool or other software dependency."@en ;
 	rdfs:range xsd:string ;
 	.
 
-configuration:isConfigurationOf
+uco-configuration:isConfigurationOf
 	a
 		owl:ObjectProperty ,
 		owl:IrreflexiveProperty
 		;
 	rdfs:label "isConfigurationOf"@en ;
 	rdfs:comment "The object which has been configured to run in a more specified manner than another object.  This property is expected to have a more specific range when associated with a class, such as a configured Tool having this property have a range of a Tool."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-configuration:itemDescription
+uco-configuration:itemDescription
 	a owl:DatatypeProperty ;
 	rdfs:label "itemDescription"@en ;
 	rdfs:comment "A description of a configuration setting entry item."@en ;
 	rdfs:range xsd:string ;
 	.
 
-configuration:itemName
+uco-configuration:itemName
 	a owl:DatatypeProperty ;
 	rdfs:label "itemName"@en ;
 	rdfs:comment "The name of a configuration setting entry item."@en ;
 	rdfs:range xsd:string ;
 	.
 
-configuration:itemObject
+uco-configuration:itemObject
 	a owl:ObjectProperty ;
 	rdfs:comment "The structured value of a configuration setting entry instance."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/432> ;
 	.
 
-configuration:itemType
+uco-configuration:itemType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "itemType"@en ;
 	rdfs:comment "The type of a configuration setting entry item."@en ;
 	rdfs:range xsd:string ;
 	.
 
-configuration:itemValue
+uco-configuration:itemValue
 	a owl:DatatypeProperty ;
 	rdfs:label "itemValue"@en ;
 	rdfs:comment "The value of a configuration setting entry instance."@en ;
 	rdfs:range xsd:string ;
 	.
 
-configuration:usageContextAssumptions
+uco-configuration:usageContextAssumptions
 	a owl:DatatypeProperty ;
 	rdfs:label "usageContextAssumptions"@en ;
 	rdfs:comment "Description of the various relevant usage context assumptions for a tool or other software ."@en ;
 	rdfs:range xsd:string ;
 	.
 
-configuration:usesConfiguration
+uco-configuration:usesConfiguration
 	a owl:ObjectProperty ;
 	rdfs:label "usesConfiguration"@en ;
 	rdfs:comment "A configuration used by an object."@en ;
-	rdfs:range configuration:Configuration ;
+	rdfs:range uco-configuration:Configuration ;
 	.
 

--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -1,104 +1,104 @@
-@prefix action: <https://ontology.unifiedcyberontology.org/uco/action/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/core>
 	a owl:Ontology ;
 	rdfs:label "uco-core"@en ;
 	rdfs:comment "This ontology defines classes and properties that are shared across the various UCO ontologies.  At a high-level, the UCO core ontology provides base classes, relationship-oriented classes, content-aggregation classes, and shared classes."@en ;
-	owl:backwardCompatibleWith core:1.2.0 ;
-	owl:priorVersion core:1.2.0 ;
-	owl:versionIRI core:1.3.0 ;
+	owl:backwardCompatibleWith uco-core:1.2.0 ;
+	owl:priorVersion uco-core:1.2.0 ;
+	owl:versionIRI uco-core:1.3.0 ;
 	.
 
-action:Action
+uco-action:Action
 	a owl:Class ;
 	rdfs:isDefinedBy <https://ontology.unifiedcyberontology.org/uco/types> ;
 	.
 
-core:Annotation
+uco-core:Annotation
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Assertion ;
+	rdfs:subClassOf uco-core:Assertion ;
 	rdfs:label "Annotation"@en ;
 	rdfs:comment "An annotation is an assertion made in relation to one or more objects."@en ;
 	sh:property [
-		sh:class core:UcoObject ;
+		sh:class uco-core:UcoObject ;
 		sh:minCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path core:object ;
+		sh:path uco-core:object ;
 	] ;
-	sh:targetClass core:Annotation ;
+	sh:targetClass uco-core:Annotation ;
 	.
 
-core:Assertion
+uco-core:Assertion
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Assertion"@en ;
 	rdfs:comment "An assertion is a statement declared to be true."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:nodeKind sh:Literal ;
-		sh:path core:statement ;
+		sh:path uco-core:statement ;
 	] ;
-	sh:targetClass core:Assertion ;
+	sh:targetClass uco-core:Assertion ;
 	.
 
-core:AttributedName
+uco-core:AttributedName
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "AttributedName"@en ;
 	rdfs:comment "An attributed name is a name of an entity issued by some attributed naming authority."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path core:namingAuthority ;
+		sh:path uco-core:namingAuthority ;
 	] ;
-	sh:targetClass core:AttributedName ;
+	sh:targetClass uco-core:AttributedName ;
 	.
 
-core:Bundle
+uco-core:Bundle
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:EnclosingCompilation ;
+	rdfs:subClassOf uco-core:EnclosingCompilation ;
 	rdfs:label "Bundle"@en ;
 	rdfs:comment "A bundle is a container for a grouping of UCO content with no presumption of shared context."@en ;
-	sh:targetClass core:Bundle ;
+	sh:targetClass uco-core:Bundle ;
 	.
 
-core:Compilation
+uco-core:Compilation
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Compilation"@en ;
 	rdfs:comment "A compilation is a grouping of things."@en ;
-	sh:targetClass core:Compilation ;
+	sh:targetClass uco-core:Compilation ;
 	.
 
-core:ConfidenceFacet
+uco-core:ConfidenceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ConfidenceFacet"@en ;
 	rdfs:comment "A confidence is a grouping of characteristics unique to an asserted level of certainty in the accuracy of some information."@en ;
 	sh:property [
@@ -106,33 +106,33 @@ core:ConfidenceFacet
 		sh:maxCount "1"^^xsd:integer ;
 		sh:minCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path core:confidence ;
+		sh:path uco-core:confidence ;
 	] ;
-	sh:targetClass core:ConfidenceFacet ;
+	sh:targetClass uco-core:ConfidenceFacet ;
 	.
 
-core:ContextualCompilation
+uco-core:ContextualCompilation
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Compilation ;
+	rdfs:subClassOf uco-core:Compilation ;
 	rdfs:label "ContextualCompilation"@en ;
 	rdfs:comment "A contextual compilation is a grouping of things sharing some context (e.g., a set of network connections observed on a given day, all accounts associated with a given person)."@en ;
 	sh:property [
-		sh:class core:UcoObject ;
+		sh:class uco-core:UcoObject ;
 		sh:nodeKind sh:IRI ;
-		sh:path core:object ;
+		sh:path uco-core:object ;
 	] ;
-	sh:targetClass core:ContextualCompilation ;
+	sh:targetClass uco-core:ContextualCompilation ;
 	.
 
-core:ControlledVocabulary
+uco-core:ControlledVocabulary
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "ControlledVocabulary"@en ;
 	rdfs:comment "A controlled vocabulary is an explicitly constrained set of string values."@en ;
 	sh:property
@@ -140,87 +140,87 @@ core:ControlledVocabulary
 			sh:datatype xsd:anyURI ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:constrainingVocabularyReference ;
+			sh:path uco-core:constrainingVocabularyReference ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:value ;
+			sh:path uco-core:value ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:constrainingVocabularyName ;
+			sh:path uco-core:constrainingVocabularyName ;
 		]
 		;
-	sh:targetClass core:ControlledVocabulary ;
+	sh:targetClass uco-core:ControlledVocabulary ;
 	.
 
-core:EnclosingCompilation
+uco-core:EnclosingCompilation
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Compilation ;
+	rdfs:subClassOf uco-core:Compilation ;
 	rdfs:label "EnclosingCompilation"@en ;
 	rdfs:comment "An enclosing compilation is a container for a grouping of things."@en ;
 	sh:property [
-		sh:class core:UcoObject ;
+		sh:class uco-core:UcoObject ;
 		sh:minCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path core:object ;
+		sh:path uco-core:object ;
 	] ;
-	sh:targetClass core:EnclosingCompilation ;
+	sh:targetClass uco-core:EnclosingCompilation ;
 	.
 
-core:Event
+uco-core:Event
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Event"@en ;
 	rdfs:comment "An Event is a noteworthy occurrence (something that happens or might happen)."@en ;
-	owl:disjointWith action:Action ;
+	owl:disjointWith uco-action:Action ;
 	sh:property
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:eventContext ;
+			sh:path uco-core:eventContext ;
 		] ,
 		[
-			sh:class types:Dictionary ;
+			sh:class uco-types:Dictionary ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:eventAttribute ;
+			sh:path uco-core:eventAttribute ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:endTime ;
+			sh:path uco-core:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:startTime ;
+			sh:path uco-core:startTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:eventType ;
+			sh:path uco-core:eventType ;
 		]
 		;
-	sh:targetClass core:Event ;
+	sh:targetClass uco-core:Event ;
 	.
 
-core:ExternalReference
+uco-core:ExternalReference
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ExternalReference"@en ;
 	rdfs:comment "Characteristics of a reference to a resource outside of the UCO."@en ;
 	sh:property
@@ -228,96 +228,96 @@ core:ExternalReference
 			sh:datatype xsd:anyURI ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:referenceURL ;
+			sh:path uco-core:referenceURL ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:definingContext ;
+			sh:path uco-core:definingContext ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:externalIdentifier ;
+			sh:path uco-core:externalIdentifier ;
 		]
 		;
-	sh:targetClass core:ExternalReference ;
+	sh:targetClass uco-core:ExternalReference ;
 	.
 
-core:Facet
+uco-core:Facet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "Facet"@en ;
 	rdfs:comment "A facet is a grouping of characteristics singularly unique to a particular inherent aspect of a UCO domain object."@en ;
-	sh:targetClass core:Facet ;
+	sh:targetClass uco-core:Facet ;
 	.
 
-core:Grouping
+uco-core:Grouping
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:ContextualCompilation ;
+	rdfs:subClassOf uco-core:ContextualCompilation ;
 	rdfs:label "Grouping"@en ;
 	rdfs:comment "A grouping is a compilation of referenced UCO content with a shared context."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:nodeKind sh:Literal ;
-		sh:path core:context ;
+		sh:path uco-core:context ;
 	] ;
-	sh:targetClass core:Grouping ;
+	sh:targetClass uco-core:Grouping ;
 	.
 
-core:IdentityAbstraction
+uco-core:IdentityAbstraction
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "IdentityAbstraction"@en ;
 	rdfs:comment "An identity abstraction is a grouping of identifying characteristics unique to an individual or organization. This class is an ontological structural abstraction for this concept. Implementations of this concept should utilize the identity:Identity class."@en ;
-	sh:targetClass core:IdentityAbstraction ;
+	sh:targetClass uco-core:IdentityAbstraction ;
 	.
 
-core:Item
+uco-core:Item
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Item"@en ;
 	rdfs:comment "An item is a distinct article or unit."@en ;
-	sh:targetClass core:Item ;
+	sh:targetClass uco-core:Item ;
 	.
 
-core:MarkingDefinitionAbstraction
+uco-core:MarkingDefinitionAbstraction
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "MarkingDefinitionAbstraction"@en ;
 	rdfs:comment "A marking definition abstraction is a grouping of characteristics unique to the expression of a specific data marking conveying restrictions, permissions, and other guidance for how marked data can be used and shared. This class is an ontological structural abstraction for this concept. Implementations of this concept should utilize the marking:MarkingDefinition class."@en ;
-	sh:targetClass core:MarkingDefinitionAbstraction ;
+	sh:targetClass uco-core:MarkingDefinitionAbstraction ;
 	.
 
-core:ModusOperandi
+uco-core:ModusOperandi
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "ModusOperandi"@en ;
 	rdfs:comment "A modus operandi is a particular method of operation (how a particular entity behaves or the resources they use)."@en ;
-	sh:targetClass core:ModusOperandi ;
+	sh:targetClass uco-core:ModusOperandi ;
 	.
 
-core:ObjectStatusVocab
+uco-core:ObjectStatusVocab
 	a rdfs:Datatype ;
 	rdfs:label "Object Status Vocabulary"@en-US ;
 	owl:equivalentClass [
@@ -330,118 +330,118 @@ core:ObjectStatusVocab
 	] ;
 	.
 
-core:Relationship
+uco-core:Relationship
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Relationship"@en ;
 	rdfs:comment "A relationship is a grouping of characteristics unique to an assertion that one or more objects are related to another object in some way."@en ;
 	sh:property
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:target ;
+			sh:path uco-core:target ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:source ;
+			sh:path uco-core:source ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:isDirectional ;
+			sh:path uco-core:isDirectional ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:endTime ;
+			sh:path uco-core:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:startTime ;
+			sh:path uco-core:startTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:kindOfRelationship ;
+			sh:path uco-core:kindOfRelationship ;
 		]
 		;
-	sh:targetClass core:Relationship ;
+	sh:targetClass uco-core:Relationship ;
 	.
 
-core:UcoInherentCharacterizationThing
+uco-core:UcoInherentCharacterizationThing
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoThing ;
+	rdfs:subClassOf uco-core:UcoThing ;
 	rdfs:label "UcoInherentCharacterizationThing"@en ;
 	rdfs:comment "A UCO inherent characterization thing is a grouping of characteristics unique to a particular inherent aspect of a UCO domain object."@en ;
-	sh:targetClass core:UcoInherentCharacterizationThing ;
+	sh:targetClass uco-core:UcoInherentCharacterizationThing ;
 	.
 
-core:UcoInherentCharacterizationThing-disjointWith-UcoObject-shape
+uco-core:UcoInherentCharacterizationThing-disjointWith-UcoObject-shape
 	a sh:NodeShape ;
-	sh:message "core:UcoInherentCharacterizationThing and core:UcoObject are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
+	sh:message "uco-core:UcoInherentCharacterizationThing and uco-core:UcoObject are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
 	sh:not [
 		a sh:NodeShape ;
-		sh:class core:UcoObject ;
+		sh:class uco-core:UcoObject ;
 	] ;
 	sh:severity sh:Warning ;
-	sh:targetClass core:UcoInherentCharacterizationThing ;
+	sh:targetClass uco-core:UcoInherentCharacterizationThing ;
 	.
 
-core:UcoObject
+uco-core:UcoObject
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoThing ;
+	rdfs:subClassOf uco-core:UcoThing ;
 	rdfs:label "UcoObject"@en ;
 	rdfs:comment "A UCO object is a representation of a fundamental concept either directly inherent to the cyber domain or indirectly related to the cyber domain and necessary for contextually characterizing cyber domain concepts and relationships. Within the Unified Cyber Ontology (UCO) structure this is the base class acting as a consistent, unifying and interoperable foundation for all explicit and inter-relatable content objects."@en ;
 	sh:property
 		[
-			sh:class core:ExternalReference ;
+			sh:class uco-core:ExternalReference ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:externalReference ;
+			sh:path uco-core:externalReference ;
 		] ,
 		[
-			sh:class core:Facet ;
+			sh:class uco-core:Facet ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:hasFacet ;
+			sh:path uco-core:hasFacet ;
 		] ,
 		[
-			sh:class core:IdentityAbstraction ;
+			sh:class uco-core:IdentityAbstraction ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:createdBy ;
+			sh:path uco-core:createdBy ;
 		] ,
 		[
-			sh:class core:MarkingDefinitionAbstraction ;
+			sh:class uco-core:MarkingDefinitionAbstraction ;
 			sh:nodeKind sh:IRI ;
-			sh:path core:objectMarking ;
+			sh:path uco-core:objectMarking ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:objectCreatedTime ;
+			sh:path uco-core:objectCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:modifiedTime ;
+			sh:path uco-core:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
@@ -452,35 +452,35 @@ core:UcoObject
 			) ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:objectStatus ;
+			sh:path uco-core:objectStatus ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:name ;
+			sh:path uco-core:name ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:specVersion ;
+			sh:path uco-core:specVersion ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:description ;
+			sh:path uco-core:description ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:tag ;
+			sh:path uco-core:tag ;
 		]
 		;
-	sh:targetClass core:UcoObject ;
+	sh:targetClass uco-core:UcoObject ;
 	.
 
-core:UcoThing
+uco-core:UcoThing
 	a
 		owl:Class ,
 		sh:NodeShape
@@ -488,24 +488,24 @@ core:UcoThing
 	rdfs:subClassOf owl:Thing ;
 	rdfs:label "UcoThing"@en ;
 	rdfs:comment "UcoThing is the top-level class within UCO."@en ;
-	rdfs:seeAlso core:UcoThing-identifier-regex-shape ;
+	rdfs:seeAlso uco-core:UcoThing-identifier-regex-shape ;
 	sh:sparql [
 		a sh:SPARQLConstraint ;
 		sh:message "UcoThings are required to not be blank nodes."@en ;
 		sh:select """
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			SELECT $this
 			WHERE {
-			        $this a/rdfs:subClassOf* core:UcoThing .
+			        $this a/rdfs:subClassOf* uco-core:UcoThing .
 			        FILTER isBlank ($this)
 			}
 		""" ;
 	] ;
-	sh:targetClass core:UcoThing ;
+	sh:targetClass uco-core:UcoThing ;
 	.
 
-core:UcoThing-identifier-regex-shape
+uco-core:UcoThing-identifier-regex-shape
 	a sh:NodeShape ;
 	rdfs:comment "This shape is given an independent IRI for applications that have sufficient controls in place to deactivate this advisory of node identification practice."@en ;
 	rdfs:seeAlso sh:deactivated ;
@@ -516,10 +516,10 @@ core:UcoThing-identifier-regex-shape
 		sh:message "UcoThings are suggested to end with a UUID."@en ;
 		sh:select '''
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			SELECT $this
 			WHERE {
-			        $this a/rdfs:subClassOf* core:UcoThing .
+			        $this a/rdfs:subClassOf* uco-core:UcoThing .
 			        FILTER (
 			                ! REGEX (
 			                        STR($this),
@@ -530,10 +530,10 @@ core:UcoThing-identifier-regex-shape
 			}
 		''' ;
 	] ;
-	sh:targetClass core:UcoThing ;
+	sh:targetClass uco-core:UcoThing ;
 	.
 
-core:confidence
+uco-core:confidence
 	a owl:DatatypeProperty ;
 	rdfs:label "confidence"@en ;
 	rdfs:comment "An asserted level of certainty in the accuracy of some information."@en ;
@@ -548,114 +548,114 @@ core:confidence
 	] ;
 	.
 
-core:constrainingVocabularyName
+uco-core:constrainingVocabularyName
 	a owl:DatatypeProperty ;
 	rdfs:label "constrainingVocabularyName"@en ;
 	rdfs:comment "The name of an explicitly constrained set of string values."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:constrainingVocabularyReference
+uco-core:constrainingVocabularyReference
 	a owl:DatatypeProperty ;
 	rdfs:label "constrainingVocabularyReference"@en ;
 	rdfs:comment "A reference to a specification for an explicitly constrained set of string values. The specification may be unstructured (e.g., web page listing string values) or structured (e.g. RDF/OWL enumeration)."@en ;
 	rdfs:range xsd:anyURI ;
 	.
 
-core:context
+uco-core:context
 	a owl:DatatypeProperty ;
 	rdfs:label "context"@en ;
 	rdfs:comment "A description of particular contextual affinity."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:createdBy
+uco-core:createdBy
 	a owl:ObjectProperty ;
 	rdfs:label "createdBy"@en ;
 	rdfs:comment "The identity that created a characterization of a concept."@en ;
-	rdfs:range core:IdentityAbstraction ;
+	rdfs:range uco-core:IdentityAbstraction ;
 	.
 
-core:definingContext
+uco-core:definingContext
 	a owl:DatatypeProperty ;
 	rdfs:label "definingContext"@en ;
 	rdfs:comment "A description of the context relevant to the definition of a particular external reference identifier."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:description
+uco-core:description
 	a owl:DatatypeProperty ;
 	rdfs:label "description"@en ;
 	rdfs:comment "A description of a particular concept characterization."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:endTime
+uco-core:endTime
 	a owl:DatatypeProperty ;
 	rdfs:label "endTime"@en ;
 	rdfs:comment "The ending time of a time range."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-core:eventAttribute
+uco-core:eventAttribute
 	a owl:ObjectProperty ;
 	rdfs:label "Event Attribute"@en ;
 	rdfs:comment "An event attribute specifies an ad-hoc attribute/value for an event."@en ;
-	rdfs:range types:Dictionary ;
+	rdfs:range uco-types:Dictionary ;
 	.
 
-core:eventContext
+uco-core:eventContext
 	a owl:ObjectProperty ;
 	rdfs:label "Event Context"@en ;
 	rdfs:comment "An event context describes the association of actions and objects relating to an event."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-core:eventType
+uco-core:eventType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "Event Type"@en ;
 	rdfs:comment "An event type specifies a classification type for the event."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:externalIdentifier
+uco-core:externalIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "externalIdentifier"@en ;
 	rdfs:comment "An identifier for some information defined external to the UCO context."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:externalReference
+uco-core:externalReference
 	a owl:ObjectProperty ;
 	rdfs:label "External Reference"@en-US ;
 	rdfs:comment "Specifies a reference to a resource outside of the UCO."@en-US ;
-	rdfs:range core:ExternalReference ;
+	rdfs:range uco-core:ExternalReference ;
 	.
 
-core:hasFacet
+uco-core:hasFacet
 	a
 		owl:ObjectProperty ,
 		owl:InverseFunctionalProperty
 		;
 	rdfs:label "hasFacet"@en ;
 	rdfs:comment "Further sets of properties characterizing a concept based on the particular context of the class and of the particular instance of the concept being characterized."@en ;
-	rdfs:range core:Facet ;
+	rdfs:range uco-core:Facet ;
 	.
 
-core:hasFacet-shape
+uco-core:hasFacet-shape
 	a sh:PropertyShape ;
-	sh:path core:hasFacet ;
+	sh:path uco-core:hasFacet ;
 	sh:sparql [
 		a sh:SPARQLConstraint ;
 		sh:message "hasFacet must not be used to link two objects to one Facet."@en ;
 		sh:select """
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this ?value
 			WHERE {
-				?value core:hasFacet $this .
-				?nOtherValue core:hasFacet $this .
+				?value uco-core:hasFacet $this .
+				?nOtherValue uco-core:hasFacet $this .
 				FILTER ( ?value != ?nOtherValue )
 				FILTER NOT EXISTS {
 					?value owl:sameAs|^owl:sameAs ?nOtherValue .
@@ -663,141 +663,141 @@ core:hasFacet-shape
 			}
 			""" ;
 	] ;
-	sh:targetObjectsOf core:hasFacet ;
+	sh:targetObjectsOf uco-core:hasFacet ;
 	.
 
-core:informalType
+uco-core:informalType
 	a owl:DatatypeProperty ;
 	rdfs:label "informalType"@en ;
 	rdfs:comment "Informal Type serves as a parent property for string-valued properties meant to describe a type without implementing a class design.  This property hierarchy supports a balancing point between semantic specificity and operational agility.  The known benefits of describing types rather than implementing them include swift extensibility of some existing, or possibly non-existing, subclass hierarchy in UCO without requiring training in ontological development, taxonomic specification, or OWL, SHACL, or RDF maintenance logistics.  The known detractions of using string-literals for type descriptions include that used vocabularies may require careful maintenance among data-sharing parties; that vocabularies require independent logistics (external to UCO) for providing definitions (i.e., dictionary-style semantics) to string-literals chosen; and that string-literals cannot by themselves encode hierarchical structure or entailments, such as the informal device type string 'ExamplePhone 8 P4321' entailing 'ExamplePhone 8', 'ExamplePhone', or 'ExamplePhone models discontinued in 2020'.  Usage of Informal Type to house strings should be weighed against usage of classes when classes are available, and should periodically be reviewed for potential additions to UCO's class hierarchy or downstream extensions thereof."@en ;
 	.
 
-core:isDirectional
+uco-core:isDirectional
 	a owl:DatatypeProperty ;
 	rdfs:label "isDirectional"@en ;
 	rdfs:comment "A specification whether or not a relationship assertion is limited to the context FROM a source object(s) TO a target object."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-core:kindOfRelationship
+uco-core:kindOfRelationship
 	a owl:DatatypeProperty ;
 	rdfs:label "kindOfRelationship"@en ;
 	rdfs:comment "A characterization of the nature of a relationship between objects."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:modifiedTime
+uco-core:modifiedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "modifiedTime"@en ;
 	rdfs:comment "Specifies the time that this particular version of the object was modified. The object creator can use the time it deems most appropriate as the time this version of the object was modified. The value of the modified property for a given object version MUST be later than or equal to the value of the created property. Object creators MUST update the modified property when creating a new version of an object. The modified timestamp MUST be precise to the nearest millisecond (exactly three digits after the decimal place in seconds)."@en-us ;
 	rdfs:range xsd:dateTime ;
 	.
 
-core:name
+uco-core:name
 	a owl:DatatypeProperty ;
 	rdfs:label "name"@en ;
 	rdfs:comment "The name of a particular concept characterization."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:namingAuthority
+uco-core:namingAuthority
 	a owl:DatatypeProperty ;
 	rdfs:label "namingAuthority"@en ;
 	rdfs:comment "Specifies the naming authority that issued the name of the entity."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:object
+uco-core:object
 	a owl:ObjectProperty ;
 	rdfs:label "object"@en ;
 	rdfs:comment "Specifies one or more UcoObjects."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-core:objectCreatedTime
+uco-core:objectCreatedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "objectCreatedTime"@en ;
 	rdfs:comment "The time at which a characterization of a concept is created. This time pertains to the time of creating the record object, and is not an intrinsic characteristic of the concept."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-core:objectMarking
+uco-core:objectMarking
 	a owl:ObjectProperty ;
 	rdfs:label "objectMarking"@en ;
 	rdfs:comment "Marking definitions to be applied to a particular concept characterization in its entirety."@en ;
-	rdfs:range core:MarkingDefinitionAbstraction ;
+	rdfs:range uco-core:MarkingDefinitionAbstraction ;
 	.
 
-core:objectStatus
+uco-core:objectStatus
 	a owl:AnnotationProperty ;
 	rdfs:label "objectStatus"@en ;
 	rdfs:comment "The current state of formality and acceptance for a UCO object."@en-US ;
-	rdfs:range core:ObjectStatusVocab ;
+	rdfs:range uco-core:ObjectStatusVocab ;
 	.
 
-core:objectStatus-subjects-shape
+uco-core:objectStatus-subjects-shape
 	a sh:NodeShape ;
-	sh:class core:UcoObject ;
-	sh:targetSubjectsOf core:objectStatus ;
+	sh:class uco-core:UcoObject ;
+	sh:targetSubjectsOf uco-core:objectStatus ;
 	.
 
-core:referenceURL
+uco-core:referenceURL
 	a owl:DatatypeProperty ;
 	rdfs:label "referenceURL"@en ;
 	rdfs:comment "A URL for some information defined external to the UCO context."@en ;
 	rdfs:range xsd:anyURI ;
 	.
 
-core:source
+uco-core:source
 	a owl:ObjectProperty ;
 	rdfs:label "source"@en ;
 	rdfs:comment "The originating node of a specified relationship."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-core:specVersion
+uco-core:specVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "specVersion"@en ;
 	rdfs:comment "The version of UCO ontology or subontology specification used to characterize a concept."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:startTime
+uco-core:startTime
 	a owl:DatatypeProperty ;
 	rdfs:label "startTime"@en ;
 	rdfs:comment "The initial time of a time range."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-core:statement
+uco-core:statement
 	a owl:DatatypeProperty ;
 	rdfs:label "statement"@en ;
 	rdfs:comment "A textual statement of an assertion."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:tag
+uco-core:tag
 	a owl:DatatypeProperty ;
 	rdfs:label "tag"@en ;
 	rdfs:comment "A generic tag/label."@en ;
 	rdfs:range xsd:string ;
 	.
 
-core:target
+uco-core:target
 	a owl:ObjectProperty ;
 	rdfs:label "target"@en ;
 	rdfs:comment "The terminating node of a specified relationship."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-core:value
+uco-core:value
 	a owl:DatatypeProperty ;
 	rdfs:label "value"@en ;
 	rdfs:comment "A string value."@en ;
 	rdfs:range xsd:string ;
 	.
 
-types:Dictionary
+uco-types:Dictionary
 	a owl:Class ;
 	rdfs:isDefinedBy <https://ontology.unifiedcyberontology.org/uco/types> ;
 	.
@@ -805,8 +805,8 @@ types:Dictionary
 []
 	a owl:AllDisjointClasses ;
 	owl:members (
-		core:UcoInherentCharacterizationThing
-		core:UcoObject
+		uco-core:UcoInherentCharacterizationThing
+		uco-core:UcoObject
 	) ;
 	.
 

--- a/ontology/uco/identity/identity.ttl
+++ b/ontology/uco/identity/identity.ttl
@@ -1,317 +1,317 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/core/1.3.0
 # imports: https://ontology.unifiedcyberontology.org/uco/location/1.3.0
 
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
-@prefix identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
-@prefix location: <https://ontology.unifiedcyberontology.org/uco/location/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
+@prefix uco-location: <https://ontology.unifiedcyberontology.org/uco/location/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/identity>
 	a owl:Ontology ;
 	rdfs:label "uco-identity"@en ;
-	owl:backwardCompatibleWith identity:1.2.0 ;
+	owl:backwardCompatibleWith uco-identity:1.2.0 ;
 	owl:imports
-		core:1.3.0 ,
-		location:1.3.0
+		uco-core:1.3.0 ,
+		uco-location:1.3.0
 		;
-	owl:priorVersion identity:1.2.0 ;
-	owl:versionIRI identity:1.3.0 ;
+	owl:priorVersion uco-identity:1.2.0 ;
+	owl:versionIRI uco-identity:1.3.0 ;
 	.
 
-identity:AddressFacet
+uco-identity:AddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "AddressFacet"@en ;
 	rdfs:comment "An address facet is a grouping of characteristics unique to an administrative identifier for a geolocation associated with a specific identity."@en ;
 	sh:property [
-		sh:class location:Location ;
+		sh:class uco-location:Location ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path identity:address ;
+		sh:path uco-identity:address ;
 	] ;
-	sh:targetClass identity:AddressFacet ;
+	sh:targetClass uco-identity:AddressFacet ;
 	.
 
-identity:AffiliationFacet
+uco-identity:AffiliationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "AffiliationFacet"@en ;
 	rdfs:comment "An affiliation is a grouping of characteristics unique to the established affiliations of an entity."@en ;
-	sh:targetClass identity:AffiliationFacet ;
+	sh:targetClass uco-identity:AffiliationFacet ;
 	.
 
-identity:BirthInformationFacet
+uco-identity:BirthInformationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "BirthInformationFacet"@en ;
 	rdfs:comment "Birth information is a grouping of characteristics unique to information pertaining to the birth of an entity."@en ;
 	sh:property [
 		sh:datatype xsd:dateTime ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path identity:birthdate ;
+		sh:path uco-identity:birthdate ;
 	] ;
-	sh:targetClass identity:BirthInformationFacet ;
+	sh:targetClass uco-identity:BirthInformationFacet ;
 	.
 
-identity:CountryOfResidenceFacet
+uco-identity:CountryOfResidenceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "CountryOfResidenceFacet"@en ;
 	rdfs:comment "Country of residence is a grouping of characteristics unique to information related to the country, or countries, where an entity resides."@en ;
-	sh:targetClass identity:CountryOfResidenceFacet ;
+	sh:targetClass uco-identity:CountryOfResidenceFacet ;
 	.
 
-identity:EventsFacet
+uco-identity:EventsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "EventsFacet"@en ;
 	rdfs:comment "Events is a grouping of characteristics unique to information related to specific relevant things that happen in the lifetime of an entity."@en ;
-	sh:targetClass identity:EventsFacet ;
+	sh:targetClass uco-identity:EventsFacet ;
 	.
 
-identity:IdentifierFacet
+uco-identity:IdentifierFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "IdentifierFacet"@en ;
 	rdfs:comment "Identifier is a grouping of characteristics unique to information that uniquely and specifically identities an entity."@en ;
-	sh:targetClass identity:IdentifierFacet ;
+	sh:targetClass uco-identity:IdentifierFacet ;
 	.
 
-identity:Identity
+uco-identity:Identity
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:IdentityAbstraction ;
+	rdfs:subClassOf uco-core:IdentityAbstraction ;
 	rdfs:label "Identity"@en ;
 	rdfs:comment "An identity is a grouping of identifying characteristics unique to an individual or organization."@en ;
-	sh:targetClass identity:Identity ;
+	sh:targetClass uco-identity:Identity ;
 	.
 
-identity:IdentityFacet
+uco-identity:IdentityFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "IdentityFacet"@en ;
 	rdfs:comment "An identity facet is a grouping of characteristics unique to a particular aspect of an identity."@en ;
-	sh:targetClass identity:IdentityFacet ;
+	sh:targetClass uco-identity:IdentityFacet ;
 	.
 
-identity:LanguagesFacet
+uco-identity:LanguagesFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "LanguagesFacet"@en ;
 	rdfs:comment "Languages is a grouping of characteristics unique to specific syntactically and grammatically standardized forms of communication (human or computer) in which an entity has proficiency (comprehends, speaks, reads, or writes)."@en ;
-	sh:targetClass identity:LanguagesFacet ;
+	sh:targetClass uco-identity:LanguagesFacet ;
 	.
 
-identity:NationalityFacet
+uco-identity:NationalityFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "NationalityFacet"@en ;
 	rdfs:comment "Nationality is a grouping of characteristics unique to the condition of an entity belonging to a particular nation."@en ;
-	sh:targetClass identity:NationalityFacet ;
+	sh:targetClass uco-identity:NationalityFacet ;
 	.
 
-identity:OccupationFacet
+uco-identity:OccupationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "OccupationFacet"@en ;
 	rdfs:comment "Occupation is a grouping of characteristics unique to the job or profession of an entity."@en ;
-	sh:targetClass identity:OccupationFacet ;
+	sh:targetClass uco-identity:OccupationFacet ;
 	.
 
-identity:Organization
+uco-identity:Organization
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:Identity ;
+	rdfs:subClassOf uco-identity:Identity ;
 	rdfs:label "Organization"@en ;
 	rdfs:comment "An organization is a grouping of identifying characteristics unique to a group of people who work together in an organized way for a shared purpose. [based on https://dictionary.cambridge.org/us/dictionary/english/organization]"@en ;
-	sh:targetClass identity:Organization ;
+	sh:targetClass uco-identity:Organization ;
 	.
 
-identity:OrganizationDetailsFacet
+uco-identity:OrganizationDetailsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "OrganizationDetailsFacet"@en ;
 	rdfs:comment "Organization details is a grouping of characteristics unique to an identity representing an administrative and functional structure."@en ;
-	sh:targetClass identity:OrganizationDetailsFacet ;
+	sh:targetClass uco-identity:OrganizationDetailsFacet ;
 	.
 
-identity:Person
+uco-identity:Person
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:Identity ;
+	rdfs:subClassOf uco-identity:Identity ;
 	rdfs:label "Person"@en ;
 	rdfs:comment "A person is a grouping of identifying characteristics unique to a human being regarded as an individual. [based on https://www.lexico.com/en/definition/person]"@en ;
-	sh:targetClass identity:Person ;
+	sh:targetClass uco-identity:Person ;
 	.
 
-identity:PersonalDetailsFacet
+uco-identity:PersonalDetailsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "PersonalDetailsFacet"@en ;
 	rdfs:comment "Personal details is a grouping of characteristics unique to an identity representing an individual person."@en ;
-	sh:targetClass identity:PersonalDetailsFacet ;
+	sh:targetClass uco-identity:PersonalDetailsFacet ;
 	.
 
-identity:PhysicalInfoFacet
+uco-identity:PhysicalInfoFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "PhysicalInfoFacet"@en ;
 	rdfs:comment "Physical info is a grouping of characteristics unique to the outwardly observable nature of an individual person."@en ;
-	sh:targetClass identity:PhysicalInfoFacet ;
+	sh:targetClass uco-identity:PhysicalInfoFacet ;
 	.
 
-identity:QualificationFacet
+uco-identity:QualificationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "QualificationFacet"@en ;
 	rdfs:comment "Qualification is a grouping of characteristics unique to particular skills, capabilities or their related achievements (educational, professional, etc.) of an entity."@en ;
-	sh:targetClass identity:QualificationFacet ;
+	sh:targetClass uco-identity:QualificationFacet ;
 	.
 
-identity:RelatedIdentityFacet
+uco-identity:RelatedIdentityFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "RelatedIdentityFacet"@en ;
 	rdfs:comment "<Needs fleshed out from CIQ>"@en ;
-	sh:targetClass identity:RelatedIdentityFacet ;
+	sh:targetClass uco-identity:RelatedIdentityFacet ;
 	.
 
-identity:SimpleNameFacet
+uco-identity:SimpleNameFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "SimpleNameFacet"@en ;
 	rdfs:comment "A simple name facet is a grouping of characteristics unique to the personal name (e.g., Dr. John Smith Jr.) held by an identity."@en ;
 	sh:property
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path identity:familyName ;
+			sh:path uco-identity:familyName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path identity:givenName ;
+			sh:path uco-identity:givenName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path identity:honorificPrefix ;
+			sh:path uco-identity:honorificPrefix ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path identity:honorificSuffix ;
+			sh:path uco-identity:honorificSuffix ;
 		]
 		;
-	sh:targetClass identity:SimpleNameFacet ;
+	sh:targetClass uco-identity:SimpleNameFacet ;
 	.
 
-identity:VisaFacet
+uco-identity:VisaFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf identity:IdentityFacet ;
+	rdfs:subClassOf uco-identity:IdentityFacet ;
 	rdfs:label "VisaFacet"@en ;
 	rdfs:comment "Visa is a grouping of characteristics unique to information related to a person's ability to enter, leave, or stay for a specified period of time in a country."@en ;
-	sh:targetClass identity:VisaFacet ;
+	sh:targetClass uco-identity:VisaFacet ;
 	.
 
-identity:address
+uco-identity:address
 	a owl:ObjectProperty ;
 	rdfs:label "address"@en ;
 	rdfs:comment ""@en ;
-	rdfs:range location:Location ;
+	rdfs:range uco-location:Location ;
 	.
 
-identity:birthdate
+uco-identity:birthdate
 	a owl:DatatypeProperty ;
 	rdfs:label "birthdate"@en ;
 	rdfs:comment ""@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-identity:familyName
+uco-identity:familyName
 	a owl:DatatypeProperty ;
 	rdfs:label "familyName"@en ;
 	rdfs:comment ""@en ;
 	rdfs:range xsd:string ;
 	.
 
-identity:givenName
+uco-identity:givenName
 	a owl:DatatypeProperty ;
 	rdfs:label "givenName"@en ;
 	rdfs:comment ""@en ;
 	rdfs:range xsd:string ;
 	.
 
-identity:honorificPrefix
+uco-identity:honorificPrefix
 	a owl:DatatypeProperty ;
 	rdfs:label "honorificPrefix"@en ;
 	rdfs:comment ""@en ;
 	rdfs:range xsd:string ;
 	.
 
-identity:honorificSuffix
+uco-identity:honorificSuffix
 	a owl:DatatypeProperty ;
 	rdfs:label "honorificSuffix"@en ;
 	rdfs:comment ""@en ;

--- a/ontology/uco/location/location.ttl
+++ b/ontology/uco/location/location.ttl
@@ -1,28 +1,28 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/core/1.3.0
 
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
-@prefix location: <https://ontology.unifiedcyberontology.org/uco/location/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-location: <https://ontology.unifiedcyberontology.org/uco/location/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/location>
 	a owl:Ontology ;
 	rdfs:label "uco-location"@en ;
-	owl:backwardCompatibleWith location:1.2.0 ;
-	owl:imports core:1.3.0 ;
-	owl:priorVersion location:1.2.0 ;
-	owl:versionIRI location:1.3.0 ;
+	owl:backwardCompatibleWith uco-location:1.2.0 ;
+	owl:imports uco-core:1.3.0 ;
+	owl:priorVersion uco-location:1.2.0 ;
+	owl:versionIRI uco-location:1.3.0 ;
 	.
 
-location:GPSCoordinatesFacet
+uco-location:GPSCoordinatesFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "GPSCoordinatesFacet"@en ;
 	rdfs:comment "A GPS coordinates facet is a grouping of characteristics unique to the expression of quantified dilution of precision (DOP) for an asserted set of geolocation coordinates typically associated with satellite navigation such as the Global Positioning System (GPS)."@en ;
 	sh:property
@@ -30,36 +30,36 @@ location:GPSCoordinatesFacet
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:hdop ;
+			sh:path uco-location:hdop ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:pdop ;
+			sh:path uco-location:pdop ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:tdop ;
+			sh:path uco-location:tdop ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:vdop ;
+			sh:path uco-location:vdop ;
 		]
 		;
-	sh:targetClass location:GPSCoordinatesFacet ;
+	sh:targetClass uco-location:GPSCoordinatesFacet ;
 	.
 
-location:LatLongCoordinatesFacet
+uco-location:LatLongCoordinatesFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "LatLongCoordinatesFacet"@en ;
 	rdfs:comment "A lat long coordinates facet is a grouping of characteristics unique to the expression of a geolocation as the intersection of specific latitude, longitude, and altitude values."@en ;
 	sh:property
@@ -67,41 +67,41 @@ location:LatLongCoordinatesFacet
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:altitude ;
+			sh:path uco-location:altitude ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:latitude ;
+			sh:path uco-location:latitude ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:longitude ;
+			sh:path uco-location:longitude ;
 		]
 		;
-	sh:targetClass location:LatLongCoordinatesFacet ;
+	sh:targetClass uco-location:LatLongCoordinatesFacet ;
 	.
 
-location:Location
+uco-location:Location
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Location"@en ;
 	rdfs:comment "A location is a geospatial place, site, or position."@en ;
-	sh:targetClass location:Location ;
+	sh:targetClass uco-location:Location ;
 	.
 
-location:SimpleAddressFacet
+uco-location:SimpleAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "SimpleAddressFacet"@en ;
 	rdfs:comment "A simple address facet is a grouping of characteristics unique to a geolocation expressed as an administrative address."@en ;
 	sh:property
@@ -109,128 +109,128 @@ location:SimpleAddressFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:addressType ;
+			sh:path uco-location:addressType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:country ;
+			sh:path uco-location:country ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:locality ;
+			sh:path uco-location:locality ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:postalCode ;
+			sh:path uco-location:postalCode ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:region ;
+			sh:path uco-location:region ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path location:street ;
+			sh:path uco-location:street ;
 		]
 		;
-	sh:targetClass location:SimpleAddressFacet ;
+	sh:targetClass uco-location:SimpleAddressFacet ;
 	.
 
-location:addressType
+uco-location:addressType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "addressType"@en ;
 	rdfs:comment "The type of the address, for instance home or work."@en ;
 	rdfs:range xsd:string ;
 	.
 
-location:altitude
+uco-location:altitude
 	a owl:DatatypeProperty ;
 	rdfs:label "altitude"@en ;
 	rdfs:comment "The altitude coordinate of a geolocation."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-location:country
+uco-location:country
 	a owl:DatatypeProperty ;
 	rdfs:label "country"@en ;
 	rdfs:comment "The name of the geolocation country."@en ;
 	rdfs:range xsd:string ;
 	.
 
-location:hdop
+uco-location:hdop
 	a owl:DatatypeProperty ;
 	rdfs:label "hdop"@en ;
 	rdfs:comment "The horizontal dilution of precision of the GPS location."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-location:latitude
+uco-location:latitude
 	a owl:DatatypeProperty ;
 	rdfs:label "latitude"@en ;
 	rdfs:comment "The latitude coordinate of a geolocation."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-location:locality
+uco-location:locality
 	a owl:DatatypeProperty ;
 	rdfs:label "locality"@en ;
 	rdfs:comment "The name of the geolocation locality (e.g., city)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-location:longitude
+uco-location:longitude
 	a owl:DatatypeProperty ;
 	rdfs:label "longitude"@en ;
 	rdfs:comment "The longitude coordinate of a geolocation."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-location:pdop
+uco-location:pdop
 	a owl:DatatypeProperty ;
 	rdfs:label "pdop"@en ;
 	rdfs:comment "The positional (3D) dilution of precision of the GPS location."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-location:postalCode
+uco-location:postalCode
 	a owl:DatatypeProperty ;
 	rdfs:label "postalCode"@en ;
 	rdfs:comment "The zip-code."@en ;
 	rdfs:range xsd:string ;
 	.
 
-location:region
+uco-location:region
 	a owl:DatatypeProperty ;
 	rdfs:label "region"@en ;
 	rdfs:comment "The name of the geolocation region (e.g., state)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-location:street
+uco-location:street
 	a owl:DatatypeProperty ;
 	rdfs:label "street"@en ;
 	rdfs:comment "The name of the street."@en ;
 	rdfs:range xsd:string ;
 	.
 
-location:tdop
+uco-location:tdop
 	a owl:DatatypeProperty ;
 	rdfs:label "tdop"@en ;
 	rdfs:comment "The temporal dilution of precision of the GPS location."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-location:vdop
+uco-location:vdop
 	a owl:DatatypeProperty ;
 	rdfs:label "vdop"@en ;
 	rdfs:comment "The vertical dilution of precision of the GPS location."@en ;

--- a/ontology/uco/marking/marking.ttl
+++ b/ontology/uco/marking/marking.ttl
@@ -1,52 +1,52 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/core/1.3.0
 
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
-@prefix marking: <https://ontology.unifiedcyberontology.org/uco/marking/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-marking: <https://ontology.unifiedcyberontology.org/uco/marking/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/marking>
 	a owl:Ontology ;
 	rdfs:label "uco-marking"@en ;
 	rdfs:comment "Data markings represent restrictions, permissions, and other guidance for how data can be used and shared."@en ;
-	owl:backwardCompatibleWith marking:1.2.0 ;
-	owl:imports core:1.3.0 ;
-	owl:priorVersion marking:1.2.0 ;
-	owl:versionIRI marking:1.3.0 ;
+	owl:backwardCompatibleWith uco-marking:1.2.0 ;
+	owl:imports uco-core:1.3.0 ;
+	owl:priorVersion uco-marking:1.2.0 ;
+	owl:versionIRI uco-marking:1.3.0 ;
 	.
 
-marking:GranularMarking
+uco-marking:GranularMarking
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "GranularMarking"@en ;
 	rdfs:comment "A granular marking is a grouping of characteristics unique to specification of marking definitions (restrictions, permissions, and other guidance for how data can be used and shared) that apply to particular portions of a particular UCO object."@en ;
 	sh:property
 		[
-			sh:class marking:MarkingDefinition ;
+			sh:class uco-marking:MarkingDefinition ;
 			sh:nodeKind sh:IRI ;
-			sh:path marking:marking ;
+			sh:path uco-marking:marking ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:contentSelectors ;
+			sh:path uco-marking:contentSelectors ;
 		]
 		;
-	sh:targetClass marking:GranularMarking ;
+	sh:targetClass uco-marking:GranularMarking ;
 	.
 
-marking:LicenseMarking
+uco-marking:LicenseMarking
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf marking:MarkingModel ;
+	rdfs:subClassOf uco-marking:MarkingModel ;
 	rdfs:label "License Marking"@en ;
 	rdfs:comment "A license marking is a grouping of characteristics unique to the expression of data marking definitions (restrictions, permissions, and other guidance for how data can be used and shared) to convey details of license restrictions that apply to the data."@en-US ;
 	sh:property
@@ -54,61 +54,61 @@ marking:LicenseMarking
 			sh:datatype xsd:string ;
 			sh:hasValue "license" ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:definitionType ;
+			sh:path uco-marking:definitionType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:license ;
+			sh:path uco-marking:license ;
 		]
 		;
-	sh:targetClass marking:LicenseMarking ;
+	sh:targetClass uco-marking:LicenseMarking ;
 	.
 
-marking:MarkingDefinition
+uco-marking:MarkingDefinition
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:MarkingDefinitionAbstraction ;
+	rdfs:subClassOf uco-core:MarkingDefinitionAbstraction ;
 	rdfs:label "MarkingDefinition"@en ;
 	rdfs:comment "A marking definition is a grouping of characteristics unique to the expression of a specific data marking conveying restrictions, permissions, and other guidance for how marked data can be used and shared."@en ;
 	sh:property
 		[
-			sh:class marking:MarkingModel ;
+			sh:class uco-marking:MarkingModel ;
 			sh:nodeKind sh:IRI ;
-			sh:path marking:definition ;
+			sh:path uco-marking:definition ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:definitionType ;
+			sh:path uco-marking:definitionType ;
 		]
 		;
-	sh:targetClass marking:MarkingDefinition ;
+	sh:targetClass uco-marking:MarkingDefinition ;
 	.
 
-marking:MarkingModel
+uco-marking:MarkingModel
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "MarkingModel"@en ;
 	rdfs:comment "A marking model is a grouping of characteristics unique to the expression of a particular form of data marking definitions (restrictions, permissions, and other guidance for how data can be used and shared)."@en ;
-	sh:targetClass marking:MarkingModel ;
+	sh:targetClass uco-marking:MarkingModel ;
 	.
 
-marking:ReleaseToMarking
+uco-marking:ReleaseToMarking
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf marking:MarkingModel ;
+	rdfs:subClassOf uco-marking:MarkingModel ;
 	rdfs:label "Release-To Marking"@en ;
 	rdfs:comment "A release-to marking is a grouping of characteristics unique to the expression of data marking definitions (restrictions, permissions, and other guidance for how data can be used and shared) to convey details of authorized persons and/or organizations to which to the associated content may be released. The existence of the Release-To marking restricts access to ONLY those identities explicitly listed, regardless of whether another data marking exists that allows sharing with other members of the community."@en-US ;
 	sh:property
@@ -116,24 +116,24 @@ marking:ReleaseToMarking
 			sh:datatype xsd:string ;
 			sh:hasValue "release-to" ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:definitionType ;
+			sh:path uco-marking:definitionType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:authorizedIdentities ;
+			sh:path uco-marking:authorizedIdentities ;
 		]
 		;
-	sh:targetClass marking:ReleaseToMarking ;
+	sh:targetClass uco-marking:ReleaseToMarking ;
 	.
 
-marking:StatementMarking
+uco-marking:StatementMarking
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf marking:MarkingModel ;
+	rdfs:subClassOf uco-marking:MarkingModel ;
 	rdfs:label "Statement Marking"@en ;
 	rdfs:comment "A statement marking is a grouping of characteristics unique to the expression of data marking definitions (restrictions, permissions, and other guidance for how data can be used and shared) to convey details of a textual marking statement, (e.g., copyright) whose semantic meaning should apply to the associated content. Statement markings are generally not machine-readable. An example of this would be a simple marking to apply copyright information, such as 'Copyright 2014 Acme Inc.'."@en ;
 	sh:property
@@ -141,25 +141,25 @@ marking:StatementMarking
 			sh:datatype xsd:string ;
 			sh:hasValue "statement" ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:definitionType ;
+			sh:path uco-marking:definitionType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:statement ;
+			sh:path uco-marking:statement ;
 		]
 		;
-	sh:targetClass marking:StatementMarking ;
+	sh:targetClass uco-marking:StatementMarking ;
 	.
 
-marking:TermsOfUseMarking
+uco-marking:TermsOfUseMarking
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf marking:MarkingModel ;
+	rdfs:subClassOf uco-marking:MarkingModel ;
 	rdfs:label "Terms Of Use Marking"@en ;
 	rdfs:comment "A terms of use marking is a grouping of characteristics unique to the expression of data marking definitions (restrictions, permissions, and other guidance for how data can be used and shared) to convey details of a textual statement specifying the Terms of Use (that is, the conditions under which the content may be shared, applied, or otherwise used) of the marked content. An example of this would be used to communicate a simple statement, such as 'Acme Inc. is not responsible for the content of this file'."@en ;
 	sh:property
@@ -167,27 +167,27 @@ marking:TermsOfUseMarking
 			sh:datatype xsd:string ;
 			sh:hasValue "terms-of-use" ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:definitionType ;
+			sh:path uco-marking:definitionType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path marking:termsOfUse ;
+			sh:path uco-marking:termsOfUse ;
 		]
 		;
-	sh:targetClass marking:TermsOfUseMarking ;
+	sh:targetClass uco-marking:TermsOfUseMarking ;
 	.
 
-marking:authorizedIdentities
+uco-marking:authorizedIdentities
 	a owl:DatatypeProperty ;
 	rdfs:label "Authorized Identities"@en ;
 	rdfs:comment "Specifies the identities that are authorized to access the data to which the data marking is associated.  The list of authorized identities are represented as UUIDs."@en ;
 	rdfs:range xsd:string ;
 	.
 
-marking:contentSelectors
+uco-marking:contentSelectors
 	a owl:DatatypeProperty ;
 	rdfs:label "contentSelectors"@en ;
 	rdfs:comment """Explicit specification of exactly which portions of a UCO object to apply marking definitions to.
@@ -195,43 +195,43 @@ marking:contentSelectors
 	rdfs:range xsd:string ;
 	.
 
-marking:definition
+uco-marking:definition
 	a owl:ObjectProperty ;
 	rdfs:label "definition"@en ;
 	rdfs:comment "Explicit specification of a data marking instance."@en ;
-	rdfs:range marking:MarkingModel ;
+	rdfs:range uco-marking:MarkingModel ;
 	.
 
-marking:definitionType
+uco-marking:definitionType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "definitionType"@en ;
 	rdfs:comment "Specifies the Marking Model for a Marking Definition."@en ;
 	rdfs:range xsd:string ;
 	.
 
-marking:license
+uco-marking:license
 	a owl:DatatypeProperty ;
 	rdfs:label "License" ;
 	rdfs:comment "Specifies the identifier for the type of license" ;
 	rdfs:range xsd:string ;
 	.
 
-marking:marking
+uco-marking:marking
 	a owl:ObjectProperty ;
 	rdfs:label "marking"@en ;
 	rdfs:comment "Represents specific marking definitions to be applied to UCO data."@en ;
-	rdfs:range marking:MarkingDefinition ;
+	rdfs:range uco-marking:MarkingDefinition ;
 	.
 
-marking:statement
+uco-marking:statement
 	a owl:DatatypeProperty ;
 	rdfs:label "Statement"@en-US ;
 	rdfs:comment "Specifies the statement to apply to the structure for which the Marking is to be applied."@en-US ;
 	rdfs:range xsd:string ;
 	.
 
-marking:termsOfUse
+uco-marking:termsOfUse
 	a owl:DatatypeProperty ;
 	rdfs:label "Terms of Use"@en-US ;
 	rdfs:comment "Specifies the terms of use that apply to the structure for which the Marking is to be applied."@en-US ;

--- a/ontology/uco/observable/observable.ttl
+++ b/ontology/uco/observable/observable.ttl
@@ -6,88 +6,88 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/types/1.3.0
 # imports: https://ontology.unifiedcyberontology.org/uco/vocabulary/1.3.0
 
-@prefix action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix co: <http://purl.org/co/> .
-@prefix configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
-@prefix identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
-@prefix location: <https://ontology.unifiedcyberontology.org/uco/location/> .
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
+@prefix uco-configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
+@prefix uco-location: <https://ontology.unifiedcyberontology.org/uco/location/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/observable>
 	a owl:Ontology ;
 	rdfs:label "uco-observable"@en ;
-	owl:backwardCompatibleWith observable:1.2.0 ;
+	owl:backwardCompatibleWith uco-observable:1.2.0 ;
 	owl:imports
-		action:1.3.0 ,
-		configuration:1.3.0 ,
-		core:1.3.0 ,
-		identity:1.3.0 ,
-		location:1.3.0 ,
-		types:1.3.0 ,
-		vocabulary:1.3.0
+		uco-action:1.3.0 ,
+		uco-configuration:1.3.0 ,
+		uco-core:1.3.0 ,
+		uco-identity:1.3.0 ,
+		uco-location:1.3.0 ,
+		uco-types:1.3.0 ,
+		uco-vocabulary:1.3.0
 		;
-	owl:priorVersion observable:1.2.0 ;
-	owl:versionIRI observable:1.3.0 ;
+	owl:priorVersion uco-observable:1.2.0 ;
+	owl:versionIRI uco-observable:1.3.0 ;
 	.
 
-observable:API
+uco-observable:API
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "API"@en ;
 	rdfs:comment "An API (application programming interface) is a computing interface that defines interactions between multiple software or mixed hardware-software intermediaries. It defines the kinds of calls or requests that can be made, how to make them, the data formats that should be used, the conventions to follow, etc. [based on https://en.wikipedia.org/wiki/API]"@en ;
-	sh:targetClass observable:API ;
+	sh:targetClass uco-observable:API ;
 	.
 
-observable:ARPCache
+uco-observable:ARPCache
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "ARPCache"@en ;
 	rdfs:comment "An ARP cache is a collection of Address Resolution Protocol (ARP) entries (mostly dynamic) that are created when an IP address is resolved to a MAC address (so the computer can effectively communicate with the IP address). [based on https://en.wikipedia.org/wiki/ARP_cache]"@en ;
-	sh:targetClass observable:ARPCache ;
+	sh:targetClass uco-observable:ARPCache ;
 	.
 
-observable:ARPCacheEntry
+uco-observable:ARPCacheEntry
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "ARPCacheEntry"@en ;
 	rdfs:comment "An ARP cache entry is a single Address Resolution Protocol (ARP) response record that is created when an IP address is resolved to a MAC address (so the computer can effectively communicate with the IP address). [based on https://en.wikipedia.org/wiki/ARP_cache]"@en ;
-	sh:targetClass observable:ARPCacheEntry ;
+	sh:targetClass uco-observable:ARPCacheEntry ;
 	.
 
-observable:Account
+uco-observable:Account
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Account"@en ;
 	rdfs:comment "An account is an arrangement with an entity to enable and control the provision of some capability or service."@en ;
-	sh:targetClass observable:Account ;
+	sh:targetClass uco-observable:Account ;
 	.
 
-observable:AccountAuthenticationFacet
+uco-observable:AccountAuthenticationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AccountAuthenticationFacet"@en ;
 	rdfs:comment "An account authentication facet is a grouping of characteristics unique to the mechanism of accessing an account."@en ;
 	sh:property
@@ -95,92 +95,92 @@ observable:AccountAuthenticationFacet
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:passwordLastChanged ;
+			sh:path uco-observable:passwordLastChanged ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:password ;
+			sh:path uco-observable:password ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:passwordType ;
+			sh:path uco-observable:passwordType ;
 		]
 		;
-	sh:targetClass observable:AccountAuthenticationFacet ;
+	sh:targetClass uco-observable:AccountAuthenticationFacet ;
 	.
 
-observable:AccountFacet
+uco-observable:AccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AccountFacet"@en ;
 	rdfs:comment "An account facet is a grouping of characteristics unique to an arrangement with an entity to enable and control the provision of some capability or service."@en ;
 	sh:property
-		observable:AccountFacet-accountType-in-shape ,
+		uco-observable:AccountFacet-accountType-in-shape ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:accountIssuer ;
+			sh:path uco-observable:accountIssuer ;
 		] ,
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:owner ;
+			sh:path uco-observable:owner ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isActive ;
+			sh:path uco-observable:isActive ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:expirationTime ;
+			sh:path uco-observable:expirationTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:modifiedTime ;
+			sh:path uco-observable:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accountIdentifier ;
+			sh:path uco-observable:accountIdentifier ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:accountType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:accountType ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:accountType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:accountType ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accountType ;
+			sh:path uco-observable:accountType ;
 		]
 		;
-	sh:targetClass observable:AccountFacet ;
+	sh:targetClass uco-observable:AccountFacet ;
 	.
 
-observable:AccountFacet-accountType-in-shape
+uco-observable:AccountFacet-accountType-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"ldap"
@@ -193,99 +193,99 @@ observable:AccountFacet-accountType-in-shape
 		"windows_local"
 	) ;
 	sh:message "Value is not member of the vocabulary AccountTypeVocab." ;
-	sh:path observable:accountType ;
+	sh:path uco-observable:accountType ;
 	sh:severity sh:Info ;
 	.
 
-observable:Adaptor
+uco-observable:Adaptor
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "Adaptor"@en-US ;
 	rdfs:comment "An adaptor is a device that physically converts the pin outputs but does not alter the underlying protocol (e.g. uSD to SD, CF to ATA, etc.)"@en-US ;
-	sh:targetClass observable:Adaptor ;
+	sh:targetClass uco-observable:Adaptor ;
 	.
 
-observable:Address
+uco-observable:Address
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Address"@en ;
 	rdfs:comment "An address is an identifier assigned to enable routing and management of information."@en ;
-	sh:targetClass observable:Address ;
+	sh:targetClass uco-observable:Address ;
 	.
 
-observable:AlternateDataStream
+uco-observable:AlternateDataStream
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "AlternateDataStream"@en ;
 	rdfs:comment "An alternate data stream is data content stored within an NTFS file that is independent of the standard content stream of the file and is hidden from access by default NTFS file viewing mechanisms."@en ;
 	rdfs:seeAlso [
 		a sh:NodeShape ;
 		rdfs:comment "This anonymous shape is attached with rdfs:seeAlso in order to associate a warning-severity class constraint, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
-		sh:class observable:FileSystemObject ;
+		sh:class uco-observable:FileSystemObject ;
 		sh:message "In UCO 2.0.0, uco-observable:AlternateDataStream will be a subclass of uco-observable:FileSystemObject.  In preparation for UCO 2.0.0, the additional type uco-observable:FileSystemObject should be assigned to this node."@en ;
 		sh:severity sh:Warning ;
-		sh:targetClass observable:AlternateDataStream ;
+		sh:targetClass uco-observable:AlternateDataStream ;
 	] ;
-	sh:targetClass observable:AlternateDataStream ;
+	sh:targetClass uco-observable:AlternateDataStream ;
 	.
 
-observable:AlternateDataStreamFacet
+uco-observable:AlternateDataStreamFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AlternateDataStreamFacet"@en ;
 	rdfs:comment "An alternate data stream facet is a grouping of characteristics unique to data content stored within an NTFS file that is independent of the standard content stream of the file and is hidden from access by default NTFS file viewing mechanisms."@en ;
 	sh:property
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:hashes ;
+			sh:path uco-observable:hashes ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:size ;
+			sh:path uco-observable:size ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:name ;
+			sh:path uco-core:name ;
 		]
 		;
-	sh:targetClass observable:AlternateDataStreamFacet ;
+	sh:targetClass uco-observable:AlternateDataStreamFacet ;
 	.
 
-observable:AndroidDevice
+uco-observable:AndroidDevice
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "AndroidDevice"@en ;
 	rdfs:comment "An Android device is a device running the Android operating system. [based on https://en.wikipedia.org/wiki/Android_(operating_system)]"@en ;
-	sh:targetClass observable:AndroidDevice ;
+	sh:targetClass uco-observable:AndroidDevice ;
 	.
 
-observable:AndroidDeviceFacet
+uco-observable:AndroidDeviceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AndroidDeviceFacet"@en ;
 	rdfs:comment "An Android device facet is a grouping of characteristics unique to an Android device. [based on https://en.wikipedia.org/wiki/Android_(operating_system)]"@en ;
 	sh:property
@@ -293,56 +293,56 @@ observable:AndroidDeviceFacet
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isADBRootEnabled ;
+			sh:path uco-observable:isADBRootEnabled ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isSURootEnabled ;
+			sh:path uco-observable:isSURootEnabled ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:androidID ;
+			sh:path uco-observable:androidID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:androidFingerprint ;
+			sh:path uco-observable:androidFingerprint ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:androidVersion ;
+			sh:path uco-observable:androidVersion ;
 		]
 		;
-	sh:targetClass observable:AndroidDeviceFacet ;
+	sh:targetClass uco-observable:AndroidDeviceFacet ;
 	.
 
-observable:AndroidPhone
+uco-observable:AndroidPhone
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		observable:AndroidDevice ,
-		observable:SmartPhone
+		uco-observable:AndroidDevice ,
+		uco-observable:SmartPhone
 		;
 	rdfs:label "AndroidPhone"@en-US ;
 	rdfs:comment "An android phone is a smart phone that applies the Android mobile operating system."@en-US ;
-	sh:targetClass observable:AndroidPhone ;
+	sh:targetClass uco-observable:AndroidPhone ;
 	.
 
-observable:AntennaFacet
+uco-observable:AntennaFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AntennaFacet"@en ;
 	rdfs:comment "An antenna alignment facet contains the metadata surrounding the cell tower's antenna position."@en ;
 	sh:property
@@ -350,151 +350,151 @@ observable:AntennaFacet
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:antennaHeight ;
+			sh:path uco-observable:antennaHeight ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:azimuth ;
+			sh:path uco-observable:azimuth ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:elevation ;
+			sh:path uco-observable:elevation ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:horizontalBeamWidth ;
+			sh:path uco-observable:horizontalBeamWidth ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:signalStrength ;
+			sh:path uco-observable:signalStrength ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:skew ;
+			sh:path uco-observable:skew ;
 		]
 		;
-	sh:targetClass observable:AntennaFacet ;
+	sh:targetClass uco-observable:AntennaFacet ;
 	.
 
-observable:AppleDevice
+uco-observable:AppleDevice
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "AppleDevice"@en-US ;
 	rdfs:comment "An apple device is a smart device that applies either the MacOS or iOS operating system."@en-US ;
-	sh:targetClass observable:AppleDevice ;
+	sh:targetClass uco-observable:AppleDevice ;
 	.
 
-observable:Appliance
+uco-observable:Appliance
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "Appliance"@en ;
 	rdfs:comment "An appliance is a purpose-built computer with software or firmware that is designed to provide a specific computing capability or resource. [based on https://en.wikipedia.org/wiki/Computer_appliance]"@en ;
-	sh:targetClass observable:Appliance ;
+	sh:targetClass uco-observable:Appliance ;
 	.
 
-observable:Application
+uco-observable:Application
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Application"@en ;
 	rdfs:comment "An application is a particular software program designed for end users."@en ;
-	sh:targetClass observable:Application ;
+	sh:targetClass uco-observable:Application ;
 	.
 
-observable:ApplicationAccount
+uco-observable:ApplicationAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "ApplicationAccount"@en ;
 	rdfs:comment "An application account is an account within a particular software program designed for end users."@en ;
-	sh:targetClass observable:ApplicationAccount ;
+	sh:targetClass uco-observable:ApplicationAccount ;
 	.
 
-observable:ApplicationAccountFacet
+uco-observable:ApplicationAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ApplicationAccountFacet"@en ;
 	rdfs:comment "An application account facet is a grouping of characteristics unique to an account within a particular software program designed for end users."@en ;
 	sh:property [
-		sh:class observable:ObservableObject ;
+		sh:class uco-observable:ObservableObject ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path observable:application ;
+		sh:path uco-observable:application ;
 	] ;
-	sh:targetClass observable:ApplicationAccountFacet ;
+	sh:targetClass uco-observable:ApplicationAccountFacet ;
 	.
 
-observable:ApplicationFacet
+uco-observable:ApplicationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ApplicationFacet"@en ;
 	rdfs:comment "An application facet is a grouping of characteristics unique to a particular software program designed for end users."@en ;
 	sh:property
 		[
-			sh:class observable:ApplicationVersion ;
+			sh:class uco-observable:ApplicationVersion ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:installedVersionHistory ;
+			sh:path uco-observable:installedVersionHistory ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:operatingSystem ;
+			sh:path uco-observable:operatingSystem ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:numberOfLaunches ;
+			sh:path uco-observable:numberOfLaunches ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:applicationIdentifier ;
+			sh:path uco-observable:applicationIdentifier ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 		]
 		;
-	sh:targetClass observable:ApplicationFacet ;
+	sh:targetClass uco-observable:ApplicationFacet ;
 	.
 
-observable:ApplicationVersion
+uco-observable:ApplicationVersion
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ApplicationVersion"@en ;
 	rdfs:comment "An application version is a grouping of characteristics unique to a particular software program version."@en ;
 	sh:property
@@ -502,41 +502,41 @@ observable:ApplicationVersion
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:installDate ;
+			sh:path uco-observable:installDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:uninstallDate ;
+			sh:path uco-observable:uninstallDate ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 		]
 		;
-	sh:targetClass observable:ApplicationVersion ;
+	sh:targetClass uco-observable:ApplicationVersion ;
 	.
 
-observable:ArchiveFile
+uco-observable:ArchiveFile
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:File ;
+	rdfs:subClassOf uco-observable:File ;
 	rdfs:label "ArchiveFile"@en ;
 	rdfs:comment "An archive file is a file that is composed of one or more computer files along with metadata."@en ;
-	sh:targetClass observable:ArchiveFile ;
+	sh:targetClass uco-observable:ArchiveFile ;
 	.
 
-observable:ArchiveFileFacet
+uco-observable:ArchiveFileFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ArchiveFileFacet"@en ;
 	rdfs:comment "An archive file facet is a grouping of characteristics unique to a file that is composed of one or more computer files along with metadata."@en ;
 	sh:property
@@ -544,41 +544,41 @@ observable:ArchiveFileFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:archiveType ;
+			sh:path uco-observable:archiveType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:comment ;
+			sh:path uco-observable:comment ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 		]
 		;
-	sh:targetClass observable:ArchiveFileFacet ;
+	sh:targetClass uco-observable:ArchiveFileFacet ;
 	.
 
-observable:Audio
+uco-observable:Audio
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Audio"@en ;
 	rdfs:comment "Audio is a digital representation of sound."@en ;
-	sh:targetClass observable:Audio ;
+	sh:targetClass uco-observable:Audio ;
 	.
 
-observable:AudioFacet
+uco-observable:AudioFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AudioFacet"@en ;
 	rdfs:comment "An audio facet is a grouping of characteristics unique to a digital representation of sound."@en ;
 	sh:property
@@ -586,554 +586,554 @@ observable:AudioFacet
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:bitRate ;
+			sh:path uco-observable:bitRate ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:duration ;
+			sh:path uco-observable:duration ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:audioType ;
+			sh:path uco-observable:audioType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:format ;
+			sh:path uco-observable:format ;
 		]
 		;
-	sh:targetClass observable:AudioFacet ;
+	sh:targetClass uco-observable:AudioFacet ;
 	.
 
-observable:AutonomousSystem
+uco-observable:AutonomousSystem
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "AutonomousSystem"@en ;
 	rdfs:comment "An autonomous system is a collection of connected Internet Protocol (IP) routing prefixes under the control of one or more network operators on behalf of a single administrative entity or domain that presents a common, clearly defined routing policy to the Internet. [based on https://en.wikipedia.org/wiki/Autonomous_system_(Internet)]"@en ;
-	sh:targetClass observable:AutonomousSystem ;
+	sh:targetClass uco-observable:AutonomousSystem ;
 	.
 
-observable:AutonomousSystemFacet
+uco-observable:AutonomousSystemFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "AutonomousSystemFacet"@en ;
 	rdfs:comment "An autonomous system facet is a grouping of characteristics unique to a collection of connected Internet Protocol (IP) routing prefixes under the control of one or more network operators on behalf of a single administrative entity or domain that presents a common, clearly defined routing policy to the Internet. [based on https://en.wikipedia.org/wiki/Autonomous_system_(Internet)]"@en ;
 	sh:property
-		observable:regionalInternetRegistry-shape-value-not-vocabulary-member ,
-		observable:regionalInternetRegistry-shape-value-outside-default-vocabulary ,
+		uco-observable:regionalInternetRegistry-shape-value-not-vocabulary-member ,
+		uco-observable:regionalInternetRegistry-shape-value-outside-default-vocabulary ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:number ;
+			sh:path uco-observable:number ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:asHandle ;
+			sh:path uco-observable:asHandle ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:regionalInternetRegistry should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:regionalInternetRegistry ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:regionalInternetRegistry should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:regionalInternetRegistry ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:regionalInternetRegistry ;
+			sh:path uco-observable:regionalInternetRegistry ;
 		]
 		;
-	sh:targetClass observable:AutonomousSystemFacet ;
+	sh:targetClass uco-observable:AutonomousSystemFacet ;
 	.
 
-observable:BlackberryPhone
+uco-observable:BlackberryPhone
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:SmartPhone ;
+	rdfs:subClassOf uco-observable:SmartPhone ;
 	rdfs:label "BlackberryPhone"@en-US ;
 	rdfs:comment "A blackberry phone is a smart phone that applies the Blackberry OS mobile operating system. (Blackberry 10 re-introduces Blackberry OS, prior to that the OS was Android.)"@en-US ;
-	sh:targetClass observable:BlackberryPhone ;
+	sh:targetClass uco-observable:BlackberryPhone ;
 	.
 
-observable:BlockDeviceNode
+uco-observable:BlockDeviceNode
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "BlockDeviceNode"@en ;
 	rdfs:comment "A block device node is a UNIX filesystem special file that serves as a conduit to communicate with devices, providing buffered randomly accesible input and output. Block device nodes are used to apply access rights to the devices and to direct operations on the files to the appropriate device drivers. [based on https://en.wikipedia.org/wiki/Unix_file_types]"@en ;
-	sh:targetClass observable:BlockDeviceNode ;
+	sh:targetClass uco-observable:BlockDeviceNode ;
 	.
 
-observable:BluetoothAddress
+uco-observable:BluetoothAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:MACAddress ;
+	rdfs:subClassOf uco-observable:MACAddress ;
 	rdfs:label "BluetoothAddress"@en ;
 	rdfs:comment "A Bluetooth address is a Bluetooth standard conformant identifier assigned to a Bluetooth device to enable routing and management of Bluetooth standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:BluetoothAddress ;
+	sh:targetClass uco-observable:BluetoothAddress ;
 	.
 
-observable:BluetoothAddressFacet
+uco-observable:BluetoothAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:MACAddressFacet ;
+	rdfs:subClassOf uco-observable:MACAddressFacet ;
 	rdfs:label "BluetoothAddressFacet"@en ;
 	rdfs:comment "A Bluetooth address facet is a grouping of characteristics unique to a Bluetooth standard conformant identifier assigned to a Bluetooth device to enable routing and management of Bluetooth standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:BluetoothAddressFacet ;
+	sh:targetClass uco-observable:BluetoothAddressFacet ;
 	.
 
-observable:BotConfiguration
+uco-observable:BotConfiguration
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "BotConfiguration"@en ;
 	rdfs:comment "A bot configuration is a set of contextual settings for a software application that runs automated tasks (scripts) over the Internet at a much higher rate than would be possible for a human alone."@en ;
-	sh:targetClass observable:BotConfiguration ;
+	sh:targetClass uco-observable:BotConfiguration ;
 	.
 
-observable:BrowserBookmark
+uco-observable:BrowserBookmark
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "BrowserBookmark"@en ;
 	rdfs:comment "A browser bookmark is a saved shortcut that directs a WWW (World Wide Web) browser software program to a particular WWW accessible resource. [based on https://techterms.com/definition/bookmark]"@en ;
-	sh:targetClass observable:BrowserBookmark ;
+	sh:targetClass uco-observable:BrowserBookmark ;
 	.
 
-observable:BrowserBookmarkFacet
+uco-observable:BrowserBookmarkFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "BrowserBookmarkFacet"@en ;
 	rdfs:comment "A browser bookmark facet is a grouping of characteristics unique to a saved shortcut that directs a WWW (World Wide Web) browser software program to a particular WWW accessible resource. [based on https://techterms.com/definition/bookmark]"@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
 			sh:datatype xsd:anyURI ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:urlTargeted ;
+			sh:path uco-observable:urlTargeted ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accessedTime ;
+			sh:path uco-observable:accessedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:modifiedTime ;
+			sh:path uco-observable:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:visitCount ;
+			sh:path uco-observable:visitCount ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:bookmarkPath ;
+			sh:path uco-observable:bookmarkPath ;
 		]
 		;
-	sh:targetClass observable:BrowserBookmarkFacet ;
+	sh:targetClass uco-observable:BrowserBookmarkFacet ;
 	.
 
-observable:BrowserCookie
+uco-observable:BrowserCookie
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "BrowserCookie"@en ;
 	rdfs:comment "A browser cookie is a piece of of data sent from a website and stored on the user's computer by the user's web browser while the user is browsing. [based on https://en.wikipedia.org/wiki/HTTP_cookie]"@en ;
-	sh:targetClass observable:BrowserCookie ;
+	sh:targetClass uco-observable:BrowserCookie ;
 	.
 
-observable:BrowserCookieFacet
+uco-observable:BrowserCookieFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "BrowserCookieFacet"@en ;
 	rdfs:comment "A browser cookie facet is a grouping of characteristics unique to a piece of data sent from a website and stored on the user's computer by the user's web browser while the user is browsing. [based on https://en.wikipedia.org/wiki/HTTP_cookie]"@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:cookieDomain ;
+			sh:path uco-observable:cookieDomain ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isSecure ;
+			sh:path uco-observable:isSecure ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accessedTime ;
+			sh:path uco-observable:accessedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:expirationTime ;
+			sh:path uco-observable:expirationTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cookieName ;
+			sh:path uco-observable:cookieName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cookiePath ;
+			sh:path uco-observable:cookiePath ;
 		]
 		;
-	sh:targetClass observable:BrowserCookieFacet ;
+	sh:targetClass uco-observable:BrowserCookieFacet ;
 	.
 
-observable:Calendar
+uco-observable:Calendar
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Calendar"@en ;
 	rdfs:comment "A calendar is a collection of appointments, meetings, and events."@en ;
-	sh:targetClass observable:Calendar ;
+	sh:targetClass uco-observable:Calendar ;
 	.
 
-observable:CalendarEntry
+uco-observable:CalendarEntry
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "CalendarEntry"@en ;
 	rdfs:comment "A calendar entry is an appointment, meeting or event within a collection of appointments, meetings and events."@en ;
-	sh:targetClass observable:CalendarEntry ;
+	sh:targetClass uco-observable:CalendarEntry ;
 	.
 
-observable:CalendarEntryFacet
+uco-observable:CalendarEntryFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "CalendarEntryFacet"@en ;
 	rdfs:comment "A calendar entry facet is a grouping of characteristics unique to an appointment, meeting, or event within a collection of appointments, meetings, and events."@en ;
 	sh:property
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:owner ;
+			sh:path uco-observable:owner ;
 		] ,
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:attendant ;
+			sh:path uco-observable:attendant ;
 		] ,
 		[
-			sh:class location:Location ;
+			sh:class uco-location:Location ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:location ;
+			sh:path uco-observable:location ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isPrivate ;
+			sh:path uco-observable:isPrivate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:endTime ;
+			sh:path uco-observable:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:modifiedTime ;
+			sh:path uco-observable:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:remindTime ;
+			sh:path uco-observable:remindTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startTime ;
+			sh:path uco-observable:startTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:duration ;
+			sh:path uco-observable:duration ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventStatus ;
+			sh:path uco-observable:eventStatus ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventType ;
+			sh:path uco-observable:eventType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:recurrence ;
+			sh:path uco-observable:recurrence ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subject ;
+			sh:path uco-observable:subject ;
 		]
 		;
-	sh:targetClass observable:CalendarEntryFacet ;
+	sh:targetClass uco-observable:CalendarEntryFacet ;
 	.
 
-observable:CalendarFacet
+uco-observable:CalendarFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "CalendarFacet"@en ;
 	rdfs:comment "A calendar facet is a grouping of characteristics unique to a collection of appointments, meetings, and events."@en ;
 	sh:property
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:owner ;
+			sh:path uco-observable:owner ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		]
 		;
-	sh:targetClass observable:CalendarFacet ;
+	sh:targetClass uco-observable:CalendarFacet ;
 	.
 
-observable:Call
+uco-observable:Call
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Call"@en ;
 	rdfs:comment "A call is a connection as part of a realtime cyber communication between one or more parties."@en ;
-	sh:targetClass observable:Call ;
+	sh:targetClass uco-observable:Call ;
 	.
 
-observable:CallFacet
+uco-observable:CallFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "CallFacet"@en ;
 	rdfs:comment "A call facet is a grouping of characteristics unique to a connection as part of a realtime cyber communication between one or more parties."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:from ;
+			sh:path uco-observable:from ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:participant ;
+			sh:path uco-observable:participant ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:to ;
+			sh:path uco-observable:to ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:endTime ;
+			sh:path uco-observable:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startTime ;
+			sh:path uco-observable:startTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:duration ;
+			sh:path uco-observable:duration ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:callType ;
+			sh:path uco-observable:callType ;
 		]
 		;
-	sh:targetClass observable:CallFacet ;
+	sh:targetClass uco-observable:CallFacet ;
 	.
 
-observable:CapturedTelecommunicationsInformation
+uco-observable:CapturedTelecommunicationsInformation
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "CapturedTelecommunicationsInformation"@en ;
-	sh:targetClass observable:CapturedTelecommunicationsInformation ;
+	sh:targetClass uco-observable:CapturedTelecommunicationsInformation ;
 	.
 
-observable:CapturedTelecommunicationsInformationFacet
+uco-observable:CapturedTelecommunicationsInformationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "CapturedTelecommunicationsInformationFacet"@en ;
 	rdfs:comment "A captured telecommunications information facet represents certain information within captured or intercepted telecommunications data."@en ;
 	sh:property
 		[
-			sh:class observable:CellSite ;
+			sh:class uco-observable:CellSite ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:captureCellSite ;
+			sh:path uco-observable:captureCellSite ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:endTime ;
+			sh:path uco-observable:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startTime ;
+			sh:path uco-observable:startTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:interceptedCallState ;
+			sh:path uco-observable:interceptedCallState ;
 		]
 		;
-	sh:targetClass observable:CapturedTelecommunicationsInformationFacet ;
+	sh:targetClass uco-observable:CapturedTelecommunicationsInformationFacet ;
 	.
 
-observable:CellSite
+uco-observable:CellSite
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "CellSite"@en ;
-	sh:targetClass observable:CellSite ;
+	sh:targetClass uco-observable:CellSite ;
 	.
 
-observable:CellSiteFacet
+uco-observable:CellSiteFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "CellSiteFacet"@en ;
 	rdfs:comment "A cell site facet contains the metadata surrounding the cell site."@en ;
 	sh:property
@@ -1141,64 +1141,64 @@ observable:CellSiteFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cellSiteCountryCode ;
+			sh:path uco-observable:cellSiteCountryCode ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cellSiteIdentifier ;
+			sh:path uco-observable:cellSiteIdentifier ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cellSiteLocationAreaCode ;
+			sh:path uco-observable:cellSiteLocationAreaCode ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cellSiteNetworkCode ;
+			sh:path uco-observable:cellSiteNetworkCode ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cellSiteType ;
+			sh:path uco-observable:cellSiteType ;
 		]
 		;
-	sh:targetClass observable:CellSiteFacet ;
+	sh:targetClass uco-observable:CellSiteFacet ;
 	.
 
-observable:CharacterDeviceNode
+uco-observable:CharacterDeviceNode
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "CharacterDeviceNode"@en ;
 	rdfs:comment "A character device node is a UNIX filesystem special file that serves as a conduit to communicate with devices, providing only a serial stream of input or accepting a serial stream of output. Character device nodes are used to apply access rights to the devices and to direct operations on the files to the appropriate device drivers. [based on https://en.wikipedia.org/wiki/Unix_file_types]"@en ;
-	sh:targetClass observable:CharacterDeviceNode ;
+	sh:targetClass uco-observable:CharacterDeviceNode ;
 	.
 
-observable:Code
+uco-observable:Code
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Code"@en ;
 	rdfs:comment "Code is a direct representation (source, byte or binary) of a collection of computer instructions that form software which tell a computer how to work. [based on https://en.wikipedia.org/wiki/Software]"@en ;
-	sh:targetClass observable:Code ;
+	sh:targetClass uco-observable:Code ;
 	.
 
-observable:CompressedStreamFacet
+uco-observable:CompressedStreamFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "CompressedStreamFacet"@en ;
 	rdfs:comment "A compressed stream facet is a grouping of characteristics unique to the application of a size-reduction process to a body of data content."@en ;
 	sh:property
@@ -1206,240 +1206,240 @@ observable:CompressedStreamFacet
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:compressionRatio ;
+			sh:path uco-observable:compressionRatio ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:compressionMethod ;
+			sh:path uco-observable:compressionMethod ;
 		]
 		;
-	sh:targetClass observable:CompressedStreamFacet ;
+	sh:targetClass uco-observable:CompressedStreamFacet ;
 	.
 
-observable:Computer
+uco-observable:Computer
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "Computer"@en-US ;
 	rdfs:comment "A computer is an electronic device for storing and processing data, typically in binary, according to instructions given to it in a variable program. [based on 'Computer.' Oxford English Dictionary, Oxford University Press, 2022.]"@en-US ;
-	sh:targetClass observable:Computer ;
+	sh:targetClass uco-observable:Computer ;
 	.
 
-observable:ComputerSpecification
+uco-observable:ComputerSpecification
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "ComputerSpecification"@en ;
 	rdfs:comment "A computer specification is the hardware and software of a programmable electronic device that can store, retrieve, and process data. {based on merriam-webster.com/dictionary/computer]"@en ;
-	sh:targetClass observable:ComputerSpecification ;
+	sh:targetClass uco-observable:ComputerSpecification ;
 	.
 
-observable:ComputerSpecificationFacet
+uco-observable:ComputerSpecificationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ComputerSpecificationFacet"@en ;
 	rdfs:comment "A computer specificaiton facet is a grouping of characteristics unique to the hardware and software of a programmable electronic device that can store, retrieve, and process data. [based on merriam-webster.com/dictionary/computer]"@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:networkInterface ;
+			sh:path uco-observable:networkInterface ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:biosDate ;
+			sh:path uco-observable:biosDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:biosReleaseDate ;
+			sh:path uco-observable:biosReleaseDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:currentSystemDate ;
+			sh:path uco-observable:currentSystemDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:localTime ;
+			sh:path uco-observable:localTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:systemTime ;
+			sh:path uco-observable:systemTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:availableRam ;
+			sh:path uco-observable:availableRam ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:totalRam ;
+			sh:path uco-observable:totalRam ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:biosManufacturer ;
+			sh:path uco-observable:biosManufacturer ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:biosSerialNumber ;
+			sh:path uco-observable:biosSerialNumber ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:biosVersion ;
+			sh:path uco-observable:biosVersion ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cpu ;
+			sh:path uco-observable:cpu ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cpuFamily ;
+			sh:path uco-observable:cpuFamily ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:gpu ;
+			sh:path uco-observable:gpu ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:gpuFamily ;
+			sh:path uco-observable:gpuFamily ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:hostname ;
+			sh:path uco-observable:hostname ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:processorArchitecture ;
+			sh:path uco-observable:processorArchitecture ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:timezoneDST ;
+			sh:path uco-observable:timezoneDST ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:timezoneStandard ;
+			sh:path uco-observable:timezoneStandard ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:uptime ;
+			sh:path uco-observable:uptime ;
 		]
 		;
-	sh:targetClass observable:ComputerSpecificationFacet ;
+	sh:targetClass uco-observable:ComputerSpecificationFacet ;
 	.
 
-observable:ConfiguredSoftware
+uco-observable:ConfiguredSoftware
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Software ;
+	rdfs:subClassOf uco-observable:Software ;
 	rdfs:label "ConfiguredSoftware"@en ;
 	rdfs:comment "A ConfiguredSoftware is a Software that is known to be configured to run in a more specified manner than some unconfigured or less-configured Software."@en ;
 	sh:property
 		[
-			sh:class configuration:Configuration ;
+			sh:class uco-configuration:Configuration ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path configuration:usesConfiguration ;
+			sh:path uco-configuration:usesConfiguration ;
 		] ,
 		[
-			sh:class observable:Software ;
+			sh:class uco-observable:Software ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path configuration:isConfigurationOf ;
+			sh:path uco-configuration:isConfigurationOf ;
 		]
 		;
-	sh:targetClass observable:ConfiguredSoftware ;
+	sh:targetClass uco-observable:ConfiguredSoftware ;
 	.
 
-observable:Contact
+uco-observable:Contact
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Contact"@en ;
 	rdfs:comment "A contact is a set of identification and communication related details for a single entity."@en ;
-	sh:targetClass observable:Contact ;
+	sh:targetClass uco-observable:Contact ;
 	.
 
-observable:ContactAddress
+uco-observable:ContactAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactAddress"@en ;
 	rdfs:comment "A contact address is a grouping of characteristics unique to a geolocation address of a contact entity."@en ;
 	sh:property
-		observable:ContactAddress-contactAddressScope-in-shape ,
+		uco-observable:ContactAddress-contactAddressScope-in-shape ,
 		[
-			sh:class location:Location ;
+			sh:class uco-location:Location ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:geolocationAddress ;
+			sh:path uco-observable:geolocationAddress ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactAddressScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:contactAddressScope ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:contactAddressScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:contactAddressScope ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactAddressScope ;
+			sh:path uco-observable:contactAddressScope ;
 		]
 		;
-	sh:targetClass observable:ContactAddress ;
+	sh:targetClass uco-observable:ContactAddress ;
 	.
 
-observable:ContactAddress-contactAddressScope-in-shape
+uco-observable:ContactAddress-contactAddressScope-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"home"
@@ -1447,109 +1447,109 @@ observable:ContactAddress-contactAddressScope-in-shape
 		"school"
 	) ;
 	sh:message "Value is not member of the vocabulary ContactAddressScopeVocab." ;
-	sh:path observable:contactAddressScope ;
+	sh:path uco-observable:contactAddressScope ;
 	sh:severity sh:Info ;
 	.
 
-observable:ContactAffiliation
+uco-observable:ContactAffiliation
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactListAffiliation"@en ;
 	rdfs:comment "A contact affiliation is a grouping of characteristics unique to details of an organizational affiliation for a single contact entity."@en ;
 	sh:property
 		[
-			sh:class identity:Organization ;
+			sh:class uco-identity:Organization ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactOrganization ;
+			sh:path uco-observable:contactOrganization ;
 		] ,
 		[
-			sh:class observable:ContactAddress ;
+			sh:class uco-observable:ContactAddress ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:organizationLocation ;
+			sh:path uco-observable:organizationLocation ;
 		] ,
 		[
-			sh:class observable:ContactEmail ;
+			sh:class uco-observable:ContactEmail ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactEmail ;
+			sh:path uco-observable:contactEmail ;
 		] ,
 		[
-			sh:class observable:ContactMessaging ;
+			sh:class uco-observable:ContactMessaging ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactMessaging ;
+			sh:path uco-observable:contactMessaging ;
 		] ,
 		[
-			sh:class observable:ContactPhone ;
+			sh:class uco-observable:ContactPhone ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactPhone ;
+			sh:path uco-observable:contactPhone ;
 		] ,
 		[
-			sh:class observable:ContactProfile ;
+			sh:class uco-observable:ContactProfile ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactProfile ;
+			sh:path uco-observable:contactProfile ;
 		] ,
 		[
-			sh:class observable:ContactURL ;
+			sh:class uco-observable:ContactURL ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactURL ;
+			sh:path uco-observable:contactURL ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:organizationDepartment ;
+			sh:path uco-observable:organizationDepartment ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:organizationPosition ;
+			sh:path uco-observable:organizationPosition ;
 		]
 		;
-	sh:targetClass observable:ContactAffiliation ;
+	sh:targetClass uco-observable:ContactAffiliation ;
 	.
 
-observable:ContactEmail
+uco-observable:ContactEmail
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactEmail"@en ;
 	rdfs:comment "A contact email is a grouping of characteristics unique to details for contacting a contact entity by email."@en ;
 	sh:property
-		observable:ContactEmail-contactEmailScope-in-shape ,
+		uco-observable:ContactEmail-contactEmailScope-in-shape ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:emailAddress ;
+			sh:path uco-observable:emailAddress ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactEmailScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:contactEmailScope ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:contactEmailScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:contactEmailScope ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactEmailScope ;
+			sh:path uco-observable:contactEmailScope ;
 		]
 		;
-	sh:targetClass observable:ContactEmail ;
+	sh:targetClass uco-observable:ContactEmail ;
 	.
 
-observable:ContactEmail-contactEmailScope-in-shape
+uco-observable:ContactEmail-contactEmailScope-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"home"
@@ -1558,253 +1558,253 @@ observable:ContactEmail-contactEmailScope-in-shape
 		"cloud"
 	) ;
 	sh:message "Value is not member of the vocabulary ContactEmailScopeVocab." ;
-	sh:path observable:contactEmailScope ;
+	sh:path uco-observable:contactEmailScope ;
 	sh:severity sh:Info ;
 	.
 
-observable:ContactFacet
+uco-observable:ContactFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ContactFacet"@en ;
 	rdfs:comment "A contact facet is a grouping of characteristics unique to a set of identification and communication related details for a single entity."@en ;
 	sh:property
 		[
-			sh:class observable:ContactAddress ;
+			sh:class uco-observable:ContactAddress ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactAddress ;
+			sh:path uco-observable:contactAddress ;
 		] ,
 		[
-			sh:class observable:ContactAffiliation ;
+			sh:class uco-observable:ContactAffiliation ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactAffiliation ;
+			sh:path uco-observable:contactAffiliation ;
 		] ,
 		[
-			sh:class observable:ContactEmail ;
+			sh:class uco-observable:ContactEmail ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactEmail ;
+			sh:path uco-observable:contactEmail ;
 		] ,
 		[
-			sh:class observable:ContactMessaging ;
+			sh:class uco-observable:ContactMessaging ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactMessaging ;
+			sh:path uco-observable:contactMessaging ;
 		] ,
 		[
-			sh:class observable:ContactPhone ;
+			sh:class uco-observable:ContactPhone ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactPhone ;
+			sh:path uco-observable:contactPhone ;
 		] ,
 		[
-			sh:class observable:ContactProfile ;
+			sh:class uco-observable:ContactProfile ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactProfile ;
+			sh:path uco-observable:contactProfile ;
 		] ,
 		[
-			sh:class observable:ContactSIP ;
+			sh:class uco-observable:ContactSIP ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactSIP ;
+			sh:path uco-observable:contactSIP ;
 		] ,
 		[
-			sh:class observable:ContactURL ;
+			sh:class uco-observable:ContactURL ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactURL ;
+			sh:path uco-observable:contactURL ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:sourceApplication ;
+			sh:path uco-observable:sourceApplication ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path identity:birthdate ;
+			sh:path uco-identity:birthdate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:lastTimeContacted ;
+			sh:path uco-observable:lastTimeContacted ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:numberTimesContacted ;
+			sh:path uco-observable:numberTimesContacted ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactID ;
+			sh:path uco-observable:contactID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:displayName ;
+			sh:path uco-observable:displayName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:firstName ;
+			sh:path uco-observable:firstName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:lastName ;
+			sh:path uco-observable:lastName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:middleName ;
+			sh:path uco-observable:middleName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:namePhonetic ;
+			sh:path uco-observable:namePhonetic ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:namePrefix ;
+			sh:path uco-observable:namePrefix ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:nameSuffix ;
+			sh:path uco-observable:nameSuffix ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactGroup ;
+			sh:path uco-observable:contactGroup ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactNote ;
+			sh:path uco-observable:contactNote ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:nickname ;
+			sh:path uco-observable:nickname ;
 		]
 		;
-	sh:targetClass observable:ContactFacet ;
+	sh:targetClass uco-observable:ContactFacet ;
 	.
 
-observable:ContactList
+uco-observable:ContactList
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "ContactList"@en ;
 	rdfs:comment "A contact list is a set of multiple individual contacts such as that found in a digital address book."@en ;
-	sh:targetClass observable:ContactList ;
+	sh:targetClass uco-observable:ContactList ;
 	.
 
-observable:ContactListFacet
+uco-observable:ContactListFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ContactListFacet"@en ;
 	rdfs:comment "A contact list facet is a grouping of characteristics unique to a set of multiple individual contacts such as that found in a digital address book."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:sourceApplication ;
+			sh:path uco-observable:sourceApplication ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contact ;
+			sh:path uco-observable:contact ;
 		]
 		;
-	sh:targetClass observable:ContactListFacet ;
+	sh:targetClass uco-observable:ContactListFacet ;
 	.
 
-observable:ContactMessaging
+uco-observable:ContactMessaging
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactMessaging"@en ;
 	rdfs:comment "A contact messaging is a grouping of characteristics unique to details for contacting a contact entity by digital messaging."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactMessagingPlatform ;
+			sh:path uco-observable:contactMessagingPlatform ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:messagingAddress ;
+			sh:path uco-observable:messagingAddress ;
 		]
 		;
-	sh:targetClass observable:ContactMessaging ;
+	sh:targetClass uco-observable:ContactMessaging ;
 	.
 
-observable:ContactPhone
+uco-observable:ContactPhone
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactPhone"@en ;
 	rdfs:comment "A contact phone is a grouping of characteristics unique to details for contacting a contact entity by telephone."@en ;
 	sh:property
-		observable:ContactPhone-contactPhoneScope-in-shape ,
+		uco-observable:ContactPhone-contactPhoneScope-in-shape ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactPhoneNumber ;
+			sh:path uco-observable:contactPhoneNumber ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactPhoneScope in UCO 2.0.0." ;
-			sh:path observable:contactPhoneScope ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:contactPhoneScope in UCO 2.0.0." ;
+			sh:path uco-observable:contactPhoneScope ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactPhoneScope ;
+			sh:path uco-observable:contactPhoneScope ;
 		]
 		;
-	sh:targetClass observable:ContactPhone ;
+	sh:targetClass uco-observable:ContactPhone ;
 	.
 
-observable:ContactPhone-contactPhoneScope-in-shape
+uco-observable:ContactPhone-contactPhoneScope-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"home"
@@ -1817,67 +1817,67 @@ observable:ContactPhone-contactPhoneScope-in-shape
 		"pager"
 	) ;
 	sh:message "Value is not member of the vocabulary ContactPhoneScopeVocab." ;
-	sh:path observable:contactPhoneScope ;
+	sh:path uco-observable:contactPhoneScope ;
 	sh:severity sh:Info ;
 	.
 
-observable:ContactProfile
+uco-observable:ContactProfile
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactProfile"@en ;
 	rdfs:comment "A contact profile is a grouping of characteristics unique to details for contacting a contact entity by online service."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactProfilePlatform ;
+			sh:path uco-observable:contactProfilePlatform ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profile ;
+			sh:path uco-observable:profile ;
 		]
 		;
-	sh:targetClass observable:ContactProfile ;
+	sh:targetClass uco-observable:ContactProfile ;
 	.
 
-observable:ContactSIP
+uco-observable:ContactSIP
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactSIP"@en ;
 	rdfs:comment "A contact SIP is a grouping of characteristics unique to details for contacting a contact entity by Session Initiation Protocol (SIP)."@en ;
 	sh:property
-		observable:ContactSIP-contactSIPScope-in-shape ,
+		uco-observable:ContactSIP-contactSIPScope-in-shape ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:sipAddress ;
+			sh:path uco-observable:sipAddress ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactSIPScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:contactSIPScope ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:contactSIPScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:contactSIPScope ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactSIPScope ;
+			sh:path uco-observable:contactSIPScope ;
 		]
 		;
-	sh:targetClass observable:ContactSIP ;
+	sh:targetClass uco-observable:ContactSIP ;
 	.
 
-observable:ContactSIP-contactSIPScope-in-shape
+uco-observable:ContactSIP-contactSIPScope-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"home"
@@ -1885,42 +1885,42 @@ observable:ContactSIP-contactSIPScope-in-shape
 		"school"
 	) ;
 	sh:message "Value is not member of the vocabulary ContactSIPScopeVocab." ;
-	sh:path observable:contactSIPScope ;
+	sh:path uco-observable:contactSIPScope ;
 	sh:severity sh:Info ;
 	.
 
-observable:ContactURL
+uco-observable:ContactURL
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ContactURL"@en ;
 	rdfs:comment "A contact URL is a grouping of characteristics unique to details for contacting a contact entity by Uniform Resource Locator (URL)."@en ;
 	sh:property
-		observable:ContactURL-contactURLScope-in-shape ,
+		uco-observable:ContactURL-contactURLScope-in-shape ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:url ;
+			sh:path uco-observable:url ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contactURLScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:contactURLScope ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:contactURLScope should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:contactURLScope ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contactURLScope ;
+			sh:path uco-observable:contactURLScope ;
 		]
 		;
-	sh:targetClass observable:ContactURL ;
+	sh:targetClass uco-observable:ContactURL ;
 	.
 
-observable:ContactURL-contactURLScope-in-shape
+uco-observable:ContactURL-contactURLScope-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"home"
@@ -1929,99 +1929,99 @@ observable:ContactURL-contactURLScope-in-shape
 		"homepage"
 	) ;
 	sh:message "Value is not member of the vocabulary ContactURLScopeVocab." ;
-	sh:path observable:contactURLScope ;
+	sh:path uco-observable:contactURLScope ;
 	sh:severity sh:Info ;
 	.
 
-observable:ContentData
+uco-observable:ContentData
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "ContentData"@en ;
 	rdfs:comment "Content data is a block of digital data."@en ;
-	sh:targetClass observable:ContentData ;
+	sh:targetClass uco-observable:ContentData ;
 	.
 
-observable:ContentDataFacet
+uco-observable:ContentDataFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ContentDataFacet"@en ;
 	rdfs:comment "A content data facet is a grouping of characteristics unique to a block of digital data."@en ;
 	sh:property
-		observable:ContentDataFacet-byteOrder-in-shape ,
+		uco-observable:ContentDataFacet-byteOrder-in-shape ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:dataPayloadReferenceURL ;
+			sh:path uco-observable:dataPayloadReferenceURL ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:hash ;
+			sh:path uco-observable:hash ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isEncrypted ;
+			sh:path uco-observable:isEncrypted ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:entropy ;
+			sh:path uco-observable:entropy ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeInBytes ;
+			sh:path uco-observable:sizeInBytes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dataPayload ;
+			sh:path uco-observable:dataPayload ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:magicNumber ;
+			sh:path uco-observable:magicNumber ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mimeClass ;
+			sh:path uco-observable:mimeClass ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:byteOrder should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:byteOrder ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:byteOrder should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:byteOrder ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mimeType ;
+			sh:path uco-observable:mimeType ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:byteOrder ;
+			sh:path uco-observable:byteOrder ;
 		]
 		;
-	sh:targetClass observable:ContentDataFacet ;
+	sh:targetClass uco-observable:ContentDataFacet ;
 	.
 
-observable:ContentDataFacet-byteOrder-in-shape
+uco-observable:ContentDataFacet-byteOrder-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"Big-endian"
@@ -2029,71 +2029,71 @@ observable:ContentDataFacet-byteOrder-in-shape
 		"Middle-endian"
 	) ;
 	sh:message "Value is not member of the vocabulary EndiannessTypeVocab." ;
-	sh:path observable:byteOrder ;
+	sh:path uco-observable:byteOrder ;
 	sh:severity sh:Info ;
 	.
 
-observable:CookieHistory
+uco-observable:CookieHistory
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "CookieHistory"@en ;
 	rdfs:comment "A cookie history is the stored web cookie history for a particular web browser."@en ;
-	sh:targetClass observable:CookieHistory ;
+	sh:targetClass uco-observable:CookieHistory ;
 	.
 
-observable:Credential
+uco-observable:Credential
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Credential"@en ;
 	rdfs:comment "A credential is a single specific login and password combination for authorization of access to a digital account or system."@en ;
-	sh:targetClass observable:Credential ;
+	sh:targetClass uco-observable:Credential ;
 	.
 
-observable:CredentialDump
+uco-observable:CredentialDump
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "CredentialDump"@en ;
 	rdfs:comment "A credential dump is a collection (typically forcibly extracted from a system) of specific login and password combinations for authorization of access to a digital account or system."@en ;
-	sh:targetClass observable:CredentialDump ;
+	sh:targetClass uco-observable:CredentialDump ;
 	.
 
-observable:DNSCache
+uco-observable:DNSCache
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "DNSCache"@en ;
 	rdfs:comment "An DNS cache is a temporary locally stored collection of previous Domain Name System (DNS) query results (created when an domain name is resolved to a IP address) for a particular computer."@en ;
-	sh:targetClass observable:DNSCache ;
+	sh:targetClass uco-observable:DNSCache ;
 	.
 
-observable:DNSRecord
+uco-observable:DNSRecord
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "DNSRecord"@en ;
 	rdfs:comment "A DNS record is a single Domain Name System (DNS) artifact specifying information of a particular type (routing, authority, responsibility, security, etc.) for a specific Internet domain name."@en ;
-	sh:targetClass observable:DNSRecord ;
+	sh:targetClass uco-observable:DNSRecord ;
 	.
 
-observable:DataRangeFacet
+uco-observable:DataRangeFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DataRangeFacet"@en ;
 	rdfs:comment "A data range facet is a grouping of characteristics unique to a particular contiguous scope within a block of digital data."@en ;
 	sh:property
@@ -2101,106 +2101,106 @@ observable:DataRangeFacet
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:rangeOffset ;
+			sh:path uco-observable:rangeOffset ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:rangeSize ;
+			sh:path uco-observable:rangeSize ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:rangeOffsetType ;
+			sh:path uco-observable:rangeOffsetType ;
 		]
 		;
-	sh:targetClass observable:DataRangeFacet ;
+	sh:targetClass uco-observable:DataRangeFacet ;
 	.
 
-observable:DefinedEffectFacet
+uco-observable:DefinedEffectFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DefinedEffectFacet"@en ;
 	rdfs:comment "A defined effect facet is a grouping of characteristics unique to the effect of an observable action in relation to one or more observable objects."@en ;
-	sh:targetClass observable:DefinedEffectFacet ;
+	sh:targetClass uco-observable:DefinedEffectFacet ;
 	.
 
-observable:Device
+uco-observable:Device
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Device"@en ;
 	rdfs:comment "A device is a piece of equipment or a mechanism designed to serve a special purpose or perform a special function. [based on https://www.merriam-webster.com/dictionary/device]"@en ;
-	sh:targetClass observable:Device ;
+	sh:targetClass uco-observable:Device ;
 	.
 
-observable:DeviceFacet
+uco-observable:DeviceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DeviceFacet"@en ;
 	rdfs:comment "A device facet is a grouping of characteristics unique to a piece of equipment or a mechanism designed to serve a special purpose or perform a special function. [based on https://www.merriam-webster.com/dictionary/device]"@en ;
 	sh:property
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:manufacturer ;
+			sh:path uco-observable:manufacturer ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cpeid ;
+			sh:path uco-observable:cpeid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:deviceType ;
+			sh:path uco-observable:deviceType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:model ;
+			sh:path uco-observable:model ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:serialNumber ;
+			sh:path uco-observable:serialNumber ;
 		]
 		;
-	sh:targetClass observable:DeviceFacet ;
+	sh:targetClass uco-observable:DeviceFacet ;
 	.
 
-observable:DigitalAccount
+uco-observable:DigitalAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Account ;
+	rdfs:subClassOf uco-observable:Account ;
 	rdfs:label "DigitalAccount"@en ;
 	rdfs:comment "A digital account is an arrangement with an entity to enable and control the provision of some capability or service within the digital domain."@en ;
-	sh:targetClass observable:DigitalAccount ;
+	sh:targetClass uco-observable:DigitalAccount ;
 	.
 
-observable:DigitalAccountFacet
+uco-observable:DigitalAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DigitalAccountFacet"@en ;
 	rdfs:comment "A digital account facet is a grouping of characteristics unique to an arrangement with an entity to enable and control the provision of some capability or service within the digital domain."@en ;
 	sh:property
@@ -2208,52 +2208,52 @@ observable:DigitalAccountFacet
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isDisabled ;
+			sh:path uco-observable:isDisabled ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:firstLoginTime ;
+			sh:path uco-observable:firstLoginTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:lastLoginTime ;
+			sh:path uco-observable:lastLoginTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:displayName ;
+			sh:path uco-observable:displayName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accountLogin ;
+			sh:path uco-observable:accountLogin ;
 		]
 		;
-	sh:targetClass observable:DigitalAccountFacet ;
+	sh:targetClass uco-observable:DigitalAccountFacet ;
 	.
 
-observable:DigitalAddress
+uco-observable:DigitalAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Address ;
+	rdfs:subClassOf uco-observable:Address ;
 	rdfs:label "DigitalAddress"@en ;
 	rdfs:comment "A digital address is an identifier assigned to enable routing and management of digital communication."@en ;
-	sh:targetClass observable:DigitalAddress ;
+	sh:targetClass uco-observable:DigitalAddress ;
 	.
 
-observable:DigitalAddressFacet
+uco-observable:DigitalAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DigitalAddressFacet"@en ;
 	rdfs:comment "A digital address facet is a grouping of characteristics unique to an identifier assigned to enable routing and management of digital communication."@en ;
 	sh:property
@@ -2261,166 +2261,166 @@ observable:DigitalAddressFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:addressValue ;
+			sh:path uco-observable:addressValue ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:displayName ;
+			sh:path uco-observable:displayName ;
 		]
 		;
-	sh:targetClass observable:DigitalAddressFacet ;
+	sh:targetClass uco-observable:DigitalAddressFacet ;
 	.
 
-observable:DigitalCamera
+uco-observable:DigitalCamera
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "DigitalCamera"@en-US ;
 	rdfs:comment "A digital camera is a camera that captures photographs in digital memory as opposed to capturing images on photographic film."@en-US ;
-	sh:targetClass observable:DigitalCamera ;
+	sh:targetClass uco-observable:DigitalCamera ;
 	.
 
-observable:DigitalSignatureInfo
+uco-observable:DigitalSignatureInfo
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "DigitalSignatureInfo"@en ;
 	rdfs:comment "A digital signature info is a value calculated via a mathematical scheme for demonstrating the authenticity of an electronic message or document."@en ;
-	sh:targetClass observable:DigitalSignatureInfo ;
+	sh:targetClass uco-observable:DigitalSignatureInfo ;
 	.
 
-observable:DigitalSignatureInfoFacet
+uco-observable:DigitalSignatureInfoFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DigitalSignatureInfoFacet"@en ;
 	rdfs:comment "A digital signature info facet is a grouping of characteristics unique to a value calculated via a mathematical scheme for demonstrating the authenticity of an electronic message or document."@en ;
 	sh:property
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:certificateSubject ;
+			sh:path uco-observable:certificateSubject ;
 		] ,
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:certificateIssuer ;
+			sh:path uco-observable:certificateIssuer ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:signatureExists ;
+			sh:path uco-observable:signatureExists ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:signatureVerified ;
+			sh:path uco-observable:signatureVerified ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:signatureDescription ;
+			sh:path uco-observable:signatureDescription ;
 		]
 		;
-	sh:targetClass observable:DigitalSignatureInfoFacet ;
+	sh:targetClass uco-observable:DigitalSignatureInfoFacet ;
 	.
 
-observable:Directory
+uco-observable:Directory
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "Directory"@en ;
 	rdfs:comment "A directory is a file system cataloging structure which contains references to other computer files, and possibly other directories. On many computers, directories are known as folders, or drawers, analogous to a workbench or the traditional office filing cabinet. In UNIX a directory is implemented as a special file. [based on https://en.wikipedia.org/wiki/Directory_(computing)]"@en ;
-	sh:targetClass observable:Directory ;
+	sh:targetClass uco-observable:Directory ;
 	.
 
-observable:Disk
+uco-observable:Disk
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Disk"@en ;
 	rdfs:comment "A disk is a storage mechanism where data is recorded by various electronic, magnetic, optical, or mechanical changes to a surface layer of one or more rotating disks."@en ;
 	rdfs:seeAlso [
 		a sh:NodeShape ;
 		rdfs:comment "This anonymous shape is attached with rdfs:seeAlso in order to associate a warning-severity class constraint, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
-		sh:class observable:StorageMedium ;
+		sh:class uco-observable:StorageMedium ;
 		sh:message "In UCO 2.0.0, uco-observable:Disk will be a subclass of uco-observable:StorageMedium.  In preparation for UCO 2.0.0, the additional type uco-observable:StorageMedium should be assigned to this node."@en ;
 		sh:severity sh:Warning ;
-		sh:targetClass observable:Disk ;
+		sh:targetClass uco-observable:Disk ;
 	] ;
-	sh:targetClass observable:Disk ;
+	sh:targetClass uco-observable:Disk ;
 	.
 
-observable:DiskFacet
+uco-observable:DiskFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DiskFacet"@en ;
 	rdfs:comment "A disk facet is a grouping of characteristics unique to a storage mechanism where data is recorded by various electronic, magnetic, optical, or mechanical changes to a surface layer of one or more rotating disks."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:partition ;
+			sh:path uco-observable:partition ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:diskSize ;
+			sh:path uco-observable:diskSize ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:freeSpace ;
+			sh:path uco-observable:freeSpace ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:diskType ;
+			sh:path uco-observable:diskType ;
 		]
 		;
-	sh:targetClass observable:DiskFacet ;
+	sh:targetClass uco-observable:DiskFacet ;
 	.
 
-observable:DiskPartition
+uco-observable:DiskPartition
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "DiskPartition"@en ;
 	rdfs:comment "A disk partition is a particular managed region on a storage mechanism where data is recorded by various electronic, magnetic, optical, or mechanical changes to a surface layer of one or more rotating disks. [based on https://en.wikipedia.org/wiki/Disk_storage]"@en ;
-	sh:targetClass observable:DiskPartition ;
+	sh:targetClass uco-observable:DiskPartition ;
 	.
 
-observable:DiskPartitionFacet
+uco-observable:DiskPartitionFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DiskPartitionFacet"@en ;
 	rdfs:comment "A disk partition facet is a grouping of characteristics unique to a particular managed region on a storage mechanism."@en ;
 	sh:property
@@ -2428,77 +2428,77 @@ observable:DiskPartitionFacet
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:partitionLength ;
+			sh:path uco-observable:partitionLength ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:partitionOffset ;
+			sh:path uco-observable:partitionOffset ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:spaceLeft ;
+			sh:path uco-observable:spaceLeft ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:spaceUsed ;
+			sh:path uco-observable:spaceUsed ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:totalSpace ;
+			sh:path uco-observable:totalSpace ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:diskPartitionType ;
+			sh:path uco-observable:diskPartitionType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mountPoint ;
+			sh:path uco-observable:mountPoint ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:partitionID ;
+			sh:path uco-observable:partitionID ;
 		]
 		;
-	sh:targetClass observable:DiskPartitionFacet ;
+	sh:targetClass uco-observable:DiskPartitionFacet ;
 	.
 
-observable:DomainName
+uco-observable:DomainName
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "DomainName"@en ;
 	rdfs:comment "A domain name is an identification string that defines a realm of administrative autonomy, authority or control within the Internet. [based on https://en.wikipedia.org/wiki/Domain_name]"@en ;
-	sh:targetClass observable:DomainName ;
+	sh:targetClass uco-observable:DomainName ;
 	.
 
-observable:DomainNameFacet
+uco-observable:DomainNameFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "DomainNameFacet"@en ;
 	rdfs:comment "A domain name facet is a grouping of characteristics unique to an identification string that defines a realm of administrative autonomy, authority or control within the Internet. [based on https://en.wikipedia.org/wiki/Domain_name]"@en ;
 	sh:property
@@ -2506,326 +2506,326 @@ observable:DomainNameFacet
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isTLD ;
+			sh:path uco-observable:isTLD ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:value ;
+			sh:path uco-observable:value ;
 		]
 		;
-	sh:targetClass observable:DomainNameFacet ;
+	sh:targetClass uco-observable:DomainNameFacet ;
 	.
 
-observable:Drone
+uco-observable:Drone
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:MobileDevice ;
+	rdfs:subClassOf uco-observable:MobileDevice ;
 	rdfs:label "Drone"@en-US ;
 	rdfs:comment "A drone, unmanned aerial vehicle (UAV), is an aircraft without a human pilot, crew, or passengers that typically involve a ground-based controller and a system for communications with the UAV."@en-US ;
-	sh:targetClass observable:Drone ;
+	sh:targetClass uco-observable:Drone ;
 	.
 
-observable:ESN
+uco-observable:ESN
 	a owl:DatatypeProperty ;
 	rdfs:label "ESN"@en ;
 	rdfs:comment "Electronic Serial Number ."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:EXIFFacet
+uco-observable:EXIFFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "EXIFFacet"@en ;
 	rdfs:comment "An EXIF (exchangeable image file format) facet is a grouping of characteristics unique to the formats for images, sound, and ancillary tags used by digital cameras (including smartphones), scanners and other systems handling image and sound files recorded by digital cameras conformant to JEIDA/JEITA/CIPA specifications. [based on https://en.wikipedia.org/wiki/Exif]"@en ;
 	sh:property [
-		sh:class types:ControlledDictionary ;
+		sh:class uco-types:ControlledDictionary ;
 		sh:nodeKind sh:IRI ;
-		sh:path observable:exifData ;
+		sh:path uco-observable:exifData ;
 	] ;
-	sh:targetClass observable:EXIFFacet ;
+	sh:targetClass uco-observable:EXIFFacet ;
 	.
 
-observable:EmailAccount
+uco-observable:EmailAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "EmailAccount"@en ;
 	rdfs:comment "An email account is an arrangement with an entity to enable and control the provision of electronic mail (email) capabilities or services."@en ;
-	sh:targetClass observable:EmailAccount ;
+	sh:targetClass uco-observable:EmailAccount ;
 	.
 
-observable:EmailAccountFacet
+uco-observable:EmailAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "EmailAccountFacet"@en ;
 	rdfs:comment "An email account facet is a grouping of characteristics unique to an arrangement with an entity to enable and control the provision of electronic mail (email) capabilities or services."@en ;
 	sh:property [
-		sh:class observable:ObservableObject ;
+		sh:class uco-observable:ObservableObject ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path observable:emailAddress ;
+		sh:path uco-observable:emailAddress ;
 	] ;
-	sh:targetClass observable:EmailAccountFacet ;
+	sh:targetClass uco-observable:EmailAccountFacet ;
 	.
 
-observable:EmailAddress
+uco-observable:EmailAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddress ;
+	rdfs:subClassOf uco-observable:DigitalAddress ;
 	rdfs:label "EmailAddress"@en ;
 	rdfs:comment "An email address is an identifier for an electronic mailbox to which electronic mail messages (conformant to the Simple Mail Transfer Protocol (SMTP)) are sent from and delivered to."@en ;
-	sh:targetClass observable:EmailAddress ;
+	sh:targetClass uco-observable:EmailAddress ;
 	.
 
-observable:EmailAddressFacet
+uco-observable:EmailAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddressFacet ;
+	rdfs:subClassOf uco-observable:DigitalAddressFacet ;
 	rdfs:label "EmailAddressFacet"@en ;
 	rdfs:comment "An email address facet is a grouping of characteristics unique to an identifier for an electronic mailbox to which electronic mail messages (conformant to the Simple Mail Transfer Protocol (SMTP)) are sent from and delivered to."@en ;
-	sh:targetClass observable:EmailAddressFacet ;
+	sh:targetClass uco-observable:EmailAddressFacet ;
 	.
 
-observable:EmailMessage
+uco-observable:EmailMessage
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Message ;
+	rdfs:subClassOf uco-observable:Message ;
 	rdfs:label "EmailMessage"@en ;
 	rdfs:comment "An email message is a message that is an instance of an electronic mail correspondence conformant to the internet message format described in RFC 5322 and related RFCs."@en ;
-	sh:targetClass observable:EmailMessage ;
+	sh:targetClass uco-observable:EmailMessage ;
 	.
 
-observable:EmailMessageFacet
+uco-observable:EmailMessageFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "EmailMessageFacet"@en ;
 	rdfs:comment "An email message facet is a grouping of characteristics unique to a message that is an instance of an electronic mail correspondence conformant to the internet message format described in RFC 5322 and related RFCs."@en ;
 	sh:property
 		[
-			sh:class observable:MimePartType ;
+			sh:class uco-observable:MimePartType ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:bodyMultipart ;
+			sh:path uco-observable:bodyMultipart ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:bodyRaw ;
+			sh:path uco-observable:bodyRaw ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:from ;
+			sh:path uco-observable:from ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:headerRaw ;
+			sh:path uco-observable:headerRaw ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:sender ;
+			sh:path uco-observable:sender ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:xOriginatingIP ;
+			sh:path uco-observable:xOriginatingIP ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:bcc ;
+			sh:path uco-observable:bcc ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:cc ;
+			sh:path uco-observable:cc ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:references ;
+			sh:path uco-observable:references ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:to ;
+			sh:path uco-observable:to ;
 		] ,
 		[
-			sh:class types:Dictionary ;
+			sh:class uco-types:Dictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:otherHeaders ;
+			sh:path uco-observable:otherHeaders ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isMimeEncoded ;
+			sh:path uco-observable:isMimeEncoded ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isMultipart ;
+			sh:path uco-observable:isMultipart ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isRead ;
+			sh:path uco-observable:isRead ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:modifiedTime ;
+			sh:path uco-observable:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:receivedTime ;
+			sh:path uco-observable:receivedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sentTime ;
+			sh:path uco-observable:sentTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:body ;
+			sh:path uco-observable:body ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contentDisposition ;
+			sh:path uco-observable:contentDisposition ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contentType ;
+			sh:path uco-observable:contentType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:inReplyTo ;
+			sh:path uco-observable:inReplyTo ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:messageID ;
+			sh:path uco-observable:messageID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:priority ;
+			sh:path uco-observable:priority ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subject ;
+			sh:path uco-observable:subject ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:xMailer ;
+			sh:path uco-observable:xMailer ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:categories ;
+			sh:path uco-observable:categories ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:labels ;
+			sh:path uco-observable:labels ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:receivedLines ;
+			sh:path uco-observable:receivedLines ;
 		]
 		;
-	sh:targetClass observable:EmailMessageFacet ;
+	sh:targetClass uco-observable:EmailMessageFacet ;
 	.
 
-observable:EmbeddedDevice
+uco-observable:EmbeddedDevice
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "EmbeddedDevice"@en-US ;
 	rdfs:comment "An embedded device is a highly specialized microprocessor device meant for one or very few specific purposes and is usually embedded or included within another object or as part of a larger system. Examples include answer machine, door access logger, card scanner, etc."@en-US ;
-	sh:targetClass observable:EmbeddedDevice ;
+	sh:targetClass uco-observable:EmbeddedDevice ;
 	.
 
-observable:EncodedStreamFacet
+uco-observable:EncodedStreamFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "EncodedStreamFacet"@en ;
 	rdfs:comment "An encoded stream facet is a grouping of characteristics unique to the conversion of a body of data content from one form to another form."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:encodingMethod ;
+		sh:path uco-observable:encodingMethod ;
 	] ;
-	sh:targetClass observable:EncodedStreamFacet ;
+	sh:targetClass uco-observable:EncodedStreamFacet ;
 	.
 
-observable:EncryptedStreamFacet
+uco-observable:EncryptedStreamFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "EncryptedStreamFacet"@en ;
 	rdfs:comment "An encrypted stream facet is a grouping of characteristics unique to the conversion of a body of data content from one form to another obfuscated form in such a way that reversing the conversion to obtain the original data form can only be accomplished through possession and use of a specific key."@en ;
 	sh:property
@@ -2833,34 +2833,34 @@ observable:EncryptedStreamFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:encryptionMethod ;
+			sh:path uco-observable:encryptionMethod ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:encryptionMode ;
+			sh:path uco-observable:encryptionMode ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:encryptionIV ;
+			sh:path uco-observable:encryptionIV ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:encryptionKey ;
+			sh:path uco-observable:encryptionKey ;
 		]
 		;
-	sh:targetClass observable:EncryptedStreamFacet ;
+	sh:targetClass uco-observable:EncryptedStreamFacet ;
 	.
 
-observable:EnvironmentVariable
+uco-observable:EnvironmentVariable
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "EnvironmentVariable"@en ;
 	rdfs:comment "An environment variable is a grouping of characteristics unique to a dynamic-named value that can affect the way running processes will behave on a computer. [based on https://en.wikipedia.org/wiki/Environment_variable]"@en ;
 	sh:property
@@ -2868,137 +2868,137 @@ observable:EnvironmentVariable
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:name ;
+			sh:path uco-core:name ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:value ;
+			sh:path uco-observable:value ;
 		]
 		;
-	sh:targetClass observable:EnvironmentVariable ;
+	sh:targetClass uco-observable:EnvironmentVariable ;
 	.
 
-observable:EventLog
+uco-observable:EventLog
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "EventLog"@en ;
 	rdfs:comment "An event log is a collection of event records."@en ;
-	sh:targetClass observable:EventLog ;
+	sh:targetClass uco-observable:EventLog ;
 	.
 
-observable:EventRecord
+uco-observable:EventRecord
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "EventRecord"@en ;
 	rdfs:comment "An event record is something that happens in a digital context (e.g., operating system events)."@en ;
-	sh:targetClass observable:EventRecord ;
+	sh:targetClass uco-observable:EventRecord ;
 	.
 
-observable:EventRecordFacet
+uco-observable:EventRecordFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "EventRecordFacet"@en ;
 	rdfs:comment "An event record facet is a grouping of characteristics unique to something that happens in a digital context (e.g., operating system events)."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableAction ;
+			sh:class uco-observable:ObservableAction ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:cyberAction ;
+			sh:path uco-observable:cyberAction ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:account ;
+			sh:path uco-observable:account ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:eventRecordDevice ;
+			sh:path uco-observable:eventRecordDevice ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:endTime ;
+			sh:path uco-observable:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startTime ;
+			sh:path uco-observable:startTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventID ;
+			sh:path uco-observable:eventID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventRecordID ;
+			sh:path uco-observable:eventRecordID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventRecordRaw ;
+			sh:path uco-observable:eventRecordRaw ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventRecordServiceName ;
+			sh:path uco-observable:eventRecordServiceName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventRecordText ;
+			sh:path uco-observable:eventRecordText ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:eventType ;
+			sh:path uco-observable:eventType ;
 		]
 		;
-	sh:targetClass observable:EventRecordFacet ;
+	sh:targetClass uco-observable:EventRecordFacet ;
 	.
 
-observable:ExtInodeFacet
+uco-observable:ExtInodeFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ExtInodeFacet"@en ;
 	rdfs:comment "An extInode facet is a grouping of characteristics unique to a file system object (file, directory, etc.) conformant to the extended file system (EXT or related derivations) specification."@en ;
 	sh:property
@@ -3006,66 +3006,66 @@ observable:ExtInodeFacet
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extDeletionTime ;
+			sh:path uco-observable:extDeletionTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extInodeChangeTime ;
+			sh:path uco-observable:extInodeChangeTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extFileType ;
+			sh:path uco-observable:extFileType ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extFlags ;
+			sh:path uco-observable:extFlags ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extHardLinkCount ;
+			sh:path uco-observable:extHardLinkCount ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extInodeID ;
+			sh:path uco-observable:extInodeID ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extPermissions ;
+			sh:path uco-observable:extPermissions ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extSGID ;
+			sh:path uco-observable:extSGID ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extSUID ;
+			sh:path uco-observable:extSUID ;
 		]
 		;
-	sh:targetClass observable:ExtInodeFacet ;
+	sh:targetClass uco-observable:ExtInodeFacet ;
 	.
 
-observable:ExtractedString
+uco-observable:ExtractedString
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "ExtractedString"@en ;
 	rdfs:comment "An extracted string is a grouping of characteristics unique to a series of characters pulled from an observable object."@en ;
 	sh:property
@@ -3073,186 +3073,186 @@ observable:ExtractedString
 			sh:datatype xsd:base64Binary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:byteStringValue ;
+			sh:path uco-observable:byteStringValue ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:length ;
+			sh:path uco-observable:length ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:encoding ;
+			sh:path uco-observable:encoding ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:englishTranslation ;
+			sh:path uco-observable:englishTranslation ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:language ;
+			sh:path uco-observable:language ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:stringValue ;
+			sh:path uco-observable:stringValue ;
 		]
 		;
-	sh:targetClass observable:ExtractedString ;
+	sh:targetClass uco-observable:ExtractedString ;
 	.
 
-observable:ExtractedStringsFacet
+uco-observable:ExtractedStringsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ExtractedStringsFacet"@en ;
 	rdfs:comment "An extracted strings facet is a grouping of characteristics unique to one or more sequences of characters pulled from an observable object."@en ;
 	sh:property [
-		sh:class observable:ExtractedString ;
+		sh:class uco-observable:ExtractedString ;
 		sh:nodeKind sh:IRI ;
-		sh:path observable:strings ;
+		sh:path uco-observable:strings ;
 	] ;
-	sh:targetClass observable:ExtractedStringsFacet ;
+	sh:targetClass uco-observable:ExtractedStringsFacet ;
 	.
 
-observable:File
+uco-observable:File
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "File"@en ;
 	rdfs:comment "A file is a computer resource for recording data discretely on a computer storage device."@en ;
-	owl:disjointWith observable:URL ;
-	sh:targetClass observable:File ;
+	owl:disjointWith uco-observable:URL ;
+	sh:targetClass uco-observable:File ;
 	.
 
-observable:File-disjointWith-URL-shape
+uco-observable:File-disjointWith-URL-shape
 	a sh:NodeShape ;
-	sh:message "observable:File and observable:URL are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
+	sh:message "uco-observable:File and uco-observable:URL are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
 	sh:not [
 		a sh:NodeShape ;
-		sh:class observable:URL ;
+		sh:class uco-observable:URL ;
 	] ;
 	sh:severity sh:Warning ;
-	sh:targetClass observable:File ;
+	sh:targetClass uco-observable:File ;
 	.
 
-observable:FileFacet
+uco-observable:FileFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "FileFacet"@en ;
 	rdfs:comment "A file facet is a grouping of characteristics unique to the storage of a file (computer resource for recording data discretely in a computer storage device) on a file system (process that manages how and where data on a storage device is stored, accessed and managed). [based on https://en.wikipedia.org/Computer_file and https://www.techopedia.com/definition/5510/file-system]"@en ;
 	sh:property
 		[
 			sh:datatype xsd:boolean ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isDirectory ;
+			sh:path uco-observable:isDirectory ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accessedTime ;
+			sh:path uco-observable:accessedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:metadataChangeTime ;
+			sh:path uco-observable:metadataChangeTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:modifiedTime ;
+			sh:path uco-observable:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:description "When used to characterize a file the sizeInBytes property conveys the recorded size of a file in a file system."@en ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeInBytes ;
+			sh:path uco-observable:sizeInBytes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:allocationStatus ;
+			sh:path uco-observable:allocationStatus ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extension ;
+			sh:path uco-observable:extension ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:fileName ;
+			sh:path uco-observable:fileName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:filePath ;
+			sh:path uco-observable:filePath ;
 		]
 		;
-	sh:targetClass observable:FileFacet ;
+	sh:targetClass uco-observable:FileFacet ;
 	.
 
-observable:FilePermissionsFacet
+uco-observable:FilePermissionsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "FilePermissionsFacet"@en ;
 	rdfs:comment "A file permissions facet is a grouping of characteristics unique to the access rights (e.g., view, change, navigate, execute) of a file on a file system."@en ;
 	sh:property [
-		sh:class core:UcoObject ;
+		sh:class uco-core:UcoObject ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path observable:owner ;
+		sh:path uco-observable:owner ;
 	] ;
-	sh:targetClass observable:FilePermissionsFacet ;
+	sh:targetClass uco-observable:FilePermissionsFacet ;
 	.
 
-observable:FileSystem
+uco-observable:FileSystem
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "FileSystem"@en ;
 	rdfs:comment "A file system is the process that manages how and where data on a storage medium is stored, accessed and managed. [based on https://www.techopedia.com/definition/5510/file-system]"@en ;
-	sh:targetClass observable:FileSystem ;
+	sh:targetClass uco-observable:FileSystem ;
 	.
 
-observable:FileSystemFacet
+uco-observable:FileSystemFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "FileSystemFacet"@en ;
 	rdfs:comment "A file system facet is a grouping of characteristics unique to the process that manages how and where data on a storage medium is stored, accessed and managed. [based on https://www.techopedia.com/definition/5510/file-system]"@en ;
 	sh:property
@@ -3260,386 +3260,386 @@ observable:FileSystemFacet
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:clusterSize ;
+			sh:path uco-observable:clusterSize ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:fileSystemType ;
+			sh:path uco-observable:fileSystemType ;
 		]
 		;
-	sh:targetClass observable:FileSystemFacet ;
+	sh:targetClass uco-observable:FileSystemFacet ;
 	.
 
-observable:FileSystemObject
+uco-observable:FileSystemObject
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "FileSystemObject"@en ;
 	rdfs:comment "A file system object is an informational object represented and managed within a file system."@en ;
-	sh:targetClass observable:FileSystemObject ;
+	sh:targetClass uco-observable:FileSystemObject ;
 	.
 
-observable:ForumPost
+uco-observable:ForumPost
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Message ;
+	rdfs:subClassOf uco-observable:Message ;
 	rdfs:label "ForumPost"@en ;
 	rdfs:comment "A forum post is message submitted by a user account to an online forum where the message content (and typically metadata including who posted it and when) is viewable by any party with viewing permissions on the forum."@en ;
-	sh:targetClass observable:ForumPost ;
+	sh:targetClass uco-observable:ForumPost ;
 	.
 
-observable:ForumPrivateMessage
+uco-observable:ForumPrivateMessage
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Message ;
+	rdfs:subClassOf uco-observable:Message ;
 	rdfs:label "ForumPrivateMessage"@en ;
 	rdfs:comment "A forum private message (aka PM or DM (direct message)) is a one-to-one message from one specific user account to another specific user account on an online form where transmission is managed by the online forum platform and the message is only viewable by the parties directly involved."@en ;
-	sh:targetClass observable:ForumPrivateMessage ;
+	sh:targetClass uco-observable:ForumPrivateMessage ;
 	.
 
-observable:FragmentFacet
+uco-observable:FragmentFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "FragmentFacet"@en ;
 	rdfs:comment "A fragment facet is a grouping of characteristics unique to an individual piece of the content of a file."@en ;
 	sh:property
 		[
 			sh:datatype xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:fragmentIndex ;
+			sh:path uco-observable:fragmentIndex ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:totalFragments ;
+			sh:path uco-observable:totalFragments ;
 		]
 		;
-	sh:targetClass observable:FragmentFacet ;
+	sh:targetClass uco-observable:FragmentFacet ;
 	.
 
-observable:GUI
+uco-observable:GUI
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "GUI"@en ;
 	rdfs:comment "A GUI is a graphical user interface that allows users to interact with electronic devices through graphical icons and audio indicators such as primary notation, instead of text-based user interfaces, typed command labels or text navigation. [based on https://en.wikipedia.org/wiki/Graphical_user_interface]"@en ;
-	sh:targetClass observable:GUI ;
+	sh:targetClass uco-observable:GUI ;
 	.
 
-observable:GamingConsole
+uco-observable:GamingConsole
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "GamingConsole"@en-US ;
 	rdfs:comment "A gaming console (video game console or game console) is an electronic system that connects to a display, typically a TV or computer monitor, for the primary purpose of playing video games."@en-US ;
-	sh:targetClass observable:GamingConsole ;
+	sh:targetClass uco-observable:GamingConsole ;
 	.
 
-observable:GenericObservableObject
+uco-observable:GenericObservableObject
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "GenericObservableObject"@en ;
 	rdfs:comment "A generic observable object is an article or unit within the digital domain."@en ;
-	sh:targetClass observable:GenericObservableObject ;
+	sh:targetClass uco-observable:GenericObservableObject ;
 	.
 
-observable:GeoLocationEntry
+uco-observable:GeoLocationEntry
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "GeoLocationEntry"@en ;
 	rdfs:comment "A geolocation entry is a single application-specific geolocation entry."@en ;
-	sh:targetClass observable:GeoLocationEntry ;
+	sh:targetClass uco-observable:GeoLocationEntry ;
 	.
 
-observable:GeoLocationEntryFacet
+uco-observable:GeoLocationEntryFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "GeoLocationEntryFacet"@en ;
 	rdfs:comment "A geolocation entry facet is a grouping of characteristics unique to a single application-specific geolocation entry."@en ;
 	sh:property
 		[
-			sh:class location:Location ;
+			sh:class uco-location:Location ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:location ;
+			sh:path uco-observable:location ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		]
 		;
-	sh:targetClass observable:GeoLocationEntryFacet ;
+	sh:targetClass uco-observable:GeoLocationEntryFacet ;
 	.
 
-observable:GeoLocationLog
+uco-observable:GeoLocationLog
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "GeoLocationLog"@en ;
 	rdfs:comment "A geolocation log is a record containing geolocation tracks and/or geolocation entries."@en ;
-	sh:targetClass observable:GeoLocationLog ;
+	sh:targetClass uco-observable:GeoLocationLog ;
 	.
 
-observable:GeoLocationLogFacet
+uco-observable:GeoLocationLogFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "GeoLocationLogFacet"@en ;
 	rdfs:comment "A geolocation log facet is a grouping of characteristics unique to a record containing geolocation tracks and/or geolocation entries."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		]
 		;
-	sh:targetClass observable:GeoLocationLogFacet ;
+	sh:targetClass uco-observable:GeoLocationLogFacet ;
 	.
 
-observable:GeoLocationTrack
+uco-observable:GeoLocationTrack
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "GeoLocationTrack"@en ;
 	rdfs:comment "A geolocation track is a set of contiguous geolocation entries representing a path/track taken."@en ;
-	sh:targetClass observable:GeoLocationTrack ;
+	sh:targetClass uco-observable:GeoLocationTrack ;
 	.
 
-observable:GeoLocationTrackFacet
+uco-observable:GeoLocationTrackFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "GeoLocationTrackFacet"@en ;
 	rdfs:comment "A geolocation track facet is a grouping of characteristics unique to a set of contiguous geolocation entries representing a path/track taken."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:geoLocationEntry ;
+			sh:path uco-observable:geoLocationEntry ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:endTime ;
+			sh:path uco-observable:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startTime ;
+			sh:path uco-observable:startTime ;
 		]
 		;
-	sh:targetClass observable:GeoLocationTrackFacet ;
+	sh:targetClass uco-observable:GeoLocationTrackFacet ;
 	.
 
-observable:GlobalFlagType
+uco-observable:GlobalFlagType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "GlobalFlagType"@en ;
 	rdfs:comment 'A global flag type is a grouping of characteristics unique to the Windows systemwide global variable named NtGlobalFlag that enables various internal debugging, tracing, and validation support in the operating system. [based on "Windows Global Flags, Chapter 3: System Mechanisms of Windows Internals by Solomon, Russinovich, and Ionescu]'@en ;
 	sh:property
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:hexadecimalValue ;
+			sh:path uco-observable:hexadecimalValue ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:abbreviation ;
+			sh:path uco-observable:abbreviation ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:destination ;
+			sh:path uco-observable:destination ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:symbolicName ;
+			sh:path uco-observable:symbolicName ;
 		]
 		;
-	sh:targetClass observable:GlobalFlagType ;
+	sh:targetClass uco-observable:GlobalFlagType ;
 	.
 
-observable:HTTPConnection
+uco-observable:HTTPConnection
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:NetworkConnection ;
+	rdfs:subClassOf uco-observable:NetworkConnection ;
 	rdfs:label "HTTPConnection"@en ;
 	rdfs:comment "An HTTP connection is network connection that is conformant to the Hypertext Transfer Protocol (HTTP) standard."@en ;
-	sh:targetClass observable:HTTPConnection ;
+	sh:targetClass uco-observable:HTTPConnection ;
 	.
 
-observable:HTTPConnectionFacet
+uco-observable:HTTPConnectionFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "HTTPConnectionFacet"@en ;
 	rdfs:comment "An HTTP connection facet is a grouping of characteristics unique to portions of a network connection that are conformant to the Hypertext Transfer Protocol (HTTP) standard."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:httpMessageBodyData ;
+			sh:path uco-observable:httpMessageBodyData ;
 		] ,
 		[
-			sh:class types:Dictionary ;
+			sh:class uco-types:Dictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:httpRequestHeader ;
+			sh:path uco-observable:httpRequestHeader ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:httpMesageBodyLength ;
+			sh:path uco-observable:httpMesageBodyLength ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:requestMethod ;
+			sh:path uco-observable:requestMethod ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:requestValue ;
+			sh:path uco-observable:requestValue ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:requestVersion ;
+			sh:path uco-observable:requestVersion ;
 		]
 		;
-	sh:targetClass observable:HTTPConnectionFacet ;
+	sh:targetClass uco-observable:HTTPConnectionFacet ;
 	.
 
-observable:Hostname
+uco-observable:Hostname
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Hostname"@en ;
 	rdfs:comment "A hostname is a label that is assigned to a device connected to a computer network and that is used to identify the device in various forms of electronic communication, such as the World Wide Web. A hostname may be a domain name, if it is properly organized into the domain name system. A domain name may be a hostname if it has been assigned to an Internet host and associated with the host's IP address. [based on https://en.wikipedia.org/wiki/Hostname]"@en ;
-	sh:targetClass observable:Hostname ;
+	sh:targetClass uco-observable:Hostname ;
 	.
 
-observable:ICCID
+uco-observable:ICCID
 	a owl:DatatypeProperty ;
 	rdfs:label "ICCID"@en ;
 	rdfs:comment "Integrated circuit card identifier (http://www.itu.int/)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:ICMPConnection
+uco-observable:ICMPConnection
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:NetworkConnection ;
+	rdfs:subClassOf uco-observable:NetworkConnection ;
 	rdfs:label "ICMPConnection"@en ;
 	rdfs:comment "An ICMP connection is a network connection that is conformant to the Internet Control Message Protocol (ICMP) standard."@en ;
-	sh:targetClass observable:ICMPConnection ;
+	sh:targetClass uco-observable:ICMPConnection ;
 	.
 
-observable:ICMPConnectionFacet
+uco-observable:ICMPConnectionFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ICMPConnectionFacet"@en ;
 	rdfs:comment "An ICMP connection facet is a grouping of characteristics unique to portions of a network connection that are conformant to the Internet Control Message Protocol (ICMP) standard."@en ;
 	sh:property
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:icmpCode ;
+			sh:path uco-observable:icmpCode ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:icmpType ;
+			sh:path uco-observable:icmpType ;
 		]
 		;
-	sh:targetClass observable:ICMPConnectionFacet ;
+	sh:targetClass uco-observable:ICMPConnectionFacet ;
 	.
 
-observable:IComHandlerActionType
+uco-observable:IComHandlerActionType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "IComHandlerActionType"@en ;
 	rdfs:comment "An IComHandler action type is a grouping of characteristics unique to a Windows Task-related action that fires a Windows COM handler (smart code in the client address space that can optimize calls between a client and server). [based on https://docs.microsoft.com/en-us/windows/win32/taskschd/comhandleraction]"@en ;
 	sh:property
@@ -3647,165 +3647,165 @@ observable:IComHandlerActionType
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:comClassID ;
+			sh:path uco-observable:comClassID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:comData ;
+			sh:path uco-observable:comData ;
 		]
 		;
-	sh:targetClass observable:IComHandlerActionType ;
+	sh:targetClass uco-observable:IComHandlerActionType ;
 	.
 
-observable:IExecActionType
+uco-observable:IExecActionType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "IExecActionType"@en ;
 	rdfs:comment "An IExec action type is a grouping of characteristics unique to an action that executes a command-line operation on a Windows operating system. [based on https://docs.microsoft.com/en-us/windows/win32/api/taskschd/nn-taskschd-iexecaction?redirectedfrom=MSDN]"@en ;
 	sh:property
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:execProgramHashes ;
+			sh:path uco-observable:execProgramHashes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:execArguments ;
+			sh:path uco-observable:execArguments ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:execProgramPath ;
+			sh:path uco-observable:execProgramPath ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:execWorkingDirectory ;
+			sh:path uco-observable:execWorkingDirectory ;
 		]
 		;
-	sh:targetClass observable:IExecActionType ;
+	sh:targetClass uco-observable:IExecActionType ;
 	.
 
-observable:IMEI
+uco-observable:IMEI
 	a owl:DatatypeProperty ;
 	rdfs:label "IMEI"@en ;
 	rdfs:comment "International Mobile Equipment Identity (IMEI)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:IMSI
+uco-observable:IMSI
 	a owl:DatatypeProperty ;
 	rdfs:label "IMSI"@en ;
 	rdfs:comment "An International Mobile Subscriber Identity (IMSI) is a unique identification associated with all GSM and UMTS network mobile phone users. It is stored as a 64-bit field in the SIM inside the phone and is sent by the phone to the network."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:IPAddress
+uco-observable:IPAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddress ;
+	rdfs:subClassOf uco-observable:DigitalAddress ;
 	rdfs:label "IPAddress"@en ;
 	rdfs:comment "An IP address is an Internet Protocol (IP) standards conformant identifier assigned to a device to enable routing and management of IP standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:IPAddress ;
+	sh:targetClass uco-observable:IPAddress ;
 	.
 
-observable:IPAddressFacet
+uco-observable:IPAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddressFacet ;
+	rdfs:subClassOf uco-observable:DigitalAddressFacet ;
 	rdfs:label "IPAddressFacet"@en ;
 	rdfs:comment "An IP address facet is a grouping of characteristics unique to an Internet Protocol (IP) standards conformant identifier assigned to a device to enable routing and management of IP standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:IPAddressFacet ;
+	sh:targetClass uco-observable:IPAddressFacet ;
 	.
 
-observable:IPNetmask
+uco-observable:IPNetmask
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "IPNetmask"@en ;
 	rdfs:comment "An IP netmask is a 32-bit 'mask' used to divide an IP address into subnets and specify the network's available hosts."@en ;
-	sh:targetClass observable:IPNetmask ;
+	sh:targetClass uco-observable:IPNetmask ;
 	.
 
-observable:IPhone
+uco-observable:IPhone
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		observable:AppleDevice ,
-		observable:SmartPhone
+		uco-observable:AppleDevice ,
+		uco-observable:SmartPhone
 		;
 	rdfs:label "IPhone"@en-US ;
 	rdfs:comment "An iPhone is a smart phone that applies the iOS mobile operating system."@en-US ;
-	sh:targetClass observable:IPhone ;
+	sh:targetClass uco-observable:IPhone ;
 	.
 
-observable:IPv4Address
+uco-observable:IPv4Address
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:IPAddress ;
+	rdfs:subClassOf uco-observable:IPAddress ;
 	rdfs:label "IPv4Address"@en ;
 	rdfs:comment "An IPv4 (Internet Protocol version 4) address is an IPv4 standards conformant identifier assigned to a device to enable routing and management of IPv4 standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:IPv4Address ;
+	sh:targetClass uco-observable:IPv4Address ;
 	.
 
-observable:IPv4AddressFacet
+uco-observable:IPv4AddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:IPAddressFacet ;
+	rdfs:subClassOf uco-observable:IPAddressFacet ;
 	rdfs:label "IPv4AddressFacet"@en ;
 	rdfs:comment "An IPv4 (Internet Protocol version 4) address facet is a grouping of characteristics unique to an IPv4 standards conformant identifier assigned to a device to enable routing and management of IPv4 standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:IPv4AddressFacet ;
+	sh:targetClass uco-observable:IPv4AddressFacet ;
 	.
 
-observable:IPv6Address
+uco-observable:IPv6Address
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:IPAddress ;
+	rdfs:subClassOf uco-observable:IPAddress ;
 	rdfs:label "IPv6Address"@en ;
 	rdfs:comment "An IPv6 (Internet Protocol version 6) address is an IPv6 standards conformant identifier assigned to a device to enable routing and management of IPv6 standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:IPv6Address ;
+	sh:targetClass uco-observable:IPv6Address ;
 	.
 
-observable:IPv6AddressFacet
+uco-observable:IPv6AddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:IPAddressFacet ;
+	rdfs:subClassOf uco-observable:IPAddressFacet ;
 	rdfs:label "IPv6AddressFacet"@en ;
 	rdfs:comment "An IPv6 (Internet Protocol version 6) address facet is a grouping of characteristics unique to an IPv6 standards conformant identifier assigned to a device to enable routing and management of IPv6 standards conformant communication to or from that device."@en ;
-	sh:targetClass observable:IPv6AddressFacet ;
+	sh:targetClass uco-observable:IPv6AddressFacet ;
 	.
 
-observable:IShowMessageActionType
+uco-observable:IShowMessageActionType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "IShowMessageActionType"@en ;
 	rdfs:comment "An IShow message action type is a grouping of characteristics unique to an action that shows a message box when a task is activate. [based on https://docs.microsoft.com/en-us/windows/win32/api/taskschd/nn-taskschd-ishowmessageaction?redirectedfrom=MSDN]"@en ;
 	sh:property
@@ -3813,232 +3813,232 @@ observable:IShowMessageActionType
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:showMessageBody ;
+			sh:path uco-observable:showMessageBody ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:showMessageTitle ;
+			sh:path uco-observable:showMessageTitle ;
 		]
 		;
-	sh:targetClass observable:IShowMessageActionType ;
+	sh:targetClass uco-observable:IShowMessageActionType ;
 	.
 
-observable:Image
+uco-observable:Image
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Image"@en ;
 	rdfs:comment "An image is a complete copy of a hard disk, memory, or other digital media."@en ;
-	sh:targetClass observable:Image ;
+	sh:targetClass uco-observable:Image ;
 	.
 
-observable:ImageFacet
+uco-observable:ImageFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ImageFacet"@en ;
 	rdfs:comment "An image facet is a grouping of characteristics unique to a complete copy of a hard disk, memory, or other digital media."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:imageType ;
+		sh:path uco-observable:imageType ;
 	] ;
-	sh:targetClass observable:ImageFacet ;
+	sh:targetClass uco-observable:ImageFacet ;
 	.
 
-observable:InstantMessagingAddress
+uco-observable:InstantMessagingAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddress ;
+	rdfs:subClassOf uco-observable:DigitalAddress ;
 	rdfs:label "InstantMessagingAddress"@en ;
 	rdfs:comment ""@en ;
-	sh:targetClass observable:InstantMessagingAddress ;
+	sh:targetClass uco-observable:InstantMessagingAddress ;
 	.
 
-observable:InstantMessagingAddressFacet
+uco-observable:InstantMessagingAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddressFacet ;
+	rdfs:subClassOf uco-observable:DigitalAddressFacet ;
 	rdfs:label "InstantMessagingAddressFacet"@en ;
 	rdfs:comment "An instant messaging address facet is a grouping of characteristics unique to an identifier assigned to enable routing and management of instant messaging digital communication."@en ;
-	sh:targetClass observable:InstantMessagingAddressFacet ;
+	sh:targetClass uco-observable:InstantMessagingAddressFacet ;
 	.
 
-observable:Junction
+uco-observable:Junction
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "Junction"@en ;
 	rdfs:comment "A junction is a specific NTFS (New Technology File System) reparse point to redirect a directory access to another directory which can be on the same volume or another volume. A junction is similar to a directory symbolic link but may differ on whether they are processed on the local system or on the remote file server. [based on https://jp-andre.pagesperso-orange.fr/junctions.html]"@en ;
-	sh:targetClass observable:Junction ;
+	sh:targetClass uco-observable:Junction ;
 	.
 
-observable:Laptop
+uco-observable:Laptop
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Computer ;
+	rdfs:subClassOf uco-observable:Computer ;
 	rdfs:label "Laptop"@en-US ;
 	rdfs:comment "A laptop, laptop computer, or notebook computer is a small, portable personal computer with a screen and alphanumeric keyboard. These typically have a clam shell form factor with the screen mounted on the inside of the upper lid and the keyboard on the inside of the lower lid, although 2-in-1 PCs with a detachable keyboard are often marketed as laptops or as having a laptop mode. (Devices categorized by their manufacturer as a Laptop)"@en-US ;
-	sh:targetClass observable:Laptop ;
+	sh:targetClass uco-observable:Laptop ;
 	.
 
-observable:Library
+uco-observable:Library
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Library"@en ;
 	rdfs:comment "A library is a suite of data and programming code that is used to develop software programs and applications. [based on https://www.techopedia.com/definition/3828/software-library]"@en ;
-	sh:targetClass observable:Library ;
+	sh:targetClass uco-observable:Library ;
 	.
 
-observable:LibraryFacet
+uco-observable:LibraryFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "LibraryFacet"@en ;
 	rdfs:comment "A library facet is a grouping of characteristics unique to a suite of data and programming code that is used to develop software programs and applications. [based on https://www.techopedia.com/definition/3828/software-library]"@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:libraryType ;
+		sh:path uco-observable:libraryType ;
 	] ;
-	sh:targetClass observable:LibraryFacet ;
+	sh:targetClass uco-observable:LibraryFacet ;
 	.
 
-observable:MACAddress
+uco-observable:MACAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddress ;
+	rdfs:subClassOf uco-observable:DigitalAddress ;
 	rdfs:label "MACAddress"@en ;
 	rdfs:comment "A MAC address is a media access control standards conformant identifier assigned to a network interface to enable routing and management of communications at the data link layer of a network segment."@en ;
-	sh:targetClass observable:MACAddress ;
+	sh:targetClass uco-observable:MACAddress ;
 	.
 
-observable:MACAddressFacet
+uco-observable:MACAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddressFacet ;
+	rdfs:subClassOf uco-observable:DigitalAddressFacet ;
 	rdfs:label "MACAddressFacet"@en ;
 	rdfs:comment "A MAC address facet is a grouping of characteristics unique to a media access control standards conformant identifier assigned to a network interface to enable routing and management of communications at the data link layer of a network segment."@en ;
-	sh:targetClass observable:MACAddressFacet ;
+	sh:targetClass uco-observable:MACAddressFacet ;
 	.
 
-observable:MSISDN
+uco-observable:MSISDN
 	a owl:DatatypeProperty ;
 	rdfs:label "MSISDN"@en ;
 	rdfs:comment "Mobile Station International Subscriber Directory Number (MSISDN) is a number used to identify a mobile phone number internationally. MSISDN is defined by the E.164 numbering plan. This number includes a country code and a National Destination Code which identifies the subscriber's operator."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:MSISDNType
+uco-observable:MSISDNType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "MSISDNType"@en ;
 	rdfs:comment "???."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:Memory
+uco-observable:Memory
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Memory"@en ;
 	rdfs:comment "Memory is a particular region of temporary information storage (e.g., RAM (random access memory), ROM (read only memory)) on a digital device."@en ;
-	sh:targetClass observable:Memory ;
+	sh:targetClass uco-observable:Memory ;
 	.
 
-observable:MemoryFacet
+uco-observable:MemoryFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "MemoryFacet"@en ;
 	rdfs:comment "A memory facet is a grouping of characteristics unique to a particular region of temporary information storage (e.g., RAM (random access memory), ROM (read only memory)) on a digital device."@en ;
 	sh:property
-		observable:MemoryFacet-blockType-in-shape ,
+		uco-observable:MemoryFacet-blockType-in-shape ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isInjected ;
+			sh:path uco-observable:isInjected ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isMapped ;
+			sh:path uco-observable:isMapped ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isProtected ;
+			sh:path uco-observable:isProtected ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isVolatile ;
+			sh:path uco-observable:isVolatile ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:regionEndAddress ;
+			sh:path uco-observable:regionEndAddress ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:regionStartAddress ;
+			sh:path uco-observable:regionStartAddress ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:regionSize ;
+			sh:path uco-observable:regionSize ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:blockType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:blockType ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:blockType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:blockType ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:blockType ;
+			sh:path uco-observable:blockType ;
 		]
 		;
-	sh:targetClass observable:MemoryFacet ;
+	sh:targetClass uco-observable:MemoryFacet ;
 	.
 
-observable:MemoryFacet-blockType-in-shape
+uco-observable:MemoryFacet-blockType-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"Bit-mapped"
@@ -4048,163 +4048,163 @@ observable:MemoryFacet-blockType-in-shape
 		"Uninitialized"
 	) ;
 	sh:message "Value is not member of the vocabulary MemoryBlockTypeVocab." ;
-	sh:path observable:blockType ;
+	sh:path uco-observable:blockType ;
 	sh:severity sh:Info ;
 	.
 
-observable:Message
+uco-observable:Message
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Message"@en ;
 	rdfs:comment "A message is a discrete unit of electronic communication intended by the source for consumption by some recipient or group of recipients. [based on https://en.wikipedia.org/wiki/Message]"@en ;
-	sh:targetClass observable:Message ;
+	sh:targetClass uco-observable:Message ;
 	.
 
-observable:MessageFacet
+uco-observable:MessageFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "MessageFacet"@en ;
 	rdfs:comment "A message facet is a grouping of characteristics unique to a discrete unit of electronic communication intended by the source for consumption by some recipient or group of recipients. [based on https://en.wikipedia.org/wiki/Message]"@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:from ;
+			sh:path uco-observable:from ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:to ;
+			sh:path uco-observable:to ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sentTime ;
+			sh:path uco-observable:sentTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:messageID ;
+			sh:path uco-observable:messageID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:messageText ;
+			sh:path uco-observable:messageText ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:messageType ;
+			sh:path uco-observable:messageType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sessionID ;
+			sh:path uco-observable:sessionID ;
 		]
 		;
-	sh:targetClass observable:MessageFacet ;
+	sh:targetClass uco-observable:MessageFacet ;
 	.
 
-observable:MessageThread
+uco-observable:MessageThread
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "MessageTread"@en ;
 	rdfs:comment "A message thread is a running commentary of electronic messages pertaining to one topic or question."@en ;
-	sh:targetClass observable:MessageThread ;
+	sh:targetClass uco-observable:MessageThread ;
 	.
 
-observable:MessageThreadFacet
+uco-observable:MessageThreadFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "MessageThreadFacet"@en ;
 	rdfs:comment "A message thread facet is a grouping of characteristics unique to a running commentary of electronic messages pertaining to one topic or question."@en ;
 	sh:property
 		[
-			sh:class observable:Message ;
+			sh:class uco-observable:Message ;
 			sh:description "The contents of ordered items in the Thread linked by messageThread must be Message objects."@en ;
 			sh:path (
-				observable:messageThread
+				uco-observable:messageThread
 				co:item
 				co:itemContent
 			) ;
 		] ,
 		[
-			sh:class observable:Message ;
+			sh:class uco-observable:Message ;
 			sh:description "The contents of origin items in the Thread linked by messageThread must be Message objects."@en ;
 			sh:path (
-				observable:messageThread
-				types:threadOriginItem
+				uco-observable:messageThread
+				uco-types:threadOriginItem
 				co:itemContent
 			) ;
 		] ,
 		[
-			sh:class observable:Message ;
+			sh:class uco-observable:Message ;
 			sh:description "The contents of terminal items in the Thread linked by messageThread must be Message objects."@en ;
 			sh:path (
-				observable:messageThread
-				types:threadTerminalItem
+				uco-observable:messageThread
+				uco-types:threadTerminalItem
 				co:itemContent
 			) ;
 		] ,
 		[
-			sh:class observable:Message ;
+			sh:class uco-observable:Message ;
 			sh:description "The contents of unordered items in the Thread linked by messageThread must be Message objects."@en ;
 			sh:path (
-				observable:messageThread
+				uco-observable:messageThread
 				co:element
 			) ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:participant ;
+			sh:path uco-observable:participant ;
 		] ,
 		[
-			sh:class types:Thread ;
+			sh:class uco-types:Thread ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:messageThread ;
+			sh:path uco-observable:messageThread ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:visibility ;
+			sh:path uco-observable:visibility ;
 		]
 		;
-	sh:targetClass observable:MessageThreadFacet ;
+	sh:targetClass uco-observable:MessageThreadFacet ;
 	.
 
-observable:MftRecordFacet
+uco-observable:MftRecordFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "MftRecordFacet"@en ;
 	rdfs:comment "An MFT record facet is a grouping of characteristics unique to the details of a single file as managed in an NTFS (new technology filesystem) master file table (which is a collection of information about all files on an NTFS filesystem). [based on https://docs.microsoft.com/en-us/windows/win32/devnotes/master-file-table]"@en ;
 	sh:property
@@ -4212,132 +4212,132 @@ observable:MftRecordFacet
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftFileNameAccessedTime ;
+			sh:path uco-observable:mftFileNameAccessedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftFileNameCreatedTime ;
+			sh:path uco-observable:mftFileNameCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftFileNameModifiedTime ;
+			sh:path uco-observable:mftFileNameModifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftFileNameRecordChangeTime ;
+			sh:path uco-observable:mftFileNameRecordChangeTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftRecordChangeTime ;
+			sh:path uco-observable:mftRecordChangeTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftFileID ;
+			sh:path uco-observable:mftFileID ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftFileNameLength ;
+			sh:path uco-observable:mftFileNameLength ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftFlags ;
+			sh:path uco-observable:mftFlags ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mftParentID ;
+			sh:path uco-observable:mftParentID ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ntfsHardLinkCount ;
+			sh:path uco-observable:ntfsHardLinkCount ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ntfsOwnerID ;
+			sh:path uco-observable:ntfsOwnerID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ntfsOwnerSID ;
+			sh:path uco-observable:ntfsOwnerSID ;
 		]
 		;
-	sh:targetClass observable:MftRecordFacet ;
+	sh:targetClass uco-observable:MftRecordFacet ;
 	.
 
-observable:MimePartType
+uco-observable:MimePartType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "MimePartType"@en ;
 	rdfs:comment "A mime part type is a grouping of characteristics unique to a component of a multi-part email body."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:bodyRaw ;
+			sh:path uco-observable:bodyRaw ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:body ;
+			sh:path uco-observable:body ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contentDisposition ;
+			sh:path uco-observable:contentDisposition ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contentType ;
+			sh:path uco-observable:contentType ;
 		]
 		;
-	sh:targetClass observable:MimePartType ;
+	sh:targetClass uco-observable:MimePartType ;
 	.
 
-observable:MobileAccount
+uco-observable:MobileAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "MobileAccount"@en ;
 	rdfs:comment "A mobile account is an arrangement with an entity to enable and control the provision of some capability or service on a portable computing device. [based on https://www.lexico.com/definition/mobile_device]"@en ;
-	sh:targetClass observable:MobileAccount ;
+	sh:targetClass uco-observable:MobileAccount ;
 	.
 
-observable:MobileAccountFacet
+uco-observable:MobileAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "MobileAccountFacet"@en ;
 	rdfs:comment "A mobile account facet is a grouping of characteristics unique to an arrangement with an entity to enable and control the provision of some capability or service on a portable computing device. [based on https://www.lexico.com/definition/mobile_device]"@en ;
 	sh:property
@@ -4345,41 +4345,41 @@ observable:MobileAccountFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:IMSI ;
+			sh:path uco-observable:IMSI ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:MSISDN ;
+			sh:path uco-observable:MSISDN ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:MSISDNType ;
+			sh:path uco-observable:MSISDNType ;
 		]
 		;
-	sh:targetClass observable:MobileAccountFacet ;
+	sh:targetClass uco-observable:MobileAccountFacet ;
 	.
 
-observable:MobileDevice
+uco-observable:MobileDevice
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "MobileDevice"@en ;
 	rdfs:comment "A mobile device is a portable computing device. [based on https://www.lexico.com.definition/mobile_device]"@en ;
-	sh:targetClass observable:MobileDevice ;
+	sh:targetClass uco-observable:MobileDevice ;
 	.
 
-observable:MobileDeviceFacet
+uco-observable:MobileDeviceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "MobileDeviceFacet"@en ;
 	rdfs:comment "A mobile device facet is a grouping of characteristics unique to a portable computing device. [based on https://www.lexico.com/definition/mobile_device]"@en ;
 	sh:property
@@ -4387,87 +4387,87 @@ observable:MobileDeviceFacet
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mockLocationsAllowed ;
+			sh:path uco-observable:mockLocationsAllowed ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:clockSetting ;
+			sh:path uco-observable:clockSetting ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:phoneActivationTime ;
+			sh:path uco-observable:phoneActivationTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:storageCapacityInBytes ;
+			sh:path uco-observable:storageCapacityInBytes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ESN ;
+			sh:path uco-observable:ESN ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:bluetoothDeviceName ;
+			sh:path uco-observable:bluetoothDeviceName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:keypadUnlockCode ;
+			sh:path uco-observable:keypadUnlockCode ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:network ;
+			sh:path uco-observable:network ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:IMEI ;
+			sh:path uco-observable:IMEI ;
 		]
 		;
-	sh:targetClass observable:MobileDeviceFacet ;
+	sh:targetClass uco-observable:MobileDeviceFacet ;
 	.
 
-observable:MobilePhone
+uco-observable:MobilePhone
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:MobileDevice ;
+	rdfs:subClassOf uco-observable:MobileDevice ;
 	rdfs:label "MobilePhone"@en-US ;
 	rdfs:comment "A mobile phone is a portable telephone that at least can make and receive calls over a radio frequency link while the user is moving within a telephone service area. This category encompasses all types of mobiles, simple and smart and satellite ones all together."@en-US ;
-	sh:targetClass observable:MobilePhone ;
+	sh:targetClass uco-observable:MobilePhone ;
 	.
 
-observable:Mutex
+uco-observable:Mutex
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Mutex"@en ;
 	rdfs:comment "A mutex is a mechanism that enforces limits on access to a resource when there are many threads of execution. A mutex is designed to enforce a mutual exclusion concurrency control policy, and with a variety of possible methods there exists multiple unique implementations for different applications. [based on https://en.wikipedia.org/wiki/Lock_(computer_science)]"@en ;
-	sh:targetClass observable:Mutex ;
+	sh:targetClass uco-observable:Mutex ;
 	.
 
-observable:MutexFacet
+uco-observable:MutexFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "MutexFacet"@en ;
 	rdfs:comment "A mutex facet is a grouping of characteristics unique to a mechanism that enforces limits on access to a resource when there are many threads of execution. A mutex is designed to enforce a mutual exclusion concurrency control policy, and with a variety of possible methods there exists multiple unique implementations for different applications. [based on https://en.wikipedia.org/wiki/Lock_(computer_science)]"@en ;
 	sh:property
@@ -4475,314 +4475,314 @@ observable:MutexFacet
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isNamed ;
+			sh:path uco-observable:isNamed ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mutexName ;
+			sh:path uco-observable:mutexName ;
 		]
 		;
-	sh:targetClass observable:MutexFacet ;
+	sh:targetClass uco-observable:MutexFacet ;
 	.
 
-observable:NTFSFile
+uco-observable:NTFSFile
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:File ;
+	rdfs:subClassOf uco-observable:File ;
 	rdfs:label "NTFSFile"@en ;
 	rdfs:comment "An NTFS file is a New Technology File System (NTFS) file."@en ;
-	sh:targetClass observable:NTFSFile ;
+	sh:targetClass uco-observable:NTFSFile ;
 	.
 
-observable:NTFSFileFacet
+uco-observable:NTFSFileFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "NTFSFileFacet"@en ;
 	rdfs:comment "An NTFS file facet is a grouping of characteristics unique to a file on an NTFS (new technology filesystem) file system."@en ;
 	sh:property
 		[
-			sh:class observable:AlternateDataStream ;
+			sh:class uco-observable:AlternateDataStream ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:alternateDataStreams ;
+			sh:path uco-observable:alternateDataStreams ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:entryID ;
+			sh:path uco-observable:entryID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sid ;
+			sh:path uco-observable:sid ;
 		]
 		;
-	sh:targetClass observable:NTFSFileFacet ;
+	sh:targetClass uco-observable:NTFSFileFacet ;
 	.
 
-observable:NTFSFilePermissionsFacet
+uco-observable:NTFSFilePermissionsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "NTFSFilePermissionsFacet"@en ;
 	rdfs:comment "An NTFS file permissions facet is a grouping of characteristics unique to the access rights (e.g., view, change, navigate, execute) of a file on an NTFS (new technology filesystem) file system."@en ;
-	sh:targetClass observable:NTFSFilePermissionsFacet ;
+	sh:targetClass uco-observable:NTFSFilePermissionsFacet ;
 	.
 
-observable:NamedPipe
+uco-observable:NamedPipe
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "NamedPipe"@en ;
 	rdfs:comment "A named pipe is a mechanism for FIFO (first-in-first-out) inter-process communication. It is persisted as a filesystem object (that can be deleted like any other file), can be written to or read from by any process and exists beyond the lifespan of any process interacting with it (unlike simple anonymous pipes). [based on https://en.wikipedia.org/wiki/Named_pipe]"@en ;
-	sh:targetClass observable:NamedPipe ;
+	sh:targetClass uco-observable:NamedPipe ;
 	.
 
-observable:NetworkAppliance
+uco-observable:NetworkAppliance
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Appliance ;
+	rdfs:subClassOf uco-observable:Appliance ;
 	rdfs:label "NetworkAppliance"@en ;
 	rdfs:comment "A network appliance is a purpose-built computer with software or firmware that is designed to provide a specific network management function."@en ;
-	sh:targetClass observable:NetworkAppliance ;
+	sh:targetClass uco-observable:NetworkAppliance ;
 	.
 
-observable:NetworkConnection
+uco-observable:NetworkConnection
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "NetworkConnection"@en ;
 	rdfs:comment "A network connection is a connection (completed or attempted) across a digital network (a group of two or more computer systems linked together). [based on https://www.webopedia.com/TERM/N/network.html]"@en ;
-	sh:targetClass observable:NetworkConnection ;
+	sh:targetClass uco-observable:NetworkConnection ;
 	.
 
-observable:NetworkConnectionFacet
+uco-observable:NetworkConnectionFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "NetworkConnectionFacet"@en ;
 	rdfs:comment "A network connection facet is a grouping of characteristics unique to a connection (complete or attempted) accross a digital network (a group of two or more computer systems linked together). [based on https://www.webopedia.com/TERM/N/network.html]"@en ;
 	sh:property
 		[
-			sh:class core:UcoObject ;
+			sh:class uco-core:UcoObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:src ;
+			sh:path uco-observable:src ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:dst ;
+			sh:path uco-observable:dst ;
 		] ,
 		[
-			sh:class types:ControlledDictionary ;
+			sh:class uco-types:ControlledDictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:protocols ;
+			sh:path uco-observable:protocols ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isActive ;
+			sh:path uco-observable:isActive ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:endTime ;
+			sh:path uco-observable:endTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startTime ;
+			sh:path uco-observable:startTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:destinationPort ;
+			sh:path uco-observable:destinationPort ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sourcePort ;
+			sh:path uco-observable:sourcePort ;
 		]
 		;
-	sh:targetClass observable:NetworkConnectionFacet ;
+	sh:targetClass uco-observable:NetworkConnectionFacet ;
 	.
 
-observable:NetworkFlow
+uco-observable:NetworkFlow
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "NetworkFlow"@en ;
 	rdfs:comment "A network flow is a sequence of data transiting one or more digital network (a group or two or more computer systems linked together) connections. [based on https://www.webopedia.com/TERM/N/network.html]"@en ;
-	sh:targetClass observable:NetworkFlow ;
+	sh:targetClass uco-observable:NetworkFlow ;
 	.
 
-observable:NetworkFlowFacet
+uco-observable:NetworkFlowFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "NetworkFlowFacet"@en ;
 	rdfs:comment "A network flow facet is a grouping of characteristics unique to a sequence of data transiting one or more digital network (a group of two or more computer systems linked together) connections. [based on https://www.webopedia.com/TERM/N/network.html]"@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:dstPayload ;
+			sh:path uco-observable:dstPayload ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:srcPayload ;
+			sh:path uco-observable:srcPayload ;
 		] ,
 		[
-			sh:class types:Dictionary ;
+			sh:class uco-types:Dictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:ipfix ;
+			sh:path uco-observable:ipfix ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dstBytes ;
+			sh:path uco-observable:dstBytes ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dstPackets ;
+			sh:path uco-observable:dstPackets ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:srcBytes ;
+			sh:path uco-observable:srcBytes ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:srcPackets ;
+			sh:path uco-observable:srcPackets ;
 		]
 		;
-	sh:targetClass observable:NetworkFlowFacet ;
+	sh:targetClass uco-observable:NetworkFlowFacet ;
 	.
 
-observable:NetworkInterface
+uco-observable:NetworkInterface
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "NetworkInterface"@en ;
 	rdfs:comment "A network interface is a software or hardware interface between two pieces of equipment or protocol layers in a computer network."@en ;
-	sh:targetClass observable:NetworkInterface ;
+	sh:targetClass uco-observable:NetworkInterface ;
 	.
 
-observable:NetworkInterfaceFacet
+uco-observable:NetworkInterfaceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "NetworkInterfaceFacet"@en ;
 	rdfs:comment "A network interface facet is a grouping of characteristics unique to a software or hardware interface between two pieces of equipment or protocol layers in a computer network."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:macAddress ;
+			sh:path uco-observable:macAddress ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:dhcpServer ;
+			sh:path uco-observable:dhcpServer ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:ip ;
+			sh:path uco-observable:ip ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:ipGateway ;
+			sh:path uco-observable:ipGateway ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dhcpLeaseExpires ;
+			sh:path uco-observable:dhcpLeaseExpires ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dhcpLeaseObtained ;
+			sh:path uco-observable:dhcpLeaseObtained ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:adapterName ;
+			sh:path uco-observable:adapterName ;
 		]
 		;
-	sh:targetClass observable:NetworkInterfaceFacet ;
+	sh:targetClass uco-observable:NetworkInterfaceFacet ;
 	.
 
-observable:NetworkProtocol
+uco-observable:NetworkProtocol
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "NetworkProtocol"@en ;
 	rdfs:comment "A network protocol is an established set of structured rules that determine how data is transmitted between different devices in the same network. Essentially, it allows connected devices to communicate with each other, regardless of any differences in their internal processes, structure or design. [based on https://www.comptia.org/content/guides/what-is-a-network-protocol]"@en ;
-	sh:targetClass observable:NetworkProtocol ;
+	sh:targetClass uco-observable:NetworkProtocol ;
 	.
 
-observable:NetworkRoute
+uco-observable:NetworkRoute
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "NetworkRoute"@en ;
 	rdfs:comment "A network route is a specific path (of specific network nodes, connections and protocols) for traffic in a network or between or across multiple networks."@en ;
-	sh:targetClass observable:NetworkRoute ;
+	sh:targetClass uco-observable:NetworkRoute ;
 	.
 
-observable:NetworkSocketAddressFamily
+uco-observable:NetworkSocketAddressFamily
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -4799,7 +4799,7 @@ observable:NetworkSocketAddressFamily
 	] ;
 	.
 
-observable:NetworkSocketProtocolFamily
+uco-observable:NetworkSocketProtocolFamily
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -4833,7 +4833,7 @@ observable:NetworkSocketProtocolFamily
 	] ;
 	.
 
-observable:NetworkSocketType
+uco-observable:NetworkSocketType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -4847,98 +4847,98 @@ observable:NetworkSocketType
 	] ;
 	.
 
-observable:NetworkSubnet
+uco-observable:NetworkSubnet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "NetworkSubnet"@en ;
 	rdfs:comment "A network subnet is a logical subdivision of an IP network. [based on https://en.wikipedia.org/wiki/Subnetwork]"@en ;
-	sh:targetClass observable:NetworkSubnet ;
+	sh:targetClass uco-observable:NetworkSubnet ;
 	.
 
-observable:Note
+uco-observable:Note
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Note"@en ;
 	rdfs:comment "A note is a brief textual record."@en ;
-	sh:targetClass observable:Note ;
+	sh:targetClass uco-observable:Note ;
 	.
 
-observable:NoteFacet
+uco-observable:NoteFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "NoteFacet"@en ;
 	rdfs:comment "A note facet is a grouping of characteristics unique to a brief textual record."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:modifiedTime ;
+			sh:path uco-observable:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:text ;
+			sh:path uco-observable:text ;
 		]
 		;
-	sh:targetClass observable:NoteFacet ;
+	sh:targetClass uco-observable:NoteFacet ;
 	.
 
-observable:Observable
+uco-observable:Observable
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Observable"@en ;
 	rdfs:comment "An observable is a characterizable item or action within the digital domain."@en ;
-	sh:targetClass observable:Observable ;
+	sh:targetClass uco-observable:Observable ;
 	.
 
-observable:ObservableAction
+uco-observable:ObservableAction
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		action:Action ,
-		observable:Observable
+		uco-action:Action ,
+		uco-observable:Observable
 		;
 	rdfs:label "ObservableAction"@en ;
 	rdfs:comment "An observable action is a grouping of characteristics unique to something that may be done or performed within the digital domain."@en ;
-	sh:targetClass observable:ObservableAction ;
+	sh:targetClass uco-observable:ObservableAction ;
 	.
 
-observable:ObservableObject
+uco-observable:ObservableObject
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		core:Item ,
-		observable:Observable
+		uco-core:Item ,
+		uco-observable:Observable
 		;
 	rdfs:label "ObservableObject"@en ;
 	rdfs:comment "An observable object is a grouping of characteristics unique to a distinct article or unit within the digital domain."@en ;
@@ -4947,63 +4947,63 @@ observable:ObservableObject
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:hasChanged ;
+			sh:path uco-observable:hasChanged ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:state ;
+			sh:path uco-observable:state ;
 		]
 		;
-	sh:targetClass observable:ObservableObject ;
+	sh:targetClass uco-observable:ObservableObject ;
 	.
 
-observable:ObservablePattern
+uco-observable:ObservablePattern
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Observable ;
+	rdfs:subClassOf uco-observable:Observable ;
 	rdfs:label "ObservablePattern"@en ;
 	rdfs:comment "An observable pattern is a grouping of characteristics unique to a logical pattern composed of observable object and observable action properties."@en ;
-	sh:targetClass observable:ObservablePattern ;
+	sh:targetClass uco-observable:ObservablePattern ;
 	.
 
-observable:ObservableRelationship
+uco-observable:ObservableRelationship
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		core:Relationship ,
-		observable:Observable
+		uco-core:Relationship ,
+		uco-observable:Observable
 		;
 	rdfs:label "ObservableRelationship"@en ;
 	rdfs:comment "An observable relationship is a grouping of characteristics unique to an assertion of an association between two observable objects."@en ;
 	sh:property
 		[
-			sh:class observable:Observable ;
+			sh:class uco-observable:Observable ;
 			sh:message "The source on an ObservableRelationship is expected to be typed as an Observable, and the noted value node is not.  This will be an error in UCO 2.0.0."@en ;
-			sh:path core:source ;
+			sh:path uco-core:source ;
 			sh:severity sh:Warning ;
 		] ,
 		[
-			sh:class observable:Observable ;
+			sh:class uco-observable:Observable ;
 			sh:message "The target on an ObservableRelationship is expected to be typed as an Observable, and the noted value node is not.  This will be an error in UCO 2.0.0."@en ;
-			sh:path core:target ;
+			sh:path uco-core:target ;
 			sh:severity sh:Warning ;
 		]
 		;
-	sh:targetClass observable:ObservableRelationship ;
+	sh:targetClass uco-observable:ObservableRelationship ;
 	.
 
-observable:Observation
+uco-observable:Observation
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf action:Action ;
+	rdfs:subClassOf uco-action:Action ;
 	rdfs:label "Observation"@en ;
 	rdfs:comment "An observation is a temporal perception of an observable."@en ;
 	sh:property [
@@ -5012,510 +5012,510 @@ observable:Observation
 		sh:maxCount "1"^^xsd:integer ;
 		sh:minCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path core:name ;
+		sh:path uco-core:name ;
 	] ;
-	sh:targetClass observable:Observation ;
+	sh:targetClass uco-observable:Observation ;
 	.
 
-observable:OnlineService
+uco-observable:OnlineService
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "OnlineService"@en ;
 	rdfs:comment "An online service is a particular provision mechanism of information access, distribution or manipulation over the Internet."@en ;
-	sh:targetClass observable:OnlineService ;
+	sh:targetClass uco-observable:OnlineService ;
 	.
 
-observable:OnlineServiceFacet
+uco-observable:OnlineServiceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "OnlineServiceFacet"@en-US ;
 	rdfs:comment "An online service facet is a grouping of characteristics unique to a particular provision mechanism of information access, distribution or manipulation over the Internet."@en-US ;
 	sh:property
 		[
-			sh:class location:Location ;
+			sh:class uco-location:Location ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:location ;
+			sh:path uco-observable:location ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:inetLocation ;
+			sh:path uco-observable:inetLocation ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:name ;
+			sh:path uco-core:name ;
 		]
 		;
-	sh:targetClass observable:OnlineServiceFacet ;
+	sh:targetClass uco-observable:OnlineServiceFacet ;
 	.
 
-observable:OperatingSystem
+uco-observable:OperatingSystem
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "OperatingSystem"@en ;
 	rdfs:comment "An operating system is the software that manages computer hardware, software resources, and provides common services for computer programs. [based on https://en.wikipedia.org/wiki/Operating_system]"@en ;
 	rdfs:seeAlso [
 		a sh:NodeShape ;
 		rdfs:comment "This anonymous shape is attached with rdfs:seeAlso in order to associate a warning-severity class constraint, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
-		sh:class observable:Software ;
+		sh:class uco-observable:Software ;
 		sh:message "In UCO 2.0.0, uco-observable:OperatingSystem will be a subclass of uco-observable:Software.  In preparation for UCO 2.0.0, the additional type uco-observable:Software should be assigned to this node."@en ;
 		sh:severity sh:Warning ;
-		sh:targetClass observable:OperatingSystem ;
+		sh:targetClass uco-observable:OperatingSystem ;
 	] ;
-	sh:targetClass observable:OperatingSystem ;
+	sh:targetClass uco-observable:OperatingSystem ;
 	.
 
-observable:OperatingSystemFacet
+uco-observable:OperatingSystemFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "OperatingSystemFacet"@en ;
 	rdfs:comment "An operating system facet is a grouping of characteristics unique to the software that manages computer hardware, software resources, and provides common services for computer programs. [based on https://en.wikipedia.org/wiki/Operating_system]"@en ;
 	sh:property
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:manufacturer ;
+			sh:path uco-observable:manufacturer ;
 		] ,
 		[
-			sh:class types:Dictionary ;
+			sh:class uco-types:Dictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:environmentVariables ;
+			sh:path uco-observable:environmentVariables ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isLimitAdTrackingEnabled ;
+			sh:path uco-observable:isLimitAdTrackingEnabled ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:installDate ;
+			sh:path uco-observable:installDate ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:bitness ;
+			sh:path uco-observable:bitness ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:advertisingID ;
+			sh:path uco-observable:advertisingID ;
 		] ,
 		[
 			sh:maxCount "0"^^xsd:integer ;
 			sh:message "In UCO 2.0.0, uco-observable:manufacturer will not be associated with uco-observable:OperatingSystemFacet.  Please place this on a uco-observable:SoftwareFacet instead."@en ;
-			sh:path observable:manufacturer ;
+			sh:path uco-observable:manufacturer ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "0"^^xsd:integer ;
 			sh:message "In UCO 2.0.0, uco-observable:version will not be associated with uco-observable:OperatingSystemFacet.  Please place this on a uco-observable:SoftwareFacet instead."@en ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 			sh:severity sh:Warning ;
 		]
 		;
-	sh:targetClass observable:OperatingSystemFacet ;
+	sh:targetClass uco-observable:OperatingSystemFacet ;
 	.
 
-observable:PDFFile
+uco-observable:PDFFile
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:File ;
+	rdfs:subClassOf uco-observable:File ;
 	rdfs:label "PDFFile"@en ;
 	rdfs:comment "A PDF file is a Portable Document Format (PDF) file."@en ;
-	sh:targetClass observable:PDFFile ;
+	sh:targetClass uco-observable:PDFFile ;
 	.
 
-observable:PDFFileFacet
+uco-observable:PDFFileFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "PDFFileFacet"@en ;
 	rdfs:comment "A PDF file facet is a grouping of characteristics unique to a PDF (Portable Document Format) file."@en ;
 	sh:property
 		[
-			sh:class types:ControlledDictionary ;
+			sh:class uco-types:ControlledDictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:documentInformationDictionary ;
+			sh:path uco-observable:documentInformationDictionary ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isOptimized ;
+			sh:path uco-observable:isOptimized ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pdfCreationDate ;
+			sh:path uco-observable:pdfCreationDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pdfModDate ;
+			sh:path uco-observable:pdfModDate ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pdfId1 ;
+			sh:path uco-observable:pdfId1 ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pdfId0 ;
+			sh:path uco-observable:pdfId0 ;
 		]
 		;
-	sh:targetClass observable:PDFFileFacet ;
+	sh:targetClass uco-observable:PDFFileFacet ;
 	.
 
-observable:PIN
+uco-observable:PIN
 	a owl:DatatypeProperty ;
 	rdfs:label "PIN"@en ;
 	rdfs:comment "Personal Identification Number (PIN)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:PUK
+uco-observable:PUK
 	a owl:DatatypeProperty ;
 	rdfs:label "PUK"@en ;
 	rdfs:comment "Personal Unlocking Key (PUK) to unlock the SIM card."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:PathRelationFacet
+uco-observable:PathRelationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "PathRelationFacet"@en ;
 	rdfs:comment "A path relation facet is a grouping of characteristics unique to the location of one object within another containing object."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:path ;
+		sh:path uco-observable:path ;
 	] ;
-	sh:targetClass observable:PathRelationFacet ;
+	sh:targetClass uco-observable:PathRelationFacet ;
 	.
 
-observable:PaymentCard
+uco-observable:PaymentCard
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "PaymentCard"@en ;
 	rdfs:comment "A payment card is a physical token that is part of a payment system issued by financial institutions, such as a bank, to a customer that enables its owner (the cardholder) to access the funds in the customer's designated bank accounts, or through a credit account and make payments by electronic funds transfer and access automated teller machines (ATMs). [based on https://en.wikipedia.org/wiki/Payment_card]"@en ;
-	sh:targetClass observable:PaymentCard ;
+	sh:targetClass uco-observable:PaymentCard ;
 	.
 
-observable:PhoneAccount
+uco-observable:PhoneAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "PhoneAccount"@en ;
 	rdfs:comment "A phone account is an arrangement with an entity to enable and control the provision of a telephony capability or service."@en ;
-	sh:targetClass observable:PhoneAccount ;
+	sh:targetClass uco-observable:PhoneAccount ;
 	.
 
-observable:PhoneAccountFacet
+uco-observable:PhoneAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "PhoneAccountFacet"@en ;
 	rdfs:comment "A phone account facet is a grouping of characteristics unique to an arrangement with an entity to enable and control the provision of a telephony capability or service."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:phoneNumber ;
+		sh:path uco-observable:phoneNumber ;
 	] ;
-	sh:targetClass observable:PhoneAccountFacet ;
+	sh:targetClass uco-observable:PhoneAccountFacet ;
 	.
 
-observable:Pipe
+uco-observable:Pipe
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Pipe"@en ;
 	rdfs:comment "A pipe is a mechanism for one-way inter-process communication using message passing where data written by one process is buffered by the operating system until it is read by the next process, and this uni-directional channel disappears when the processes are completed. [based on https://en.wikipedia.org/wiki/Pipeline_(Unix) ; https://en.wikipedia.org/wiki/Anonymous_pipe]"@en ;
-	sh:targetClass observable:Pipe ;
+	sh:targetClass uco-observable:Pipe ;
 	.
 
-observable:Post
+uco-observable:Post
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Message ;
+	rdfs:subClassOf uco-observable:Message ;
 	rdfs:label "Post"@en ;
 	rdfs:comment "A post is message submitted to an online discussion/publishing site (forum, blog, etc.)."@en ;
-	sh:targetClass observable:Post ;
+	sh:targetClass uco-observable:Post ;
 	.
 
-observable:Process
+uco-observable:Process
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Process"@en ;
 	rdfs:comment "A process is an instance of a computer program executed on an operating system."@en ;
-	sh:targetClass observable:Process ;
+	sh:targetClass uco-observable:Process ;
 	.
 
-observable:ProcessFacet
+uco-observable:ProcessFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ProcessFacet"@en ;
 	rdfs:comment "A process facet is a grouping of characteristics unique to an instance of a computer program executed on an operating system."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:binary ;
+			sh:path uco-observable:binary ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:creatorUser ;
+			sh:path uco-observable:creatorUser ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:parent ;
+			sh:path uco-observable:parent ;
 		] ,
 		[
-			sh:class types:Dictionary ;
+			sh:class uco-types:Dictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:environmentVariables ;
+			sh:path uco-observable:environmentVariables ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isHidden ;
+			sh:path uco-observable:isHidden ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:exitTime ;
+			sh:path uco-observable:exitTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:exitStatus ;
+			sh:path uco-observable:exitStatus ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pid ;
+			sh:path uco-observable:pid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:currentWorkingDirectory ;
+			sh:path uco-observable:currentWorkingDirectory ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:status ;
+			sh:path uco-observable:status ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:arguments ;
+			sh:path uco-observable:arguments ;
 		]
 		;
-	sh:targetClass observable:ProcessFacet ;
+	sh:targetClass uco-observable:ProcessFacet ;
 	.
 
-observable:ProcessThread
+uco-observable:ProcessThread
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "ProcessThread"@en ;
 	rdfs:comment "A process thread is the smallest sequence of programmed instructions that can be managed independently by a scheduler on a computer, which is typically a part of the operating system. It is a component of a process. Multiple threads can exist within one process, executing concurrently and sharing resources such as memory, while different processes do not share these resources. In particular, the threads of a process share its executable code and the values of its dynamically allocated variables and non-thread-local global variables at any given time. [based on https://en.wikipedia.org/wiki/Thread_(computing)]"@en ;
-	sh:targetClass observable:ProcessThread ;
+	sh:targetClass uco-observable:ProcessThread ;
 	.
 
-observable:Profile
+uco-observable:Profile
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Profile"@en ;
 	rdfs:comment "A profile is an explicit digital representation of identity and characteristics of the owner of a single user account associated with an online service or application. [based on https://en.wikipedia.org/wiki/User_profile]"@en ;
-	sh:targetClass observable:Profile ;
+	sh:targetClass uco-observable:Profile ;
 	.
 
-observable:ProfileFacet
+uco-observable:ProfileFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "ProfileFacet"@en-US ;
 	rdfs:comment "A profile facet is a grouping of characteristics unique to an explicit digital representation of identity and characteristics of the owner of a single user account associated with an online service or application. [based on https://en.wikipedia.org/wiki/User_profile]"@en-US ;
 	sh:property
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileIdentity ;
+			sh:path uco-observable:profileIdentity ;
 		] ,
 		[
-			sh:class observable:ContactAddress ;
+			sh:class uco-observable:ContactAddress ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactAddress ;
+			sh:path uco-observable:contactAddress ;
 		] ,
 		[
-			sh:class observable:ContactEmail ;
+			sh:class uco-observable:ContactEmail ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactEmail ;
+			sh:path uco-observable:contactEmail ;
 		] ,
 		[
-			sh:class observable:ContactMessaging ;
+			sh:class uco-observable:ContactMessaging ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactMessaging ;
+			sh:path uco-observable:contactMessaging ;
 		] ,
 		[
-			sh:class observable:ContactPhone ;
+			sh:class uco-observable:ContactPhone ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactPhone ;
+			sh:path uco-observable:contactPhone ;
 		] ,
 		[
-			sh:class observable:ContactURL ;
+			sh:class uco-observable:ContactURL ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactURL ;
+			sh:path uco-observable:contactURL ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileAccount ;
+			sh:path uco-observable:profileAccount ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileService ;
+			sh:path uco-observable:profileService ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileWebsite ;
+			sh:path uco-observable:profileWebsite ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:profileCreated ;
+			sh:path uco-observable:profileCreated ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:name ;
+			sh:path uco-core:name ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:displayName ;
+			sh:path uco-observable:displayName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:profileLanguage ;
+			sh:path uco-observable:profileLanguage ;
 		]
 		;
-	sh:targetClass observable:ProfileFacet ;
+	sh:targetClass uco-observable:ProfileFacet ;
 	.
 
-observable:PropertiesEnumeratedEffectFacet
+uco-observable:PropertiesEnumeratedEffectFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		core:Facet ,
-		observable:DefinedEffectFacet
+		uco-core:Facet ,
+		uco-observable:DefinedEffectFacet
 		;
 	rdfs:label "PropertiesEnumeratedEffectFacet"@en ;
 	rdfs:comment "A properties enumerated effect facet is a grouping of characteristics unique to the effects of actions upon observable objects where a characteristic of the observable object is enumerated. An example of this would be startup parameters for a process."@en ;
@@ -5523,17 +5523,17 @@ observable:PropertiesEnumeratedEffectFacet
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:properties ;
+		sh:path uco-observable:properties ;
 	] ;
-	sh:targetClass observable:PropertiesEnumeratedEffectFacet ;
+	sh:targetClass uco-observable:PropertiesEnumeratedEffectFacet ;
 	.
 
-observable:PropertyReadEffectFacet
+uco-observable:PropertyReadEffectFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DefinedEffectFacet ;
+	rdfs:subClassOf uco-observable:DefinedEffectFacet ;
 	rdfs:label "PropertyReadEffectFacet"@en ;
 	rdfs:comment "A properties read effect facet is a grouping of characteristics unique to the effects of actions upon observable objects where a characteristic is read from an observable object. An example of this would be the current running state of a process."@en ;
 	sh:property
@@ -5541,150 +5541,150 @@ observable:PropertyReadEffectFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:propertyName ;
+			sh:path uco-observable:propertyName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:value ;
+			sh:path uco-observable:value ;
 		]
 		;
-	sh:targetClass observable:PropertyReadEffectFacet ;
+	sh:targetClass uco-observable:PropertyReadEffectFacet ;
 	.
 
-observable:ProtocolConverter
+uco-observable:ProtocolConverter
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "ProtocolConverter"@en-US ;
 	rdfs:comment "A protocol converter is a device that converts from one protocol to another (e.g. SD to USB, SATA to USB, etc."@en-US ;
-	sh:targetClass observable:ProtocolConverter ;
+	sh:targetClass uco-observable:ProtocolConverter ;
 	.
 
-observable:RasterPicture
+uco-observable:RasterPicture
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:File ;
+	rdfs:subClassOf uco-observable:File ;
 	rdfs:label "RasterPicture"@en ;
 	rdfs:comment "A raster picture is a raster (or bitmap) image."@en ;
-	sh:targetClass observable:RasterPicture ;
+	sh:targetClass uco-observable:RasterPicture ;
 	.
 
-observable:RasterPictureFacet
+uco-observable:RasterPictureFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "RasterPictureFacet"@en ;
 	rdfs:comment "A raster picture facet is a grouping of characteristics unique to a raster (or bitmap) image."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:camera ;
+			sh:path uco-observable:camera ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:bitsPerPixel ;
+			sh:path uco-observable:bitsPerPixel ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pictureHeight ;
+			sh:path uco-observable:pictureHeight ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pictureWidth ;
+			sh:path uco-observable:pictureWidth ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:imageCompressionMethod ;
+			sh:path uco-observable:imageCompressionMethod ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pictureType ;
+			sh:path uco-observable:pictureType ;
 		]
 		;
-	sh:targetClass observable:RasterPictureFacet ;
+	sh:targetClass uco-observable:RasterPictureFacet ;
 	.
 
-observable:RecoveredObject
+uco-observable:RecoveredObject
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "RecoveredObject"@en ;
 	rdfs:comment "An observable object that was the result of a recovery operation."@en ;
-	sh:targetClass observable:RecoveredObject ;
+	sh:targetClass uco-observable:RecoveredObject ;
 	.
 
-observable:RecoveredObjectFacet
+uco-observable:RecoveredObjectFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "RecoveredObjectFacet"@en ;
 	rdfs:comment "Recoverability status of name, metadata, and content."@en ;
 	sh:property
-		observable:RecoveredObjectFacet-contentRecoveredStatus-in-shape ,
-		observable:RecoveredObjectFacet-metadataRecoveredStatus-in-shape ,
-		observable:RecoveredObjectFacet-nameRecoveredStatus-in-shape ,
+		uco-observable:RecoveredObjectFacet-contentRecoveredStatus-in-shape ,
+		uco-observable:RecoveredObjectFacet-metadataRecoveredStatus-in-shape ,
+		uco-observable:RecoveredObjectFacet-nameRecoveredStatus-in-shape ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:contentRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:contentRecoveredStatus ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:contentRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:contentRecoveredStatus ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:metadataRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:metadataRecoveredStatus ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:metadataRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:metadataRecoveredStatus ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:nameRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:nameRecoveredStatus ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:nameRecoveredStatus should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:nameRecoveredStatus ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:contentRecoveredStatus ;
+			sh:path uco-observable:contentRecoveredStatus ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:metadataRecoveredStatus ;
+			sh:path uco-observable:metadataRecoveredStatus ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:nameRecoveredStatus ;
+			sh:path uco-observable:nameRecoveredStatus ;
 		]
 		;
-	sh:targetClass observable:RecoveredObjectFacet ;
+	sh:targetClass uco-observable:RecoveredObjectFacet ;
 	.
 
-observable:RecoveredObjectFacet-contentRecoveredStatus-in-shape
+uco-observable:RecoveredObjectFacet-contentRecoveredStatus-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"recovered"
@@ -5693,11 +5693,11 @@ observable:RecoveredObjectFacet-contentRecoveredStatus-in-shape
 		"unknown"
 	) ;
 	sh:message "Value is not member of the vocabulary RecoveredObjectStatusVocab." ;
-	sh:path observable:contentRecoveredStatus ;
+	sh:path uco-observable:contentRecoveredStatus ;
 	sh:severity sh:Info ;
 	.
 
-observable:RecoveredObjectFacet-metadataRecoveredStatus-in-shape
+uco-observable:RecoveredObjectFacet-metadataRecoveredStatus-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"recovered"
@@ -5706,11 +5706,11 @@ observable:RecoveredObjectFacet-metadataRecoveredStatus-in-shape
 		"unknown"
 	) ;
 	sh:message "Value is not member of the vocabulary RecoveredObjectStatusVocab." ;
-	sh:path observable:metadataRecoveredStatus ;
+	sh:path uco-observable:metadataRecoveredStatus ;
 	sh:severity sh:Info ;
 	.
 
-observable:RecoveredObjectFacet-nameRecoveredStatus-in-shape
+uco-observable:RecoveredObjectFacet-nameRecoveredStatus-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"recovered"
@@ -5719,11 +5719,11 @@ observable:RecoveredObjectFacet-nameRecoveredStatus-in-shape
 		"unknown"
 	) ;
 	sh:message "Value is not member of the vocabulary RecoveredObjectStatusVocab." ;
-	sh:path observable:nameRecoveredStatus ;
+	sh:path uco-observable:nameRecoveredStatus ;
 	sh:severity sh:Info ;
 	.
 
-observable:RegistryDatatype
+uco-observable:RegistryDatatype
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -5745,506 +5745,506 @@ observable:RegistryDatatype
 	] ;
 	.
 
-observable:ReparsePoint
+uco-observable:ReparsePoint
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "ReparsePoint"@en ;
 	rdfs:comment "A reparse point is a type of NTFS (New Technology File System) object which is an optional attribute of files and directories meant to define some sort of preprocessing before accessing the said file or directory. For instance reparse points can be used to redirect access to files which have been moved to long term storage so that some application would retrieve them and make them directly accessible. A reparse point contains a reparse tag and data that are interpreted by a filesystem filter identified by the tag. [based on https://jp-andre.pagesperso-orange.fr/junctions.html ; https://en.wikipedia.org/wiki/NTFS_reparse_point]"@en ;
-	sh:targetClass observable:ReparsePoint ;
+	sh:targetClass uco-observable:ReparsePoint ;
 	.
 
-observable:SIMCard
+uco-observable:SIMCard
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "SIMCard" ;
 	rdfs:comment "A SIM card is a subscriber identification module card intended to securely store the international mobile subscriber identity (IMSI) number and its related key, which are used to identify and authenticate subscribers on mobile telephony. [based on https://en.wikipedia.org/wiki/SIM_card]"@en ;
-	sh:targetClass observable:SIMCard ;
+	sh:targetClass uco-observable:SIMCard ;
 	.
 
-observable:SIMCardFacet
+uco-observable:SIMCardFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "SIMCardFacet"@en ;
 	rdfs:comment "A SIM card facet is a grouping of characteristics unique to a subscriber identification module card intended to securely store the international mobile subscriber identity (IMSI) number and its related key, which are used to identify and authenticate subscribers on mobile telephony devices (such as mobile phones and computers). [based on https://en.wikipedia.org/wiki/SIM_card]"@en ;
 	sh:property
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:carrier ;
+			sh:path uco-observable:carrier ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:storageCapacityInBytes ;
+			sh:path uco-observable:storageCapacityInBytes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ICCID ;
+			sh:path uco-observable:ICCID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:IMSI ;
+			sh:path uco-observable:IMSI ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:PIN ;
+			sh:path uco-observable:PIN ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:PUK ;
+			sh:path uco-observable:PUK ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:SIMForm ;
+			sh:path uco-observable:SIMForm ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:SIMType ;
+			sh:path uco-observable:SIMType ;
 		]
 		;
-	sh:targetClass observable:SIMCardFacet ;
+	sh:targetClass uco-observable:SIMCardFacet ;
 	.
 
-observable:SIMForm
+uco-observable:SIMForm
 	a owl:DatatypeProperty ;
 	rdfs:label "SIMForm"@en ;
 	rdfs:comment "The form of SIM card such as SIM, Micro SIM, Nano SIM."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:SIMType
+uco-observable:SIMType
 	a owl:DatatypeProperty ;
 	rdfs:label "SIMType"@en ;
 	rdfs:comment "The type of SIM card such as SIM, USIM, UICC."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:SIPAddress
+uco-observable:SIPAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddress ;
+	rdfs:subClassOf uco-observable:DigitalAddress ;
 	rdfs:label "SIPAddress"@en ;
 	rdfs:comment "A SIP address is an identifier for Session Initiation Protocol (SIP) communication."@en ;
-	sh:targetClass observable:SIPAddress ;
+	sh:targetClass uco-observable:SIPAddress ;
 	.
 
-observable:SIPAddressFacet
+uco-observable:SIPAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAddressFacet ;
+	rdfs:subClassOf uco-observable:DigitalAddressFacet ;
 	rdfs:label "SIPAddressFacet"@en ;
 	rdfs:comment "A SIP address facet is a grouping of characteristics unique to a Session Initiation Protocol (SIP) standards conformant identifier assigned to a user to enable routing and management of SIP standards conformant communication to or from that user loosely coupled from any particular devices."@en ;
-	sh:targetClass observable:SIPAddressFacet ;
+	sh:targetClass uco-observable:SIPAddressFacet ;
 	.
 
-observable:SMSMessage
+uco-observable:SMSMessage
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Message ;
+	rdfs:subClassOf uco-observable:Message ;
 	rdfs:label "SMSMessage"@en ;
 	rdfs:comment "An SMS message is a message conformant to the short message service (SMS) communication protocol standards."@en ;
-	sh:targetClass observable:SMSMessage ;
+	sh:targetClass uco-observable:SMSMessage ;
 	.
 
-observable:SMSMessageFacet
+uco-observable:SMSMessageFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "SMSMessageFacet"@en ;
 	rdfs:comment "A SMS message facet is a grouping of characteristics unique to a message conformant to the short message service (SMS) communication protocol standards."@en ;
 	sh:property [
 		sh:datatype xsd:boolean ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:isRead ;
+		sh:path uco-observable:isRead ;
 	] ;
-	sh:targetClass observable:SMSMessageFacet ;
+	sh:targetClass uco-observable:SMSMessageFacet ;
 	.
 
-observable:SQLiteBlob
+uco-observable:SQLiteBlob
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "SQLiteBlob"@en ;
 	rdfs:comment "An SQLite blob is a blob (binary large object) of data within an SQLite database. [based on https://en.wikipedia.org/wiki/SQLite]"@en ;
-	sh:targetClass observable:SQLiteBlob ;
+	sh:targetClass uco-observable:SQLiteBlob ;
 	.
 
-observable:SQLiteBlobFacet
+uco-observable:SQLiteBlobFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "SQLiteBlobFacet"@en ;
 	rdfs:comment "An SQLite blob facet is a grouping of characteristics unique to a blob (binary large object) of data within an SQLite database. [based on https://en.wikipedia.org/wiki/SQLite]"@en ;
 	sh:property
 		[
 			sh:datatype xsd:positiveInteger ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:rowIndex ;
+			sh:path uco-observable:rowIndex ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:columnName ;
+			sh:path uco-observable:columnName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:rowCondition ;
+			sh:path uco-observable:rowCondition ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:tableName ;
+			sh:path uco-observable:tableName ;
 		]
 		;
-	sh:targetClass observable:SQLiteBlobFacet ;
+	sh:targetClass uco-observable:SQLiteBlobFacet ;
 	.
 
-observable:SecurityAppliance
+uco-observable:SecurityAppliance
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Appliance ;
+	rdfs:subClassOf uco-observable:Appliance ;
 	rdfs:label "SecurityAppliance"@en ;
 	rdfs:comment "A security appliance is a purpose-built computer with software or firmware that is designed to provide a specific security function to protect computer networks."@en ;
-	sh:targetClass observable:SecurityAppliance ;
+	sh:targetClass uco-observable:SecurityAppliance ;
 	.
 
-observable:Semaphore
+uco-observable:Semaphore
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Semaphore"@en ;
 	rdfs:comment "A semaphore is a variable or abstract data type used to control access to a common resource by multiple processes and avoid critical section problems in a concurrent system such as a multitasking operating system. [based on https://en.wikipedia.org/wiki/Semaphore_(programming)]"@en ;
-	sh:targetClass observable:Semaphore ;
+	sh:targetClass uco-observable:Semaphore ;
 	.
 
-observable:SendControlCodeEffectFacet
+uco-observable:SendControlCodeEffectFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DefinedEffectFacet ;
+	rdfs:subClassOf uco-observable:DefinedEffectFacet ;
 	rdfs:label "SendControlCodeEffectFacet"@en ;
 	rdfs:comment "A send control code effect facet is a grouping of characteristics unique to the effects of actions upon observable objects where a control code, or other control-oriented communication signal, is sent to the observable object. An example of this would be an action sending a control code changing the running state of a process."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:controlCode ;
+		sh:path uco-observable:controlCode ;
 	] ;
-	sh:targetClass observable:SendControlCodeEffectFacet ;
+	sh:targetClass uco-observable:SendControlCodeEffectFacet ;
 	.
 
-observable:Server
+uco-observable:Server
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Computer ;
+	rdfs:subClassOf uco-observable:Computer ;
 	rdfs:label "Server"@en-US ;
 	rdfs:comment "A server is a server rack-mount based computer, minicomputer, supercomputer, etc."@en-US ;
-	sh:targetClass observable:Server ;
+	sh:targetClass uco-observable:Server ;
 	.
 
-observable:ShopListing
+uco-observable:ShopListing
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "ShopListing"@en ;
 	rdfs:comment "A shop listing is a listing of offered products on an online marketplace/shop."@en ;
-	sh:targetClass observable:ShopListing ;
+	sh:targetClass uco-observable:ShopListing ;
 	.
 
-observable:SmartDevice
+uco-observable:SmartDevice
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "SmartDevice"@en-US ;
 	rdfs:comment "A smart device is a microprocessor IoT device that is expected to be connected directly to cloud-based networks or via smartphone"@en-US ;
-	sh:targetClass observable:SmartDevice ;
+	sh:targetClass uco-observable:SmartDevice ;
 	.
 
-observable:SmartPhone
+uco-observable:SmartPhone
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		observable:Computer ,
-		observable:MobilePhone ,
-		observable:SmartDevice
+		uco-observable:Computer ,
+		uco-observable:MobilePhone ,
+		uco-observable:SmartDevice
 		;
 	rdfs:label "SmartPhone"@en-US ;
 	rdfs:comment "A smartphone is a portable device that combines mobile telephone and computing functions into one unit.  Examples include iPhone, Samsung Galaxy, Huawei, Blackberry. (Inferred by model and OperatingSystemFacet)"@en-US ;
-	sh:targetClass observable:SmartPhone ;
+	sh:targetClass uco-observable:SmartPhone ;
 	.
 
-observable:Snapshot
+uco-observable:Snapshot
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "Snapshot"@en ;
 	rdfs:comment "A snapshot is a file system object representing a snapshot of the contents of a part of a file system at a point in time."@en ;
-	sh:targetClass observable:Snapshot ;
+	sh:targetClass uco-observable:Snapshot ;
 	.
 
-observable:Socket
+uco-observable:Socket
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "Socket"@en ;
 	rdfs:comment "A socket is a special file used for inter-process communication, which enables communication between two processes. In addition to sending data, processes can send file descriptors across a Unix domain socket connection using the sendmsg() and recvmsg() system calls. Unlike named pipes which allow only unidirectional data flow, sockets are fully duplex-capable. [based on https://en.wikipedia.org/wiki/Unix_file_types]"@en ;
-	sh:targetClass observable:Socket ;
+	sh:targetClass uco-observable:Socket ;
 	.
 
-observable:SocketAddress
+uco-observable:SocketAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Address ;
+	rdfs:subClassOf uco-observable:Address ;
 	rdfs:label "SocketAddress"@en ;
 	rdfs:comment "A socket address (combining and IP address and a port number) is a composite identifier for a network socket endpoint supporting internet protocol communications."@en ;
-	sh:targetClass observable:SocketAddress ;
+	sh:targetClass uco-observable:SocketAddress ;
 	.
 
-observable:Software
+uco-observable:Software
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Software"@en ;
 	rdfs:comment "Software is a definitely scoped instance of a collection of data or computer instructions that tell the computer how to work. [based on https://en.wikipedia.org/wiki/Software]"@en ;
-	sh:targetClass observable:Software ;
+	sh:targetClass uco-observable:Software ;
 	.
 
-observable:SoftwareFacet
+uco-observable:SoftwareFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "SoftwareFacet"@en ;
 	rdfs:comment "A software facet is a grouping of characteristics unique to a software program (a definitively scoped instance of a collection of data or computer instructions that tell the computer how to work). [based on https://en.wikipedia.org/wiki/Software]"@en ;
 	sh:property
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:manufacturer ;
+			sh:path uco-observable:manufacturer ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:cpeid ;
+			sh:path uco-observable:cpeid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:language ;
+			sh:path uco-observable:language ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:swid ;
+			sh:path uco-observable:swid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 		]
 		;
-	sh:targetClass observable:SoftwareFacet ;
+	sh:targetClass uco-observable:SoftwareFacet ;
 	.
 
-observable:StateChangeEffectFacet
+uco-observable:StateChangeEffectFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DefinedEffectFacet ;
+	rdfs:subClassOf uco-observable:DefinedEffectFacet ;
 	rdfs:label "StateChangeEffectFacet"@en ;
 	rdfs:comment "A state change effect facet is a grouping of characteristics unique to the effects of actions upon observable objects where a state of the observable object is changed."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:newObject ;
+			sh:path uco-observable:newObject ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:oldObject ;
+			sh:path uco-observable:oldObject ;
 		]
 		;
-	sh:targetClass observable:StateChangeEffectFacet ;
+	sh:targetClass uco-observable:StateChangeEffectFacet ;
 	.
 
-observable:StorageMedium
+uco-observable:StorageMedium
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "StorageMedium"@en-US ;
 	rdfs:comment "A storage medium is any digital storage device that applies electromagnetic or optical surfaces, or depends solely on electronic circuits as solid state storage, for storing digital data. Examples include HDD (PATA), SATA, SSD, Optical, Memory_Card, Tape, etc"@en-US ;
-	sh:targetClass observable:StorageMedium ;
+	sh:targetClass uco-observable:StorageMedium ;
 	.
 
-observable:StorageMediumFacet
+uco-observable:StorageMediumFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "StorageMediumFacet"@en ;
 	rdfs:comment "A storage medium facet is a grouping of characteristics unique to a the storage capabilities of a piece of equipment or a mechanism designed to serve a special purpose or perform a special function."@en ;
 	sh:property [
 		sh:datatype xsd:integer ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:totalStorageCapacityInBytes ;
+		sh:path uco-observable:totalStorageCapacityInBytes ;
 	] ;
-	sh:targetClass observable:StorageMediumFacet ;
+	sh:targetClass uco-observable:StorageMediumFacet ;
 	.
 
-observable:SymbolicLink
+uco-observable:SymbolicLink
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:FileSystemObject ;
+	rdfs:subClassOf uco-observable:FileSystemObject ;
 	rdfs:label "SymbolicLink"@en ;
 	rdfs:comment "A symbolic link is a file that contains a reference to another file or directory in the form of an absolute or relative path and that affects pathname resolution. [based on https://en.wikipedia.org/wiki/Symbolic_link]"@en ;
-	sh:targetClass observable:SymbolicLink ;
+	sh:targetClass uco-observable:SymbolicLink ;
 	.
 
-observable:SymbolicLinkFacet
+uco-observable:SymbolicLinkFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "SymbolicLinkFacet"@en ;
 	rdfs:comment "A symbolic link facet is a grouping of characteristics unique to a file that contains a reference to another file or directory in the form of an absolute or relative path and that affects pathname resolution. [based on https://en.wikipedia.org/wiki/Symbolic_link]"@en ;
 	sh:property [
-		sh:class observable:ObservableObject ;
+		sh:class uco-observable:ObservableObject ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path observable:targetFile ;
+		sh:path uco-observable:targetFile ;
 	] ;
-	sh:targetClass observable:SymbolicLinkFacet ;
+	sh:targetClass uco-observable:SymbolicLinkFacet ;
 	.
 
-observable:TCPConnection
+uco-observable:TCPConnection
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:NetworkConnection ;
+	rdfs:subClassOf uco-observable:NetworkConnection ;
 	rdfs:label "TCPConnection"@en ;
 	rdfs:comment "A TCP connection is a network connection that is conformant to the Transfer "@en ;
-	sh:targetClass observable:TCPConnection ;
+	sh:targetClass uco-observable:TCPConnection ;
 	.
 
-observable:TCPConnectionFacet
+uco-observable:TCPConnectionFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "TCPConnectionFacet"@en ;
 	rdfs:comment "A TCP connection facet is a grouping of characteristics unique to portions of a network connection that are conformant to the Transmission Control Protocl (TCP) standard."@en ;
 	sh:property
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:destinationFlags ;
+			sh:path uco-observable:destinationFlags ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sourceFlags ;
+			sh:path uco-observable:sourceFlags ;
 		]
 		;
-	sh:targetClass observable:TCPConnectionFacet ;
+	sh:targetClass uco-observable:TCPConnectionFacet ;
 	.
 
-observable:TableField
+uco-observable:TableField
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "TableField"@en ;
 	rdfs:comment "A database table field and its associated value contained within a relational database."@en ;
-	sh:targetClass observable:TableField ;
+	sh:targetClass uco-observable:TableField ;
 	.
 
-observable:TableFieldFacet
+uco-observable:TableFieldFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "TableFieldFacet"@en ;
 	rdfs:comment "A database record facet contains properties associated with a specific table record value from a database."@en ;
 	sh:property
@@ -6252,25 +6252,25 @@ observable:TableFieldFacet
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:recordFieldIsNull ;
+			sh:path uco-observable:recordFieldIsNull ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:recordFieldName ;
+			sh:path uco-observable:recordFieldName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:tableName ;
+			sh:path uco-observable:tableName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:tableSchema ;
+			sh:path uco-observable:tableSchema ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
@@ -6289,7 +6289,7 @@ observable:TableFieldFacet
 					sh:datatype xsd:string ;
 				]
 			) ;
-			sh:path observable:recordFieldValue ;
+			sh:path uco-observable:recordFieldValue ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
@@ -6302,16 +6302,16 @@ observable:TableFieldFacet
 					sh:datatype xsd:string ;
 				]
 			) ;
-			sh:path observable:recordRowID ;
+			sh:path uco-observable:recordRowID ;
 		]
 		;
-	sh:targetClass observable:TableFieldFacet ;
+	sh:targetClass uco-observable:TableFieldFacet ;
 	sh:xone (
 		[
 			a sh:NodeShape ;
 			sh:property [
 				sh:hasValue "false"^^xsd:boolean ;
-				sh:path observable:recordFieldIsNull ;
+				sh:path uco-observable:recordFieldIsNull ;
 			] ;
 		]
 		[
@@ -6319,11 +6319,11 @@ observable:TableFieldFacet
 			sh:property
 				[
 					sh:hasValue "true"^^xsd:boolean ;
-					sh:path observable:recordFieldIsNull ;
+					sh:path uco-observable:recordFieldIsNull ;
 				] ,
 				[
 					sh:maxCount "0"^^xsd:integer ;
-					sh:path observable:recordFieldValue ;
+					sh:path uco-observable:recordFieldValue ;
 				]
 				;
 		]
@@ -6331,83 +6331,83 @@ observable:TableFieldFacet
 			a sh:NodeShape ;
 			sh:property [
 				sh:maxCount "0"^^xsd:integer ;
-				sh:path observable:recordFieldIsNull ;
+				sh:path uco-observable:recordFieldIsNull ;
 			] ;
 		]
 	) ;
 	.
 
-observable:Tablet
+uco-observable:Tablet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
-		observable:Computer ,
-		observable:MobileDevice ,
-		observable:SmartDevice
+		uco-observable:Computer ,
+		uco-observable:MobileDevice ,
+		uco-observable:SmartDevice
 		;
 	rdfs:label "Tablet"@en-US ;
 	rdfs:comment "A tablet is a mobile computer that is primarily operated by touching the screen. (Devices categorized by their manufacturer as a Tablet)"@en-US ;
-	sh:targetClass observable:Tablet ;
+	sh:targetClass uco-observable:Tablet ;
 	.
 
-observable:TaskActionType
+uco-observable:TaskActionType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "TaskActionType"@en ;
 	rdfs:comment "A task action type is a grouping of characteristics for a scheduled action to be completed."@en ;
 	sh:property
-		observable:TaskActionType-actionType-in-shape ,
+		uco-observable:TaskActionType-actionType-in-shape ,
 		[
-			sh:class observable:IComHandlerActionType ;
+			sh:class uco-observable:IComHandlerActionType ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:iComHandlerAction ;
+			sh:path uco-observable:iComHandlerAction ;
 		] ,
 		[
-			sh:class observable:IExecActionType ;
+			sh:class uco-observable:IExecActionType ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:iExecAction ;
+			sh:path uco-observable:iExecAction ;
 		] ,
 		[
-			sh:class observable:IShowMessageActionType ;
+			sh:class uco-observable:IShowMessageActionType ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:iShowMessageAction ;
+			sh:path uco-observable:iShowMessageAction ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:iEmailAction ;
+			sh:path uco-observable:iEmailAction ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:actionID ;
+			sh:path uco-observable:actionID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:actionType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:actionType ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:actionType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:actionType ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:actionType ;
+			sh:path uco-observable:actionType ;
 		]
 		;
-	sh:targetClass observable:TaskActionType ;
+	sh:targetClass uco-observable:TaskActionType ;
 	.
 
-observable:TaskActionType-actionType-in-shape
+uco-observable:TaskActionType-actionType-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"TASK_ACTION_COM_HANDLER"
@@ -6416,84 +6416,84 @@ observable:TaskActionType-actionType-in-shape
 		"TASK_ACTION_SHOW_MESSAGE"
 	) ;
 	sh:message "Value is not member of the vocabulary TaskActionTypeVocab." ;
-	sh:path observable:actionType ;
+	sh:path uco-observable:actionType ;
 	sh:severity sh:Info ;
 	.
 
-observable:TriggerType
+uco-observable:TriggerType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "TriggerType"@en ;
 	rdfs:comment "A trigger type is a grouping of characterizes unique to a set of criteria that, when met, starts the execution of a task within a Windows operating system. [based on https://docs.microsoft.com/en-us/windows/win32/taskschd/task-triggers]"@en ;
 	sh:property
-		observable:TriggerType-triggerFrequency-in-shape ,
-		observable:TriggerType-triggerType-in-shape ,
+		uco-observable:TriggerType-triggerFrequency-in-shape ,
+		uco-observable:TriggerType-triggerType-in-shape ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isEnabled ;
+			sh:path uco-observable:isEnabled ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerBeginTime ;
+			sh:path uco-observable:triggerBeginTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerEndTime ;
+			sh:path uco-observable:triggerEndTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerDelay ;
+			sh:path uco-observable:triggerDelay ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerMaxRunTime ;
+			sh:path uco-observable:triggerMaxRunTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerSessionChangeType ;
+			sh:path uco-observable:triggerSessionChangeType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:triggerFrequency should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:triggerFrequency ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:triggerFrequency should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:triggerFrequency ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:triggerType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:triggerType ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:triggerType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:triggerType ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerFrequency ;
+			sh:path uco-observable:triggerFrequency ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:triggerType ;
+			sh:path uco-observable:triggerType ;
 		]
 		;
-	sh:targetClass observable:TriggerType ;
+	sh:targetClass uco-observable:TriggerType ;
 	.
 
-observable:TriggerType-triggerFrequency-in-shape
+uco-observable:TriggerType-triggerFrequency-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"TASK_EVENT_TRIGGER_AT_LOGON"
@@ -6506,11 +6506,11 @@ observable:TriggerType-triggerFrequency-in-shape
 		"TASK_TIME_TRIGGER_WEEKLY"
 	) ;
 	sh:message "Value is not member of the vocabulary TriggerFrequencyVocab." ;
-	sh:path observable:triggerFrequency ;
+	sh:path uco-observable:triggerFrequency ;
 	sh:severity sh:Info ;
 	.
 
-observable:TriggerType-triggerType-in-shape
+uco-observable:TriggerType-triggerType-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"TASK_TRIGGER_BOOT"
@@ -6522,147 +6522,147 @@ observable:TriggerType-triggerType-in-shape
 		"TASK_TRIGGER_TIME"
 	) ;
 	sh:message "Value is not member of the vocabulary TriggerTypeVocab." ;
-	sh:path observable:triggerType ;
+	sh:path uco-observable:triggerType ;
 	sh:severity sh:Info ;
 	.
 
-observable:Tweet
+uco-observable:Tweet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Message ;
+	rdfs:subClassOf uco-observable:Message ;
 	rdfs:label "Tweet"@en ;
 	rdfs:comment "A tweet is message submitted by a Twitter user account to the Twitter microblogging platform."@en ;
-	sh:targetClass observable:Tweet ;
+	sh:targetClass uco-observable:Tweet ;
 	.
 
-observable:TwitterProfileFacet
+uco-observable:TwitterProfileFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "TwitterProfileFacet" ;
 	rdfs:comment "A twitter profile facet is a grouping of characteristics unique to an explicit digital representation of identity and characteristics of the owner of a single Twitter user account. [based on https://en.wikipedia.org/wiki/User_profile]" ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileBackgroundLocation ;
+			sh:path uco-observable:profileBackgroundLocation ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileBannerLocation ;
+			sh:path uco-observable:profileBannerLocation ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileImageLocation ;
+			sh:path uco-observable:profileImageLocation ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileBackgroundHash ;
+			sh:path uco-observable:profileBackgroundHash ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileBannerHash ;
+			sh:path uco-observable:profileBannerHash ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:profileImageHash ;
+			sh:path uco-observable:profileImageHash ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:profileIsProtected ;
+			sh:path uco-observable:profileIsProtected ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:profileIsVerified ;
+			sh:path uco-observable:profileIsVerified ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:listedCount ;
+			sh:path uco-observable:listedCount ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:favoritesCount ;
+			sh:path uco-observable:favoritesCount ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:followersCount ;
+			sh:path uco-observable:followersCount ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:friendsCount ;
+			sh:path uco-observable:friendsCount ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:statusesCount ;
+			sh:path uco-observable:statusesCount ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:twitterHandle ;
+			sh:path uco-observable:twitterHandle ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:twitterId ;
+			sh:path uco-observable:twitterId ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:userLocationString ;
+			sh:path uco-observable:userLocationString ;
 		]
 		;
-	sh:targetClass observable:TwitterProfileFacet ;
+	sh:targetClass uco-observable:TwitterProfileFacet ;
 	.
 
-observable:UNIXAccount
+uco-observable:UNIXAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "UNIXAccount"@en ;
 	rdfs:comment "A UNIX account is an account on a UNIX operating system."@en ;
-	sh:targetClass observable:UNIXAccount ;
+	sh:targetClass uco-observable:UNIXAccount ;
 	.
 
-observable:UNIXAccountFacet
+uco-observable:UNIXAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "UNIXAccountFacet"@en ;
 	rdfs:comment "A UNIX account facet is a grouping of characteristics unique to an account on a UNIX operating system."@en ;
 	sh:property
@@ -6670,80 +6670,80 @@ observable:UNIXAccountFacet
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:gid ;
+			sh:path uco-observable:gid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:shell ;
+			sh:path uco-observable:shell ;
 		]
 		;
-	sh:targetClass observable:UNIXAccountFacet ;
+	sh:targetClass uco-observable:UNIXAccountFacet ;
 	.
 
-observable:UNIXFile
+uco-observable:UNIXFile
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:File ;
+	rdfs:subClassOf uco-observable:File ;
 	rdfs:label "UNIXFile"@en ;
 	rdfs:comment "A UNIX file is a file pertaining to the UNIX operating system."@en ;
-	sh:targetClass observable:UNIXFile ;
+	sh:targetClass uco-observable:UNIXFile ;
 	.
 
-observable:UNIXFilePermissionsFacet
+uco-observable:UNIXFilePermissionsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "UNIXFilePermissionsFacet"@en ;
 	rdfs:comment "A UNIX file permissions facet is a grouping of characteristics unique to the access rights (e.g., view, change, navigate, execute) of a file on a UNIX file system."@en ;
-	sh:targetClass observable:UNIXFilePermissionsFacet ;
+	sh:targetClass uco-observable:UNIXFilePermissionsFacet ;
 	.
 
-observable:UNIXProcess
+uco-observable:UNIXProcess
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Process ;
+	rdfs:subClassOf uco-observable:Process ;
 	rdfs:label "UNIXProcess"@en ;
 	rdfs:comment "A UNIX process is an instance of a computer program executed on a UNIX operating system."@en ;
-	sh:targetClass observable:UNIXProcess ;
+	sh:targetClass uco-observable:UNIXProcess ;
 	.
 
-observable:UNIXProcessFacet
+uco-observable:UNIXProcessFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "UNIXProcessFacet"@en ;
 	rdfs:comment "A UNIX process facet is a grouping of characteristics unique to an instance of a computer program executed on a UNIX operating system."@en ;
 	sh:property
 		[
 			sh:datatype xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:openFileDescriptor ;
+			sh:path uco-observable:openFileDescriptor ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ruid ;
+			sh:path uco-observable:ruid ;
 		]
 		;
-	sh:targetClass observable:UNIXProcessFacet ;
+	sh:targetClass uco-observable:UNIXProcessFacet ;
 	.
 
-observable:UNIXVolumeFacet
+uco-observable:UNIXVolumeFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "UNIXVolumeFacet"@en ;
 	rdfs:comment "A UNIX volume facet is a grouping of characteristics unique to a single accessible storage area (volume) with a single UNIX file system. [based on https://en.wikipedia.org/wiki/Volume_(computing)]"@en ;
 	sh:property
@@ -6751,277 +6751,277 @@ observable:UNIXVolumeFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mountPoint ;
+			sh:path uco-observable:mountPoint ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:options ;
+			sh:path uco-observable:options ;
 		]
 		;
-	sh:targetClass observable:UNIXVolumeFacet ;
+	sh:targetClass uco-observable:UNIXVolumeFacet ;
 	.
 
-observable:URL
+uco-observable:URL
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "URL"@en ;
 	rdfs:comment "A URL is a uniform resource locator (URL) acting as a resolvable address to a particular WWW (World Wide Web) accessible resource."@en ;
-	sh:targetClass observable:URL ;
+	sh:targetClass uco-observable:URL ;
 	.
 
-observable:URLFacet
+uco-observable:URLFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "URLFacet"@en ;
 	rdfs:comment "A URL facet is a grouping of characteristics unique to a uniform resource locator (URL) acting as a resolvable address to a particular WWW (World Wide Web) accessible resource."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:host ;
+			sh:path uco-observable:host ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:port ;
+			sh:path uco-observable:port ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:fragment ;
+			sh:path uco-observable:fragment ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:fullValue ;
+			sh:path uco-observable:fullValue ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:password ;
+			sh:path uco-observable:password ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:path ;
+			sh:path uco-observable:path ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:query ;
+			sh:path uco-observable:query ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:scheme ;
+			sh:path uco-observable:scheme ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:userName ;
+			sh:path uco-observable:userName ;
 		]
 		;
-	sh:targetClass observable:URLFacet ;
+	sh:targetClass uco-observable:URLFacet ;
 	.
 
-observable:URLHistory
+uco-observable:URLHistory
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "URLHistory"@en ;
 	rdfs:comment "A URL history characterizes the stored URL history for a particular web browser"@en ;
-	sh:targetClass observable:URLHistory ;
+	sh:targetClass uco-observable:URLHistory ;
 	.
 
-observable:URLHistoryEntry
+uco-observable:URLHistoryEntry
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "URL History Entry"@en-US ;
 	rdfs:comment "A URL history entry is a grouping of characteristics unique to the properties of a single URL history entry for a particular browser."@en-US ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:url ;
+			sh:path uco-observable:url ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:referrerUrl ;
+			sh:path uco-observable:referrerUrl ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:expirationTime ;
+			sh:path uco-observable:expirationTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:firstVisit ;
+			sh:path uco-observable:firstVisit ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:lastVisit ;
+			sh:path uco-observable:lastVisit ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:visitCount ;
+			sh:path uco-observable:visitCount ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:manuallyEnteredCount ;
+			sh:path uco-observable:manuallyEnteredCount ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:browserUserProfile ;
+			sh:path uco-observable:browserUserProfile ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:hostname ;
+			sh:path uco-observable:hostname ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pageTitle ;
+			sh:path uco-observable:pageTitle ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:minCount "0"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:keywordSearchTerm ;
+			sh:path uco-observable:keywordSearchTerm ;
 		]
 		;
-	sh:targetClass observable:URLHistoryEntry ;
+	sh:targetClass uco-observable:URLHistoryEntry ;
 	.
 
-observable:URLHistoryFacet
+uco-observable:URLHistoryFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "URLHistoryFacet"@en-US ;
 	rdfs:comment "A URL history facet is a grouping of characteristics unique to the stored URL history for a particular web browser"@en-US ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:browserInformation ;
+			sh:path uco-observable:browserInformation ;
 		] ,
 		[
-			sh:class observable:URLHistoryEntry ;
+			sh:class uco-observable:URLHistoryEntry ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:urlHistoryEntry ;
+			sh:path uco-observable:urlHistoryEntry ;
 		]
 		;
-	sh:targetClass observable:URLHistoryFacet ;
+	sh:targetClass uco-observable:URLHistoryFacet ;
 	.
 
-observable:URLVisit
+uco-observable:URLVisit
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "URLVisit"@en ;
 	rdfs:comment "A URL visit characterizes the properties of a visit of a URL within a particular browser."@en ;
-	sh:targetClass observable:URLVisit ;
+	sh:targetClass uco-observable:URLVisit ;
 	.
 
-observable:URLVisitFacet
+uco-observable:URLVisitFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "URLVisitFacet"@en ;
 	rdfs:comment "A URL visit facet is a grouping of characteristics unique to the properties of a visit of a URL within a particular browser."@en ;
 	sh:property
-		observable:URLVisitFacet-urlTransitionType-in-shape ,
+		uco-observable:URLVisitFacet-urlTransitionType-in-shape ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:browserInformation ;
+			sh:path uco-observable:browserInformation ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:fromURLVisit ;
+			sh:path uco-observable:fromURLVisit ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:url ;
+			sh:path uco-observable:url ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:visitTime ;
+			sh:path uco-observable:visitTime ;
 		] ,
 		[
 			sh:datatype xsd:duration ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:visitDuration ;
+			sh:path uco-observable:visitDuration ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:urlTransitionType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:urlTransitionType ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:urlTransitionType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:urlTransitionType ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:urlTransitionType ;
+			sh:path uco-observable:urlTransitionType ;
 		]
 		;
-	sh:targetClass observable:URLVisitFacet ;
+	sh:targetClass uco-observable:URLVisitFacet ;
 	.
 
-observable:URLVisitFacet-urlTransitionType-in-shape
+uco-observable:URLVisitFacet-urlTransitionType-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"link"
@@ -7037,27 +7037,27 @@ observable:URLVisitFacet-urlTransitionType-in-shape
 		"keyword_generated"
 	) ;
 	sh:message "Value is not member of the vocabulary URLTransitionTypeVocab." ;
-	sh:path observable:urlTransitionType ;
+	sh:path uco-observable:urlTransitionType ;
 	sh:severity sh:Info ;
 	.
 
-observable:UserAccount
+uco-observable:UserAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "UserAccount"@en ;
 	rdfs:comment "A user account is an account controlling a user's access to a network, system or platform."@en ;
-	sh:targetClass observable:UserAccount ;
+	sh:targetClass uco-observable:UserAccount ;
 	.
 
-observable:UserAccountFacet
+uco-observable:UserAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "UserAccountFacet"@en ;
 	rdfs:comment "A user account facet is a grouping of characteristics unique to an account controlling a user's access to a network, system, or platform."@en ;
 	sh:property
@@ -7065,118 +7065,118 @@ observable:UserAccountFacet
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:canEscalatePrivs ;
+			sh:path uco-observable:canEscalatePrivs ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isPrivileged ;
+			sh:path uco-observable:isPrivileged ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isServiceAccount ;
+			sh:path uco-observable:isServiceAccount ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:homeDirectory ;
+			sh:path uco-observable:homeDirectory ;
 		]
 		;
-	sh:targetClass observable:UserAccountFacet ;
+	sh:targetClass uco-observable:UserAccountFacet ;
 	.
 
-observable:UserSession
+uco-observable:UserSession
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "UserSession"@en ;
 	rdfs:comment "A user session is a temporary and interactive information interchange between two or more communicating devices within the managed scope of a single user. [based on https://en.wikipedia.org/wiki/Session_(computer_science)]"@en ;
-	sh:targetClass observable:UserSession ;
+	sh:targetClass uco-observable:UserSession ;
 	.
 
-observable:UserSessionFacet
+uco-observable:UserSessionFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "UserSessionFacet"@en ;
 	rdfs:comment "A user session facet is a grouping of characteristics unique to a temporary and interactive information interchange between two or more communicating devices within the managed scope of a single user. [based on https://en.wikipedia.org/wiki/Session_(computer_science)]"@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:effectiveUser ;
+			sh:path uco-observable:effectiveUser ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:loginTime ;
+			sh:path uco-observable:loginTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:logoutTime ;
+			sh:path uco-observable:logoutTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:effectiveGroup ;
+			sh:path uco-observable:effectiveGroup ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:effectiveGroupID ;
+			sh:path uco-observable:effectiveGroupID ;
 		]
 		;
-	sh:targetClass observable:UserSessionFacet ;
+	sh:targetClass uco-observable:UserSessionFacet ;
 	.
 
-observable:ValuesEnumeratedEffectFacet
+uco-observable:ValuesEnumeratedEffectFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DefinedEffectFacet ;
+	rdfs:subClassOf uco-observable:DefinedEffectFacet ;
 	rdfs:label "ValuesEnumeratedEffectFacet"@en ;
 	rdfs:comment "A values enumerated effect facet is a grouping of characteristics unique to the effects of actions upon observable objects where a value of the observable object is enumerated. An example of this would be the values of a registry key."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:values ;
+		sh:path uco-observable:values ;
 	] ;
-	sh:targetClass observable:ValuesEnumeratedEffectFacet ;
+	sh:targetClass uco-observable:ValuesEnumeratedEffectFacet ;
 	.
 
-observable:Volume
+uco-observable:Volume
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Volume"@en ;
 	rdfs:comment "A volume is a single accessible storage area (volume) with a single file system. [based on https://en.wikipedia.org/wiki/Volume_(computing)]"@en ;
-	sh:targetClass observable:Volume ;
+	sh:targetClass uco-observable:Volume ;
 	.
 
-observable:VolumeFacet
+uco-observable:VolumeFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "VolumeFacet"@en ;
 	rdfs:comment "A volume facet is a grouping of characteristics unique to a single accessible storage area (volume) with a single file system. [based on https://en.wikipedia.org/wiki/Volume_(computing)]"@en ;
 	sh:property
@@ -7184,178 +7184,178 @@ observable:VolumeFacet
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sectorSize ;
+			sh:path uco-observable:sectorSize ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:volumeID ;
+			sh:path uco-observable:volumeID ;
 		]
 		;
-	sh:targetClass observable:VolumeFacet ;
+	sh:targetClass uco-observable:VolumeFacet ;
 	.
 
-observable:WearableDevice
+uco-observable:WearableDevice
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:SmartDevice ;
+	rdfs:subClassOf uco-observable:SmartDevice ;
 	rdfs:label "WearableDevice"@en-US ;
 	rdfs:comment "A wearable device is an electronic device that is designed to be worn on a person's body."@en-US ;
-	sh:targetClass observable:WearableDevice ;
+	sh:targetClass uco-observable:WearableDevice ;
 	.
 
-observable:WebPage
+uco-observable:WebPage
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WebPage"@en ;
 	rdfs:comment "A web page is a specific collection of information provided by a website and displayed to a user in a web browser. A website typically consists of many web pages linked together in a coherent fashion. [based on https://en.wikipedia.org/wiki/Web_page]"@en ;
-	sh:targetClass observable:WebPage ;
+	sh:targetClass uco-observable:WebPage ;
 	.
 
-observable:WhoIs
+uco-observable:WhoIs
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WhoIs"@en ;
 	rdfs:comment "WhoIs is a response record conformant to the WHOIS protocol standard (RFC 3912). [based on https://en.wikipedia.org/wiki/WHOIS]"@en ;
-	sh:targetClass observable:WhoIs ;
+	sh:targetClass uco-observable:WhoIs ;
 	.
 
-observable:WhoIsFacet
+uco-observable:WhoIsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WhoIsFacet"@en ;
 	rdfs:comment "A whois facet is a grouping of characteristics unique to a response record conformant to the WHOIS protocol standard (RFC 3912). [based on https://en.wikipedia.org/wiki/WHOIS]"@en ;
 	sh:property
-		observable:WhoIsFacet-status-in-shape ,
-		observable:regionalInternetRegistry-shape-value-not-vocabulary-member ,
-		observable:regionalInternetRegistry-shape-value-outside-default-vocabulary ,
+		uco-observable:WhoIsFacet-status-in-shape ,
+		uco-observable:regionalInternetRegistry-shape-value-not-vocabulary-member ,
+		uco-observable:regionalInternetRegistry-shape-value-outside-default-vocabulary ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:domainName ;
+			sh:path uco-observable:domainName ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:ipAddress ;
+			sh:path uco-observable:ipAddress ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:registrantContactInfo ;
+			sh:path uco-observable:registrantContactInfo ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:serverName ;
+			sh:path uco-observable:serverName ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:nameServer ;
+			sh:path uco-observable:nameServer ;
 		] ,
 		[
-			sh:class observable:WhoisRegistrarInfoType ;
+			sh:class uco-observable:WhoisRegistrarInfoType ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:registrarInfo ;
+			sh:path uco-observable:registrarInfo ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:creationDate ;
+			sh:path uco-observable:creationDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:expirationDate ;
+			sh:path uco-observable:expirationDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:lookupDate ;
+			sh:path uco-observable:lookupDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:updatedDate ;
+			sh:path uco-observable:updatedDate ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:domainID ;
+			sh:path uco-observable:domainID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:remarks ;
+			sh:path uco-observable:remarks ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sponsoringRegistrar ;
+			sh:path uco-observable:sponsoringRegistrar ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:regionalInternetRegistry should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:regionalInternetRegistry ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:regionalInternetRegistry should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:regionalInternetRegistry ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:status should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:status ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:status should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:status ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:registrantIDs ;
+			sh:path uco-observable:registrantIDs ;
 		] ,
 		[
-			sh:datatype vocabulary:WhoisDNSSECTypeVocab ;
+			sh:datatype uco-vocabulary:WhoisDNSSECTypeVocab ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dnssec ;
-		] ,
-		[
-			sh:maxCount "1"^^xsd:integer ;
-			sh:nodeKind sh:Literal ;
-			sh:path observable:regionalInternetRegistry ;
+			sh:path uco-observable:dnssec ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:status ;
+			sh:path uco-observable:regionalInternetRegistry ;
+		] ,
+		[
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path uco-observable:status ;
 		]
 		;
-	sh:targetClass observable:WhoIsFacet ;
+	sh:targetClass uco-observable:WhoIsFacet ;
 	.
 
-observable:WhoIsFacet-status-in-shape
+uco-observable:WhoIsFacet-status-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"ADD_PERIOD"
@@ -7379,36 +7379,36 @@ observable:WhoIsFacet-status-in-shape
 		"UPDATE_PROHIBITED"
 	) ;
 	sh:message "Value is not member of the vocabulary WhoisStatusTypeVocab." ;
-	sh:path observable:status ;
+	sh:path uco-observable:status ;
 	sh:severity sh:Info ;
 	.
 
-observable:WhoisContactFacet
+uco-observable:WhoisContactFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ContactFacet ;
+	rdfs:subClassOf uco-observable:ContactFacet ;
 	rdfs:label "WhoIsContactFacet"@en ;
 	rdfs:comment "A Whois contact type is a grouping of characteristics unique to contact-related information present in a response record conformant to the WHOIS protocol standard (RFC 3912). [based on https://en.wikipedia.org/wiki/WHOIS]"@en ;
 	sh:property
-		observable:WhoisContactFacet-whoisContactType-in-shape ,
+		uco-observable:WhoisContactFacet-whoisContactType-in-shape ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:whoisContactType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:whoisContactType ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:whoisContactType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:whoisContactType ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:whoisContactType ;
+			sh:path uco-observable:whoisContactType ;
 		]
 		;
-	sh:targetClass observable:WhoisContactFacet ;
+	sh:targetClass uco-observable:WhoisContactFacet ;
 	.
 
-observable:WhoisContactFacet-whoisContactType-in-shape
+uco-observable:WhoisContactFacet-whoisContactType-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"ADMIN"
@@ -7416,159 +7416,159 @@ observable:WhoisContactFacet-whoisContactType-in-shape
 		"TECHNICAL"
 	) ;
 	sh:message "Value is not member of the vocabulary WhoisContactTypeVocab." ;
-	sh:path observable:whoisContactType ;
+	sh:path uco-observable:whoisContactType ;
 	sh:severity sh:Info ;
 	.
 
-observable:WhoisRegistrarInfoType
+uco-observable:WhoisRegistrarInfoType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "WhoisRegistrarInfoType"@en ;
 	rdfs:comment "A Whois registrar info type is a grouping of characteristics unique to registrar-related information present in a response record conformant to the WHOIS protocol standard (RFC 3912). [based on https://en.wikipedia.org/wiki/WHOIS]"@en ;
 	sh:property
 		[
-			sh:class location:Location ;
+			sh:class uco-location:Location ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:geolocationAddress ;
+			sh:path uco-observable:geolocationAddress ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:contactPhoneNumber ;
+			sh:path uco-observable:contactPhoneNumber ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:emailAddress ;
+			sh:path uco-observable:emailAddress ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:referralURL ;
+			sh:path uco-observable:referralURL ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:whoisServer ;
+			sh:path uco-observable:whoisServer ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:registrarGUID ;
+			sh:path uco-observable:registrarGUID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:registrarID ;
+			sh:path uco-observable:registrarID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:registrarName ;
+			sh:path uco-observable:registrarName ;
 		]
 		;
-	sh:targetClass observable:WhoisRegistrarInfoType ;
+	sh:targetClass uco-observable:WhoisRegistrarInfoType ;
 	.
 
-observable:WifiAddress
+uco-observable:WifiAddress
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:MACAddress ;
+	rdfs:subClassOf uco-observable:MACAddress ;
 	rdfs:label "WifiAddress"@en ;
 	rdfs:comment "A Wi-Fi address is a media access control (MAC) standards-conformant identifier assigned to a device network interface to enable routing and management of IEEE 802.11 standards-conformant communications to and from that device."@en ;
-	sh:targetClass observable:WifiAddress ;
+	sh:targetClass uco-observable:WifiAddress ;
 	.
 
-observable:WifiAddressFacet
+uco-observable:WifiAddressFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:MACAddressFacet ;
+	rdfs:subClassOf uco-observable:MACAddressFacet ;
 	rdfs:label "WifiAddressFacet"@en ;
 	rdfs:comment "A Wi-Fi address facet is a grouping of characteristics unique to a media access control (MAC) standards conformant identifier assigned to a device network interface to enable routing and management of IEEE 802.11 standards-conformant communications to and from that device."@en ;
-	sh:targetClass observable:WifiAddressFacet ;
+	sh:targetClass uco-observable:WifiAddressFacet ;
 	.
 
-observable:Wiki
+uco-observable:Wiki
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "Wiki"@en ;
 	rdfs:comment "A wiki is an online hypertext publication collaboratively edited and managed by its own audience directly using a web browser. A typical wiki contains multiple pages/articles for the subjects or scope of the project and could be either open to the public or limited to use within an organization for maintaining its internal knowledge base. [based on https://en.wikipedia.org/wiki/Wiki]"@en ;
-	sh:targetClass observable:Wiki ;
+	sh:targetClass uco-observable:Wiki ;
 	.
 
-observable:WikiArticle
+uco-observable:WikiArticle
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WikiArticle"@en ;
 	rdfs:comment "A wiki article is one or more pages in a wiki focused on characterizing a particular topic."@en ;
-	sh:targetClass observable:WikiArticle ;
+	sh:targetClass uco-observable:WikiArticle ;
 	.
 
-observable:WindowsAccount
+uco-observable:WindowsAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "WindowsAccount"@en ;
 	rdfs:comment "A Windows account is a user account on a Windows operating system."@en ;
-	sh:targetClass observable:WindowsAccount ;
+	sh:targetClass uco-observable:WindowsAccount ;
 	.
 
-observable:WindowsAccountFacet
+uco-observable:WindowsAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsAccountFacet"@en ;
 	rdfs:comment "A Windows account facet is a grouping of characteristics unique to a user account on a Windows operating system."@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:groups ;
+		sh:path uco-observable:groups ;
 	] ;
-	sh:targetClass observable:WindowsAccountFacet ;
+	sh:targetClass uco-observable:WindowsAccountFacet ;
 	.
 
-observable:WindowsActiveDirectoryAccount
+uco-observable:WindowsActiveDirectoryAccount
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:DigitalAccount ;
+	rdfs:subClassOf uco-observable:DigitalAccount ;
 	rdfs:label "WindowsActiveDirectoryAccount"@en ;
 	rdfs:comment "A Windows Active Directory account is an account managed by directory-based identity-related services of a Windows operating system."@en ;
-	sh:targetClass observable:WindowsActiveDirectoryAccount ;
+	sh:targetClass uco-observable:WindowsActiveDirectoryAccount ;
 	.
 
-observable:WindowsActiveDirectoryAccountFacet
+uco-observable:WindowsActiveDirectoryAccountFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsActiveDirectoryAccountFacet"@en ;
 	rdfs:comment "A Windows Active Directory account facet is a grouping of characteristics unique to an account managed by directory-based identity-related services of a Windows operating system."@en ;
 	sh:property
@@ -7576,286 +7576,286 @@ observable:WindowsActiveDirectoryAccountFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:objectGUID ;
+			sh:path uco-observable:objectGUID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:activeDirectoryGroups ;
+			sh:path uco-observable:activeDirectoryGroups ;
 		]
 		;
-	sh:targetClass observable:WindowsActiveDirectoryAccountFacet ;
+	sh:targetClass uco-observable:WindowsActiveDirectoryAccountFacet ;
 	.
 
-observable:WindowsComputerSpecification
+uco-observable:WindowsComputerSpecification
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsComputerSpecification"@en ;
 	rdfs:comment "A Windows computer specification is the hardware ans software of a programmable electronic device that can store, retrieve, and process data running a Microsoft Windows operating system. [based on merriam-webster.com/dictionary/computer]"@en ;
-	sh:targetClass observable:WindowsComputerSpecification ;
+	sh:targetClass uco-observable:WindowsComputerSpecification ;
 	.
 
-observable:WindowsComputerSpecificationFacet
+uco-observable:WindowsComputerSpecificationFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsComputerSpecificationFacet"@en ;
 	rdfs:comment "A Windows computer specification facet is a grouping of characteristics unique to the hardware and software of a programmable electronic device that can store, retrieve, and process data running a Microsoft Windows operating system. [based on merriam-webster.com/dictionary/computer]"@en ;
 	sh:property
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:registeredOrganization ;
+			sh:path uco-observable:registeredOrganization ;
 		] ,
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:registeredOwner ;
+			sh:path uco-observable:registeredOwner ;
 		] ,
 		[
-			sh:class observable:GlobalFlagType ;
+			sh:class uco-observable:GlobalFlagType ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:globalFlagList ;
+			sh:path uco-observable:globalFlagList ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:windowsDirectory ;
+			sh:path uco-observable:windowsDirectory ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:windowsSystemDirectory ;
+			sh:path uco-observable:windowsSystemDirectory ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:windowsTempDirectory ;
+			sh:path uco-observable:windowsTempDirectory ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:lastShutdownDate ;
+			sh:path uco-observable:lastShutdownDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:osInstallDate ;
+			sh:path uco-observable:osInstallDate ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:osLastUpgradeDate ;
+			sh:path uco-observable:osLastUpgradeDate ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:msProductID ;
+			sh:path uco-observable:msProductID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:msProductName ;
+			sh:path uco-observable:msProductName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:netBIOSName ;
+			sh:path uco-observable:netBIOSName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:domain ;
+			sh:path uco-observable:domain ;
 		]
 		;
-	sh:targetClass observable:WindowsComputerSpecificationFacet ;
+	sh:targetClass uco-observable:WindowsComputerSpecificationFacet ;
 	.
 
-observable:WindowsCriticalSection
+uco-observable:WindowsCriticalSection
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsCriticalSection"@en ;
 	rdfs:comment "A Windows critical section is a Windows object that provides synchronization similar to that provided by a mutex object, except that a critical section can be used only by the threads of a single process. Critical section objects cannot be shared across processes. Event, mutex, and semaphore objects can also be used in a single-process application, but critical section objects provide a slightly faster, more efficient mechanism for mutual-exclusion synchronization (a processor-specific test and set instruction). Like a mutex object, a critical section object can be owned by only one thread at a time, which makes it useful for protecting a shared resource from simultaneous access. Unlike a mutex object, there is no way to tell whether a critical section has been abandoned. [based on https://docs.microsoft.com/en-us/windows/win32/sync/critical-section-objects]"@en ;
-	sh:targetClass observable:WindowsCriticalSection ;
+	sh:targetClass uco-observable:WindowsCriticalSection ;
 	.
 
-observable:WindowsEvent
+uco-observable:WindowsEvent
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsEvent"@en ;
 	rdfs:comment "A Windows event is a notification record of an occurance of interest (system, security, application, etc.) on a Windows operating system."@en ;
-	sh:targetClass observable:WindowsEvent ;
+	sh:targetClass uco-observable:WindowsEvent ;
 	.
 
-observable:WindowsFilemapping
+uco-observable:WindowsFilemapping
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsFilemapping"@en ;
 	rdfs:comment "A Windows file mapping is the association of a file's contents with a portion of the virtual address space of a process within a Windows operating system. The system creates a file mapping object (also known as a section object) to maintain this association. A file view is the portion of virtual address space that a process uses to access the file's contents. File mapping allows the process to use both random input and output (I/O) and sequential I/O. It also allows the process to work efficiently with a large data file, such as a database, without having to map the whole file into memory. Multiple processes can also use memory-mapped files to share data. Processes read from and write to the file view using pointers, just as they would with dynamically allocated memory. The use of file mapping improves efficiency because the file resides on disk, but the file view resides in memory.[based on https://docs.microsoft.com/en-us/windows/win32/memory/file-mapping]"@en ;
-	sh:targetClass observable:WindowsFilemapping ;
+	sh:targetClass uco-observable:WindowsFilemapping ;
 	.
 
-observable:WindowsHandle
+uco-observable:WindowsHandle
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsHandle"@en ;
 	rdfs:comment "A Windows handle is an abstract reference to a resource within the Windows operating system, such as a window, memory, an open file or a pipe. It is the mechanism by which applications interact with such resources in the Windows operating system."@en ;
-	sh:targetClass observable:WindowsHandle ;
+	sh:targetClass uco-observable:WindowsHandle ;
 	.
 
-observable:WindowsHook
+uco-observable:WindowsHook
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsHook"@en ;
 	rdfs:comment "A Windows hook is a mechanism by which an application can intercept events, such as messages, mouse actions, and keystrokes within the Windows operating system. A function that intercepts a particular type of event is known as a hook procedure. A hook procedure can act on each event it receives, and then modify or discard the event. [based on https://docs.microsoft.com/en-us/windows/win32/winmsg/about-hooks]"@en ;
-	sh:targetClass observable:WindowsHook ;
+	sh:targetClass uco-observable:WindowsHook ;
 	.
 
-observable:WindowsMailslot
+uco-observable:WindowsMailslot
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsMailslot"@en ;
 	rdfs:comment "A Windows mailslot is is a pseudofile that resides in memory, and may be accessed using standard file functions. The data in a mailslot message can be in any form, but cannot be larger than 424 bytes when sent between computers. Unlike disk files, mailslots are temporary. When all handles to a mailslot are closed, the mailslot and all the data it contains are deleted. [based on https://docs.microsoft.com/en-us/windows/win32/ipc/about-mailslots]"@en ;
-	sh:targetClass observable:WindowsMailslot ;
+	sh:targetClass uco-observable:WindowsMailslot ;
 	.
 
-observable:WindowsNetworkShare
+uco-observable:WindowsNetworkShare
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsNetworkShare"@en ;
 	rdfs:comment "A Windows network share is a Windows computer resource made available from one host to other hosts on a computer network. It is a device or piece of information on a computer that can be remotely accessed from another computer transparently as if it were a resource in the local machine. Network sharing is made possible by inter-process communication over the network. [based on https://en.wikipedia.org/wiki/Shared_resource]"@en ;
-	sh:targetClass observable:WindowsNetworkShare ;
+	sh:targetClass uco-observable:WindowsNetworkShare ;
 	.
 
-observable:WindowsPEBinaryFile
+uco-observable:WindowsPEBinaryFile
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:File ;
+	rdfs:subClassOf uco-observable:File ;
 	rdfs:label "WindowsPEBinaryFile"@en ;
 	rdfs:comment "A Windows PE binary file is a Windows portable executable (PE) file."@en ;
-	sh:targetClass observable:WindowsPEBinaryFile ;
+	sh:targetClass uco-observable:WindowsPEBinaryFile ;
 	.
 
-observable:WindowsPEBinaryFileFacet
+uco-observable:WindowsPEBinaryFileFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsPEBinaryFileFacet"@en ;
 	rdfs:comment "A Windows PE binary file facet is a grouping of characteristics unique to a Windows portable executable (PE) file."@en ;
 	sh:property
 		[
-			sh:class observable:WindowsPEOptionalHeader ;
+			sh:class uco-observable:WindowsPEOptionalHeader ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:optionalHeader ;
+			sh:path uco-observable:optionalHeader ;
 		] ,
 		[
-			sh:class observable:WindowsPESection ;
+			sh:class uco-observable:WindowsPESection ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:sections ;
+			sh:path uco-observable:sections ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:fileHeaderHashes ;
+			sh:path uco-observable:fileHeaderHashes ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:timeDateStamp ;
+			sh:path uco-observable:timeDateStamp ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:pointerToSymbolTable ;
+			sh:path uco-observable:pointerToSymbolTable ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:numberOfSections ;
+			sh:path uco-observable:numberOfSections ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:numberOfSymbols ;
+			sh:path uco-observable:numberOfSymbols ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfOptionalHeader ;
+			sh:path uco-observable:sizeOfOptionalHeader ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:impHash ;
+			sh:path uco-observable:impHash ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:peType ;
+			sh:path uco-observable:peType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:machine ;
+			sh:path uco-observable:machine ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:characteristics ;
+			sh:path uco-observable:characteristics ;
 		]
 		;
-	sh:targetClass observable:WindowsPEBinaryFileFacet ;
+	sh:targetClass uco-observable:WindowsPEBinaryFileFacet ;
 	.
 
-observable:WindowsPEBinaryType
+uco-observable:WindowsPEBinaryType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -7867,434 +7867,434 @@ observable:WindowsPEBinaryType
 	] ;
 	.
 
-observable:WindowsPEFileHeader
+uco-observable:WindowsPEFileHeader
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "WindowsPEFileHeader"@en ;
 	rdfs:comment "A Windows PE file header is a grouping of characteristics unique to the 'header' of a Windows PE (Portable Executable) file, consisting of a collection of metadata about the overall nature and structure of the file."@en ;
 	sh:property [
 		sh:datatype xsd:dateTime ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:timeDateStamp ;
+		sh:path uco-observable:timeDateStamp ;
 	] ;
-	sh:targetClass observable:WindowsPEFileHeader ;
+	sh:targetClass uco-observable:WindowsPEFileHeader ;
 	.
 
-observable:WindowsPEOptionalHeader
+uco-observable:WindowsPEOptionalHeader
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "WindowsPEOptionalHeader"@en ;
 	rdfs:comment "A Windows PE optional header is a grouping of characteristics unique to the 'optional header' of a Windows PE (Portable Executable) file, consisting of a collection of metadata about the executable code structure of the file."@en ;
 	sh:property
 		[
 			sh:datatype xsd:byte ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:majorLinkerVersion ;
+			sh:path uco-observable:majorLinkerVersion ;
 		] ,
 		[
 			sh:datatype xsd:byte ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:minorLinkerVersion ;
+			sh:path uco-observable:minorLinkerVersion ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:addressOfEntryPoint ;
+			sh:path uco-observable:addressOfEntryPoint ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:baseOfCode ;
+			sh:path uco-observable:baseOfCode ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:checksum ;
+			sh:path uco-observable:checksum ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:fileAlignment ;
+			sh:path uco-observable:fileAlignment ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:imageBase ;
+			sh:path uco-observable:imageBase ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:loaderFlags ;
+			sh:path uco-observable:loaderFlags ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:numberOfRVAAndSizes ;
+			sh:path uco-observable:numberOfRVAAndSizes ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sectionAlignment ;
+			sh:path uco-observable:sectionAlignment ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfCode ;
+			sh:path uco-observable:sizeOfCode ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfHeaders ;
+			sh:path uco-observable:sizeOfHeaders ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfHeapCommit ;
+			sh:path uco-observable:sizeOfHeapCommit ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfHeapReserve ;
+			sh:path uco-observable:sizeOfHeapReserve ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfImage ;
+			sh:path uco-observable:sizeOfImage ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfInitializedData ;
+			sh:path uco-observable:sizeOfInitializedData ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfStackCommit ;
+			sh:path uco-observable:sizeOfStackCommit ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfStackReserve ;
+			sh:path uco-observable:sizeOfStackReserve ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:sizeOfUninitializedData ;
+			sh:path uco-observable:sizeOfUninitializedData ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:win32VersionValue ;
+			sh:path uco-observable:win32VersionValue ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dllCharacteristics ;
+			sh:path uco-observable:dllCharacteristics ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:magic ;
+			sh:path uco-observable:magic ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:majorImageVersion ;
+			sh:path uco-observable:majorImageVersion ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:majorOSVersion ;
+			sh:path uco-observable:majorOSVersion ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:majorSubsystemVersion ;
+			sh:path uco-observable:majorSubsystemVersion ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:minorImageVersion ;
+			sh:path uco-observable:minorImageVersion ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:minorOSVersion ;
+			sh:path uco-observable:minorOSVersion ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:minorSubsystemVersion ;
+			sh:path uco-observable:minorSubsystemVersion ;
 		] ,
 		[
 			sh:datatype xsd:unsignedShort ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subsystem ;
+			sh:path uco-observable:subsystem ;
 		]
 		;
-	sh:targetClass observable:WindowsPEOptionalHeader ;
+	sh:targetClass uco-observable:WindowsPEOptionalHeader ;
 	.
 
-observable:WindowsPESection
+uco-observable:WindowsPESection
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "WindowsPESection"@en ;
 	rdfs:comment "A Windows PE section is a grouping of characteristics unique to a specific default or custom-defined region of a Windows PE (Portable Executable) file, consisting of an individual portion of the actual executable content of the file delineated according to unique purpose and memory protection requirements."@en ;
 	sh:property
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:hashes ;
+			sh:path uco-observable:hashes ;
 		] ,
 		[
 			sh:datatype xsd:decimal ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:entropy ;
+			sh:path uco-observable:entropy ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:size ;
+			sh:path uco-observable:size ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:name ;
+			sh:path uco-core:name ;
 		]
 		;
-	sh:targetClass observable:WindowsPESection ;
+	sh:targetClass uco-observable:WindowsPESection ;
 	.
 
-observable:WindowsPrefetch
+uco-observable:WindowsPrefetch
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsPrefetch"@en ;
 	rdfs:comment "The Windows prefetch contains entries in a Windows prefetch file (used to speed up application startup starting with Windows XP)."@en ;
-	sh:targetClass observable:WindowsPrefetch ;
+	sh:targetClass uco-observable:WindowsPrefetch ;
 	.
 
-observable:WindowsPrefetchFacet
+uco-observable:WindowsPrefetchFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsPrefetchFacet"@en ;
 	rdfs:comment "A Windows prefetch facet is a grouping of characteristics unique to entries in the Windows prefetch file (used to speed up application startup starting with Windows XP)."@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:volume ;
+			sh:path uco-observable:volume ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:accessedDirectory ;
+			sh:path uco-observable:accessedDirectory ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:accessedFile ;
+			sh:path uco-observable:accessedFile ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:firstRun ;
+			sh:path uco-observable:firstRun ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:lastRun ;
+			sh:path uco-observable:lastRun ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:timesExecuted ;
+			sh:path uco-observable:timesExecuted ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:applicationFileName ;
+			sh:path uco-observable:applicationFileName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:prefetchHash ;
+			sh:path uco-observable:prefetchHash ;
 		]
 		;
-	sh:targetClass observable:WindowsPrefetchFacet ;
+	sh:targetClass uco-observable:WindowsPrefetchFacet ;
 	.
 
-observable:WindowsProcess
+uco-observable:WindowsProcess
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Process ;
+	rdfs:subClassOf uco-observable:Process ;
 	rdfs:label "WindowsProcess"@en ;
 	rdfs:comment "A Windows process is a program running on a Windows operating system."@en ;
-	sh:targetClass observable:WindowsProcess ;
+	sh:targetClass uco-observable:WindowsProcess ;
 	.
 
-observable:WindowsProcessFacet
+uco-observable:WindowsProcessFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsProcessFacet"@en ;
 	rdfs:comment "A Windows process facet is a grouping of characteristics unique to a program running on a Windows operating system."@en ;
 	sh:property
 		[
-			sh:class types:Dictionary ;
+			sh:class uco-types:Dictionary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:startupInfo ;
+			sh:path uco-observable:startupInfo ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:aslrEnabled ;
+			sh:path uco-observable:aslrEnabled ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:depEnabled ;
+			sh:path uco-observable:depEnabled ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ownerSID ;
+			sh:path uco-observable:ownerSID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:priority ;
+			sh:path uco-observable:priority ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:windowTitle ;
+			sh:path uco-observable:windowTitle ;
 		]
 		;
-	sh:targetClass observable:WindowsProcessFacet ;
+	sh:targetClass uco-observable:WindowsProcessFacet ;
 	.
 
-observable:WindowsRegistryHive
+uco-observable:WindowsRegistryHive
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsRegistryHive"@en ;
 	rdfs:comment "The Windows registry hive is a particular logical group of keys, subkeys, and values in a Windows registry (a hierarchical database that stores low-level settings for the Microsoft Windows operating system and for applications that opt to use the registry). [based on https://en.wikipedia.org/wiki/Windows_Registry]"@en ;
-	sh:targetClass observable:WindowsRegistryHive ;
+	sh:targetClass uco-observable:WindowsRegistryHive ;
 	.
 
-observable:WindowsRegistryHiveFacet
+uco-observable:WindowsRegistryHiveFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsRegistryHiveFacet"@en ;
 	rdfs:comment "A Windows registry hive facet is a grouping of characteristics unique to a particular logical group of keys, subkeys, and values in a Windows registry (a hierarchical database that stores low-level settings for the Microsoft Windows operating system and for applications that opt to use the registry). [based on https://en.wikipedia.org/wiki/Windows_Registry]"@en ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path observable:hiveType ;
+		sh:path uco-observable:hiveType ;
 	] ;
-	sh:targetClass observable:WindowsRegistryHiveFacet ;
+	sh:targetClass uco-observable:WindowsRegistryHiveFacet ;
 	.
 
-observable:WindowsRegistryKey
+uco-observable:WindowsRegistryKey
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsRegistryKey"@en ;
 	rdfs:comment "A Windows registry key is a particular key within a Windows registry (a hierarchical database that stores low-level settings for the Microsoft Windows operating system and for applications that opt to use the registry). [based on https://en.wikipedia.org/wiki/Windows_Registry]"@en ;
-	sh:targetClass observable:WindowsRegistryKey ;
+	sh:targetClass uco-observable:WindowsRegistryKey ;
 	.
 
-observable:WindowsRegistryKeyFacet
+uco-observable:WindowsRegistryKeyFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsRegistryKeyFacet"@en ;
 	rdfs:comment "A Windows registry key facet is a grouping of characteristics unique to a particular key within a Windows registry (A hierarchical database that stores low-level settings for the Microsoft Windows operating system and for applications that opt to use the registry). [based on https://en.wikipedia.org/wiki/Windows_Registry]"@en ;
 	sh:property
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:creator ;
+			sh:path uco-observable:creator ;
 		] ,
 		[
-			sh:class observable:WindowsRegistryValue ;
+			sh:class uco-observable:WindowsRegistryValue ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:registryValues ;
+			sh:path uco-observable:registryValues ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:modifiedTime ;
+			sh:path uco-observable:modifiedTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:numberOfSubkeys ;
+			sh:path uco-observable:numberOfSubkeys ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:key ;
+			sh:path uco-observable:key ;
 		]
 		;
-	sh:targetClass observable:WindowsRegistryKeyFacet ;
+	sh:targetClass uco-observable:WindowsRegistryKeyFacet ;
 	.
 
-observable:WindowsRegistryValue
+uco-observable:WindowsRegistryValue
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "WindowsRegistryValue"@en ;
 	rdfs:comment "A Windows registry value is a grouping of characteristics unique to a particular value within a Windows registry (a hierarchical database that stores low-level settings for the Microsoft Windows operating system and for applications that opt to use the registry. [based on https://en.wikipedia.org/wiki/Windows_Registry]"@en ;
 	sh:property
@@ -8302,41 +8302,41 @@ observable:WindowsRegistryValue
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path core:name ;
+			sh:path uco-core:name ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:data ;
+			sh:path uco-observable:data ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:dataType ;
+			sh:path uco-observable:dataType ;
 		]
 		;
-	sh:targetClass observable:WindowsRegistryValue ;
+	sh:targetClass uco-observable:WindowsRegistryValue ;
 	.
 
-observable:WindowsService
+uco-observable:WindowsService
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsService"@en ;
 	rdfs:comment "A Windows service is a specific Windows service (a computer program that operates in the background of a Windows operating system, similar to the way a UNIX daemon runs on UNIX). [based on https://en.wikipedia.org/wiki/Windows_service]"@en ;
-	sh:targetClass observable:WindowsService ;
+	sh:targetClass uco-observable:WindowsService ;
 	.
 
-observable:WindowsServiceFacet
+uco-observable:WindowsServiceFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsServiceFacet"@en ;
 	rdfs:comment "A Windows service facet is a grouping of characteristics unique to a specific Windows service (a computer program that operates in the background of a Windows operating system, similar to the way a UNIX daemon runs on UNIX). [based on https://en.wikipedia.org/wiki/Windows_service]"@en ;
 	sh:property
@@ -8344,54 +8344,54 @@ observable:WindowsServiceFacet
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:displayName ;
+			sh:path uco-observable:displayName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:groupName ;
+			sh:path uco-observable:groupName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:serviceName ;
+			sh:path uco-observable:serviceName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:serviceStatus ;
+			sh:path uco-observable:serviceStatus ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:serviceType ;
+			sh:path uco-observable:serviceType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startCommandLine ;
+			sh:path uco-observable:startCommandLine ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startType ;
+			sh:path uco-observable:startType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:descriptions ;
+			sh:path uco-observable:descriptions ;
 		]
 		;
-	sh:targetClass observable:WindowsServiceFacet ;
+	sh:targetClass uco-observable:WindowsServiceFacet ;
 	.
 
-observable:WindowsServiceStartType
+uco-observable:WindowsServiceStartType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -8405,7 +8405,7 @@ observable:WindowsServiceStartType
 	] ;
 	.
 
-observable:WindowsServiceStatus
+uco-observable:WindowsServiceStatus
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -8421,7 +8421,7 @@ observable:WindowsServiceStatus
 	] ;
 	.
 
-observable:WindowsServiceType
+uco-observable:WindowsServiceType
 	a rdfs:Datatype ;
 	owl:equivalentClass [
 		a rdfs:Datatype ;
@@ -8434,164 +8434,164 @@ observable:WindowsServiceType
 	] ;
 	.
 
-observable:WindowsSystemRestore
+uco-observable:WindowsSystemRestore
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsSystemRestore"@en ;
 	rdfs:comment "A Windows system restore is a capture of a Windows computer's state (including system files, installed applications, Windows Registry, and system settings) at a particular point in time such that the computer can be reverted to that state in the event of system malfunctions or other problems. [based on https://en.wikipedia.org/wiki/System_Restore]"@en ;
-	sh:targetClass observable:WindowsSystemRestore ;
+	sh:targetClass uco-observable:WindowsSystemRestore ;
 	.
 
-observable:WindowsTask
+uco-observable:WindowsTask
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsTask"@en ;
 	rdfs:comment "A Windows task is a process that is scheduled to execute on a Windows operating system by the Windows Task Scheduler. [based on http://msdn.microsoft.com/en-us/library/windows/desktop/aa381311(v=vs.85).aspx]"@en ;
-	sh:targetClass observable:WindowsTask ;
+	sh:targetClass uco-observable:WindowsTask ;
 	.
 
-observable:WindowsTaskFacet
+uco-observable:WindowsTaskFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsTaskFacet"@en ;
 	rdfs:comment "A Windows Task facet is a grouping of characteristics unique to a Windows Task (a process that is scheduled to execute on a Windows operating system by the Windows Task Scheduler). [based on http://msdn.microsoft.com/en-us/library/windows/desktop/aa381311(v=vs.85).aspx]"@en ;
 	sh:property
-		observable:WindowsTaskFacet-flags-in-shape ,
-		observable:WindowsTaskFacet-priority-in-shape ,
-		observable:WindowsTaskFacet-status-in-shape ,
+		uco-observable:WindowsTaskFacet-flags-in-shape ,
+		uco-observable:WindowsTaskFacet-priority-in-shape ,
+		uco-observable:WindowsTaskFacet-status-in-shape ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:account ;
+			sh:path uco-observable:account ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:application ;
+			sh:path uco-observable:application ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:workItemData ;
+			sh:path uco-observable:workItemData ;
 		] ,
 		[
-			sh:class observable:ObservableObject ;
+			sh:class uco-observable:ObservableObject ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:workingDirectory ;
+			sh:path uco-observable:workingDirectory ;
 		] ,
 		[
-			sh:class observable:TaskActionType ;
+			sh:class uco-observable:TaskActionType ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:actionList ;
+			sh:path uco-observable:actionList ;
 		] ,
 		[
-			sh:class observable:TriggerType ;
+			sh:class uco-observable:TriggerType ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:triggerList ;
+			sh:path uco-observable:triggerList ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:mostRecentRunTime ;
+			sh:path uco-observable:mostRecentRunTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:nextRunTime ;
+			sh:path uco-observable:nextRunTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:exitCode ;
+			sh:path uco-observable:exitCode ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:maxRunTime ;
+			sh:path uco-observable:maxRunTime ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accountLogonType ;
+			sh:path uco-observable:accountLogonType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:accountRunLevel ;
+			sh:path uco-observable:accountRunLevel ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:imageName ;
+			sh:path uco-observable:imageName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:parameters ;
+			sh:path uco-observable:parameters ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:taskComment ;
+			sh:path uco-observable:taskComment ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:taskCreator ;
+			sh:path uco-observable:taskCreator ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:flags should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:flags ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:flags should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:flags ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:status should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:status ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:status should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:status ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:priority ;
+			sh:path uco-observable:priority ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:status ;
+			sh:path uco-observable:status ;
 		] ,
 		[
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:priority should be xsd:string or xsd:integer.  Not using xsd:string or xsd:integer will be an error in UCO 2.0.0." ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:priority should be xsd:string or xsd:integer.  Not using xsd:string or xsd:integer will be an error in UCO 2.0.0." ;
 			sh:or (
 				[
 					sh:datatype xsd:integer ;
@@ -8600,18 +8600,18 @@ observable:WindowsTaskFacet
 					sh:datatype xsd:string ;
 				]
 			) ;
-			sh:path observable:priority ;
+			sh:path uco-observable:priority ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:nodeKind sh:Literal ;
-			sh:path observable:flags ;
+			sh:path uco-observable:flags ;
 		]
 		;
-	sh:targetClass observable:WindowsTaskFacet ;
+	sh:targetClass uco-observable:WindowsTaskFacet ;
 	.
 
-observable:WindowsTaskFacet-flags-in-shape
+uco-observable:WindowsTaskFacet-flags-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"TASK_FLAG_DELETE_WHEN_DONE"
@@ -8629,11 +8629,11 @@ observable:WindowsTaskFacet-flags-in-shape
 		"TASK_FLAG_ZERO"
 	) ;
 	sh:message "Value is not member of the vocabulary TaskFlagVocab." ;
-	sh:path observable:flags ;
+	sh:path uco-observable:flags ;
 	sh:severity sh:Info ;
 	.
 
-observable:WindowsTaskFacet-priority-in-shape
+uco-observable:WindowsTaskFacet-priority-in-shape
 	a sh:PropertyShape ;
 	sh:message "Value is not member of the vocabulary TaskPriorityVocab." ;
 	sh:or (
@@ -8651,11 +8651,11 @@ observable:WindowsTaskFacet-priority-in-shape
 			sh:datatype xsd:integer ;
 		]
 	) ;
-	sh:path observable:priority ;
+	sh:path uco-observable:priority ;
 	sh:severity sh:Info ;
 	.
 
-observable:WindowsTaskFacet-status-in-shape
+uco-observable:WindowsTaskFacet-status-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"SCHED_E_ACCOUNT_DBASE_CORRUPT"
@@ -8684,26 +8684,26 @@ observable:WindowsTaskFacet-status-in-shape
 		"TASK_STATE_UNKNOWN"
 	) ;
 	sh:message "Value is not member of the vocabulary TaskStatusVocab." ;
-	sh:path observable:status ;
+	sh:path uco-observable:status ;
 	.
 
-observable:WindowsThread
+uco-observable:WindowsThread
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ProcessThread ;
+	rdfs:subClassOf uco-observable:ProcessThread ;
 	rdfs:label "WindowsThread"@en ;
 	rdfs:comment "A Windows thread is a single thread of execution within a Windows process."@en ;
-	sh:targetClass observable:WindowsThread ;
+	sh:targetClass uco-observable:WindowsThread ;
 	.
 
-observable:WindowsThreadFacet
+uco-observable:WindowsThreadFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsThreadFacet"@en ;
 	rdfs:comment "A Windows thread facet is a grouping os characteristics unique to a single thread of execution within a Windows process."@en ;
 	sh:property
@@ -8711,105 +8711,105 @@ observable:WindowsThreadFacet
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:creationTime ;
+			sh:path uco-observable:creationTime ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:observableCreatedTime ;
+			sh:path uco-observable:observableCreatedTime ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:parameterAddress ;
+			sh:path uco-observable:parameterAddress ;
 		] ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:startAddress ;
+			sh:path uco-observable:startAddress ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:priority ;
+			sh:path uco-observable:priority ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:stackSize ;
+			sh:path uco-observable:stackSize ;
 		] ,
 		[
 			sh:datatype xsd:nonNegativeInteger ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:threadID ;
+			sh:path uco-observable:threadID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:context ;
+			sh:path uco-observable:context ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:runningStatus ;
+			sh:path uco-observable:runningStatus ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:securityAttributes ;
+			sh:path uco-observable:securityAttributes ;
 		] ,
 		[
 			sh:datatype xsd:unsignedInt ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:creationFlags ;
+			sh:path uco-observable:creationFlags ;
 		]
 		;
-	sh:targetClass observable:WindowsThreadFacet ;
+	sh:targetClass uco-observable:WindowsThreadFacet ;
 	.
 
-observable:WindowsVolumeFacet
+uco-observable:WindowsVolumeFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WindowsVolumeFacet"@en ;
 	rdfs:comment "A Windows volume facet is a grouping of characteristics unique to a single accessible storage area (volume) with a single Windows file system. [based on https://en.wikipedia.org/wiki/Volume_(computing)]"@en ;
 	sh:property
-		observable:WindowsVolumeFacet-driveType-in-shape ,
+		uco-observable:WindowsVolumeFacet-driveType-in-shape ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:driveLetter ;
+			sh:path uco-observable:driveLetter ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:driveType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:driveType ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:driveType should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:driveType ;
 			sh:severity sh:Warning ;
 		] ,
 		[
-			sh:datatype vocabulary:WindowsVolumeAttributeVocab ;
+			sh:datatype uco-vocabulary:WindowsVolumeAttributeVocab ;
 			sh:maxCount "4"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:windowsVolumeAttributes ;
+			sh:path uco-observable:windowsVolumeAttributes ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:driveType ;
+			sh:path uco-observable:driveType ;
 		]
 		;
-	sh:targetClass observable:WindowsVolumeFacet ;
+	sh:targetClass uco-observable:WindowsVolumeFacet ;
 	.
 
-observable:WindowsVolumeFacet-driveType-in-shape
+uco-observable:WindowsVolumeFacet-driveType-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"DRIVE_CDROM"
@@ -8821,76 +8821,76 @@ observable:WindowsVolumeFacet-driveType-in-shape
 		"DRIVE_UNKNOWN"
 	) ;
 	sh:message "Value is not member of the vocabulary WindowsDriveTypeVocab." ;
-	sh:path observable:driveType ;
+	sh:path uco-observable:driveType ;
 	sh:severity sh:Info ;
 	.
 
-observable:WindowsWaitableTime
+uco-observable:WindowsWaitableTime
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "WindowsWaitableTime"@en ;
 	rdfs:comment "A Windows waitable timer is a synchronization object within the Windows operating system whose state is set to signaled when a specified due time arrives. There are two types of waitable timers that can be created: manual-reset and synchronization. A timer of either type can also be a periodic timer. [based on https://docs.microsoft.com/en-us/windows/win32/sync/waitable-timer-objects]"@en ;
-	sh:targetClass observable:WindowsWaitableTime ;
+	sh:targetClass uco-observable:WindowsWaitableTime ;
 	.
 
-observable:WirelessNetworkConnection
+uco-observable:WirelessNetworkConnection
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:NetworkConnection ;
+	rdfs:subClassOf uco-observable:NetworkConnection ;
 	rdfs:label "WirelessNetworkConnection"@en ;
 	rdfs:comment "A wireless network connection is a connection (completed or attempted) across an IEEE 802.11 standards-confromant digital network (a group of two or more computer systems linked together). [based on https://www.webopedia.com/TERM/N/network.html]"@en ;
-	sh:targetClass observable:WirelessNetworkConnection ;
+	sh:targetClass uco-observable:WirelessNetworkConnection ;
 	.
 
-observable:WirelessNetworkConnectionFacet
+uco-observable:WirelessNetworkConnectionFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "WirelessNetworkConnectionFacet"@en ;
 	rdfs:comment "A wireless network connection facet is a grouping of characteristics unique to a connection (completed or attempted) across an IEEE 802.11 standards-conformant digital network (a group of two or more computer systems linked together). [based on https://www.webopedia.com/TERM/N/network.html]"@en ;
 	sh:property
-		observable:WirelessNetworkConnectionFacet-wirelessNetworkSecurityMode-in-shape ,
+		uco-observable:WirelessNetworkConnectionFacet-wirelessNetworkSecurityMode-in-shape ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:baseStation ;
+			sh:path uco-observable:baseStation ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:password ;
+			sh:path uco-observable:password ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:ssid ;
+			sh:path uco-observable:ssid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for observable:wirelessNetworkSecurityMode should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path observable:wirelessNetworkSecurityMode ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-observable:wirelessNetworkSecurityMode should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-observable:wirelessNetworkSecurityMode ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:wirelessNetworkSecurityMode ;
+			sh:path uco-observable:wirelessNetworkSecurityMode ;
 		]
 		;
-	sh:targetClass observable:WirelessNetworkConnectionFacet ;
+	sh:targetClass uco-observable:WirelessNetworkConnectionFacet ;
 	.
 
-observable:WirelessNetworkConnectionFacet-wirelessNetworkSecurityMode-in-shape
+uco-observable:WirelessNetworkConnectionFacet-wirelessNetworkSecurityMode-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"None"
@@ -8902,158 +8902,158 @@ observable:WirelessNetworkConnectionFacet-wirelessNetworkSecurityMode-in-shape
 		"WPA3-Enterprise"
 	) ;
 	sh:message "Value is not member of the vocabulary WirelessNetworkSecurityModeVocab." ;
-	sh:path observable:wirelessNetworkSecurityMode ;
+	sh:path uco-observable:wirelessNetworkSecurityMode ;
 	sh:severity sh:Info ;
 	.
 
-observable:WriteBlocker
+uco-observable:WriteBlocker
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:Device ;
+	rdfs:subClassOf uco-observable:Device ;
 	rdfs:label "WriteBlocker"@en-US ;
 	rdfs:comment "A write blocker is a device that allows read-only access to storage mediums in order to preserve the integrity of the data being analyzed. Examples include Tableau, Cellibrite, Talon, etc."@en-US ;
-	sh:targetClass observable:WriteBlocker ;
+	sh:targetClass uco-observable:WriteBlocker ;
 	.
 
-observable:X509Certificate
+uco-observable:X509Certificate
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "X509Certificate"@en ;
 	rdfs:comment "A X.509 certificate is a public key digital identity certificate conformant to the X.509 PKI (Public Key Infrastructure) standard."@en ;
-	sh:targetClass observable:X509Certificate ;
+	sh:targetClass uco-observable:X509Certificate ;
 	.
 
-observable:X509CertificateFacet
+uco-observable:X509CertificateFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "X509CertificateFacet"@en ;
 	rdfs:comment "A X.509 certificate facet is a grouping of characteristics unique to a public key digital identity certificate conformant to the X.509 PKI (Public Key Infrastructure) standard. "@en ;
 	sh:property
 		[
-			sh:class observable:X509V3ExtensionsFacet ;
+			sh:class uco-observable:X509V3ExtensionsFacet ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:x509v3extensions ;
+			sh:path uco-observable:x509v3extensions ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:issuerHash ;
+			sh:path uco-observable:issuerHash ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:subjectHash ;
+			sh:path uco-observable:subjectHash ;
 		] ,
 		[
-			sh:class types:Hash ;
+			sh:class uco-types:Hash ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path observable:thumbprintHash ;
+			sh:path uco-observable:thumbprintHash ;
 		] ,
 		[
 			sh:datatype xsd:boolean ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:isSelfSigned ;
+			sh:path uco-observable:isSelfSigned ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:validityNotAfter ;
+			sh:path uco-observable:validityNotAfter ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:validityNotBefore ;
+			sh:path uco-observable:validityNotBefore ;
 		] ,
 		[
 			sh:datatype xsd:integer ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subjectPublicKeyExponent ;
+			sh:path uco-observable:subjectPublicKeyExponent ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:issuer ;
+			sh:path uco-observable:issuer ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:serialNumber ;
+			sh:path uco-observable:serialNumber ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:signature ;
+			sh:path uco-observable:signature ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:signatureAlgorithm ;
+			sh:path uco-observable:signatureAlgorithm ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subject ;
+			sh:path uco-observable:subject ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subjectPublicKeyAlgorithm ;
+			sh:path uco-observable:subjectPublicKeyAlgorithm ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subjectPublicKeyModulus ;
+			sh:path uco-observable:subjectPublicKeyModulus ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:version ;
+			sh:path uco-observable:version ;
 		]
 		;
-	sh:targetClass observable:X509CertificateFacet ;
+	sh:targetClass uco-observable:X509CertificateFacet ;
 	.
 
-observable:X509V3Certificate
+uco-observable:X509V3Certificate
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:subClassOf uco-observable:ObservableObject ;
 	rdfs:label "X509V3Certificate"@en ;
 	rdfs:comment "An X.509 v3 certificate is a public key digital identity certificate conformant to the X.509 v3 PKI (Public Key Infrastructure) standard. "@en ;
-	sh:targetClass observable:X509V3Certificate ;
+	sh:targetClass uco-observable:X509V3Certificate ;
 	.
 
-observable:X509V3ExtensionsFacet
+uco-observable:X509V3ExtensionsFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "X509V3ExtensionsFacet"@en ;
 	rdfs:comment "An X.509 v3 certificate extensions facet is a grouping of characteristics unique to a public key digital identity certificate conformant to the X.509 v3 PKI (Public Key Infrastructure) standard."@en ;
 	sh:property
@@ -9061,724 +9061,724 @@ observable:X509V3ExtensionsFacet
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:privateKeyUsagePeriodNotAfter ;
+			sh:path uco-observable:privateKeyUsagePeriodNotAfter ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:privateKeyUsagePeriodNotBefore ;
+			sh:path uco-observable:privateKeyUsagePeriodNotBefore ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:authorityKeyIdentifier ;
+			sh:path uco-observable:authorityKeyIdentifier ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:basicConstraints ;
+			sh:path uco-observable:basicConstraints ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:certificatePolicies ;
+			sh:path uco-observable:certificatePolicies ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:crlDistributionPoints ;
+			sh:path uco-observable:crlDistributionPoints ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:extendedKeyUsage ;
+			sh:path uco-observable:extendedKeyUsage ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:inhibitAnyPolicy ;
+			sh:path uco-observable:inhibitAnyPolicy ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:issuerAlternativeName ;
+			sh:path uco-observable:issuerAlternativeName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:keyUsage ;
+			sh:path uco-observable:keyUsage ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:nameConstraints ;
+			sh:path uco-observable:nameConstraints ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:policyConstraints ;
+			sh:path uco-observable:policyConstraints ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:policyMappings ;
+			sh:path uco-observable:policyMappings ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subjectAlternativeName ;
+			sh:path uco-observable:subjectAlternativeName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subjectDirectoryAttributes ;
+			sh:path uco-observable:subjectDirectoryAttributes ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path observable:subjectKeyIdentifier ;
+			sh:path uco-observable:subjectKeyIdentifier ;
 		]
 		;
-	sh:targetClass observable:X509V3ExtensionsFacet ;
+	sh:targetClass uco-observable:X509V3ExtensionsFacet ;
 	.
 
-observable:abbreviation
+uco-observable:abbreviation
 	a owl:DatatypeProperty ;
 	rdfs:label "abbreviation"@en ;
 	rdfs:comment "The abbreviation of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:accessedDirectory
+uco-observable:accessedDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "accessedDirectory"@en ;
 	rdfs:comment "Directories accessed by the prefetch application during startup."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:accessedFile
+uco-observable:accessedFile
 	a owl:ObjectProperty ;
 	rdfs:label "accessedFile"@en ;
 	rdfs:comment "Files (e.g., DLLs and other support files) used by the application during startup."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:accessedTime
+uco-observable:accessedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "accessedTime"@en ;
 	rdfs:comment "The date and time at which the Object was accessed."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:account
+uco-observable:account
 	a owl:ObjectProperty ;
 	rdfs:label "account"@en ;
 	rdfs:comment "Specifies the account referenced in an event log entry or used to run the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381228(v=vs.85).aspx."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:accountIdentifier
+uco-observable:accountIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "accountIdentifier"@en ;
 	rdfs:comment "The unique identifier for the account."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:accountIssuer
+uco-observable:accountIssuer
 	a owl:ObjectProperty ;
 	rdfs:label "accountIssuer"@en ;
 	rdfs:comment "The issuer of this account."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-observable:accountLogin
+uco-observable:accountLogin
 	a owl:DatatypeProperty ;
 	rdfs:label "accountLogin"@en ;
 	rdfs:comment "The login identifier for the digital account."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:accountLogonType
+uco-observable:accountLogonType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "accountLogonType"@en ;
 	rdfs:comment "Specifies the security logon method required to run the tasks associated with the account. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383013(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:accountRunLevel
+uco-observable:accountRunLevel
 	a owl:DatatypeProperty ;
 	rdfs:label "accountRunLevel"@en ;
 	rdfs:comment "Specifies the permission level of the account that the task will be run at."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:accountType
+uco-observable:accountType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "accountType"@en ;
 	rdfs:comment "The type of account, for instance bank, phone, application, service, etc."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:AccountTypeVocab
+			uco-vocabulary:AccountTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:actionID
+uco-observable:actionID
 	a owl:DatatypeProperty ;
 	rdfs:label "actionID"@en ;
 	rdfs:comment "Specifies the user-defined identifier for the action. This identifier is used by the Task Scheduler for logging purposes. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380590(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:actionList
+uco-observable:actionList
 	a owl:ObjectProperty ;
 	rdfs:label "actionList"@en ;
 	rdfs:comment "Specifies a list of actions to be performed by the scheduled task."@en ;
-	rdfs:range observable:TaskActionType ;
+	rdfs:range uco-observable:TaskActionType ;
 	.
 
-observable:actionType
+uco-observable:actionType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "actionType"@en ;
 	rdfs:comment "Specifies the type of the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380596(v=vs.85).aspx."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:TaskActionTypeVocab
+			uco-vocabulary:TaskActionTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:activeDirectoryGroups
+uco-observable:activeDirectoryGroups
 	a owl:DatatypeProperty ;
 	rdfs:label "activeDirectoryGroups"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:adapterName
+uco-observable:adapterName
 	a owl:DatatypeProperty ;
 	rdfs:label "adapterName"@en ;
 	rdfs:comment "Specifies the name of the network adapter used by the network interface."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:addressOfEntryPoint
+uco-observable:addressOfEntryPoint
 	a owl:DatatypeProperty ;
 	rdfs:label "addressOfEntryPoint"@en ;
 	rdfs:comment "Specifies the address of the entry point relative to the image base when the executable is loaded into memory."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:addressValue
+uco-observable:addressValue
 	a owl:DatatypeProperty ;
 	rdfs:label "addressValue"@en ;
 	rdfs:comment "The value of an address."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:advertisingID
+uco-observable:advertisingID
 	a owl:DatatypeProperty ;
 	rdfs:label "advertisingID"@en ;
 	rdfs:comment "Advertising ID as a UUID. [based on https://developer.android.com/reference/androidx/ads/identifier/AdvertisingIdInfo]"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:allocationStatus
+uco-observable:allocationStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "allocationStatus"@en ;
 	rdfs:comment "The allocation status of a file."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:alternateDataStreams
+uco-observable:alternateDataStreams
 	a owl:ObjectProperty ;
 	rdfs:label "alternateDataStreams"@en ;
-	rdfs:range observable:AlternateDataStream ;
+	rdfs:range uco-observable:AlternateDataStream ;
 	.
 
-observable:androidFingerprint
+uco-observable:androidFingerprint
 	a owl:DatatypeProperty ;
 	rdfs:label "androidFingerprint"@en ;
 	rdfs:comment "A string that uniquely identifies a build of the Android operating system. [based on https://developer.android.com/reference/android/os/Build#FINGERPRINT]"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:androidID
+uco-observable:androidID
 	a owl:DatatypeProperty ;
 	rdfs:label "androidID"@en ;
 	rdfs:comment "A 64-bit number (expressed as a hexadecimal string), unique to each combination of app-signing key, user, and device. [based on https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID]"@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:androidVersion
+uco-observable:androidVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "androidVersion"@en ;
 	rdfs:comment "The user-visible version string. E.g., '1.0' or '3.4b5' or 'bananas'. This field is an opaque string. Do not assume that its value has any particular structure or that values of RELEASE from different releases can be somehow ordered. [based on https://developer.android.com/reference/android/os/Build.VERSION#RELEASE]"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:antennaHeight
+uco-observable:antennaHeight
 	a owl:DatatypeProperty ;
 	rdfs:label "antennaHeight"@en ;
 	rdfs:comment "The height (in meters) of the antenna from the ground."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-observable:application
+uco-observable:application
 	a owl:ObjectProperty ;
 	rdfs:label "application"@en ;
 	rdfs:comment "The application associated with this object."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:applicationFileName
+uco-observable:applicationFileName
 	a owl:DatatypeProperty ;
 	rdfs:label "applicationFileName"@en ;
 	rdfs:comment "Name of the executable of the prefetch file."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:applicationIdentifier
+uco-observable:applicationIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "applicationIdentifier"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:archiveType
+uco-observable:archiveType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "archiveType"@en ;
 	rdfs:comment "The type of a file archive, e.g. ZIP, GZIP or RAR."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:arguments
+uco-observable:arguments
 	a owl:DatatypeProperty ;
 	rdfs:label "arguments"@en ;
 	rdfs:comment "A list of arguments utilized in initiating the process."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:asHandle
+uco-observable:asHandle
 	a owl:DatatypeProperty ;
 	rdfs:label "asHandle"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:aslrEnabled
+uco-observable:aslrEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "aslrEnabled"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:attendant
+uco-observable:attendant
 	a owl:ObjectProperty ;
 	rdfs:label "attendant"@en ;
 	rdfs:comment "The attendants of the event."@en ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-observable:audioType
+uco-observable:audioType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "audioType"@en ;
 	rdfs:comment "The type of a audio. For example: music or speech."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:authorityKeyIdentifier
+uco-observable:authorityKeyIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "authorityKeyIdentifier"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:availableRam
+uco-observable:availableRam
 	a owl:DatatypeProperty ;
 	rdfs:label "availableRam"@en ;
 	rdfs:comment "Specifies the amount of physical memory available on the system, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:azimuth
+uco-observable:azimuth
 	a owl:DatatypeProperty ;
 	rdfs:label "azimuth"@en ;
 	rdfs:comment "The median rotation in degrees around a vertical axis of the cell antenna sector accessed."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-observable:baseOfCode
+uco-observable:baseOfCode
 	a owl:DatatypeProperty ;
 	rdfs:label "baseOfCode"@en ;
 	rdfs:comment "Specifies the address that is relative to the image base of the beginning-of-code section when it is loaded into memory."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:baseStation
+uco-observable:baseStation
 	a owl:DatatypeProperty ;
 	rdfs:label "baseStation"@en ;
 	rdfs:comment "The base station."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:basicConstraints
+uco-observable:basicConstraints
 	a owl:DatatypeProperty ;
 	rdfs:label "basicConstraints"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:bcc
+uco-observable:bcc
 	a owl:ObjectProperty ;
 	rdfs:label "bcc"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:binary
+uco-observable:binary
 	a owl:ObjectProperty ;
 	rdfs:label "binary"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:biosDate
+uco-observable:biosDate
 	a owl:DatatypeProperty ;
 	rdfs:label "biosDate"@en ;
 	rdfs:comment "Specifies the date of the BIOS (e.g. the datestamp of the BIOS revision)."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:biosManufacturer
+uco-observable:biosManufacturer
 	a owl:DatatypeProperty ;
 	rdfs:label "biosManufacturer"@en ;
 	rdfs:comment "Specifies the manufacturer of the BIOS."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:biosReleaseDate
+uco-observable:biosReleaseDate
 	a owl:DatatypeProperty ;
 	rdfs:label "biosReleaseDate"@en ;
 	rdfs:comment "Specifies the date the BIOS was released."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:biosSerialNumber
+uco-observable:biosSerialNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "biosSerialNumber"@en ;
 	rdfs:comment "Specifies the serial number of the BIOS."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:biosVersion
+uco-observable:biosVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "biosVersion"@en ;
 	rdfs:comment "Specifies the version of the BIOS."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:bitRate
+uco-observable:bitRate
 	a owl:DatatypeProperty ;
 	rdfs:label "bitRate"@en ;
 	rdfs:comment "The bitrate of the audio in bits per second."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:bitness
+uco-observable:bitness
 	a owl:DatatypeProperty ;
 	rdfs:label "bitness"@en ;
 	rdfs:comment "Specifies the bitness of the operating system (i.e. 32 or 64). Note that this is potentially different from the word size of the underlying hardware or CPU. A 32-bit operating system can be installed on a machine running a 64-bit processor."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:bitsPerPixel
+uco-observable:bitsPerPixel
 	a owl:DatatypeProperty ;
 	rdfs:label "bitsPerPixel"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:blockType
+uco-observable:blockType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "blockType"@en ;
 	rdfs:comment "The blockType property specifies the block type of a particular memory object."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:MemoryBlockTypeVocab
+			uco-vocabulary:MemoryBlockTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:bluetoothDeviceName
+uco-observable:bluetoothDeviceName
 	a owl:DatatypeProperty ;
 	rdfs:label "bluetoothDeviceName"@en ;
 	rdfs:comment "Name configured withing Bluetooth settings on a device."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:body
+uco-observable:body
 	a owl:DatatypeProperty ;
 	rdfs:label "body"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:bodyMultipart
+uco-observable:bodyMultipart
 	a owl:ObjectProperty ;
 	rdfs:label "bodyMultipart"@en ;
 	rdfs:comment "A list of the MIME parts that make up the email body. This field MAY only be used if isMultipart is true."@en ;
-	rdfs:range observable:MimePartType ;
+	rdfs:range uco-observable:MimePartType ;
 	.
 
-observable:bodyRaw
+uco-observable:bodyRaw
 	a owl:ObjectProperty ;
 	rdfs:label "bodyRaw"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:bookmarkPath
+uco-observable:bookmarkPath
 	a owl:DatatypeProperty ;
 	rdfs:label "bookmarkPath"@en ;
 	rdfs:comment "The folder containing the bookmark."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:browserInformation
+uco-observable:browserInformation
 	a owl:ObjectProperty ;
 	rdfs:label "Browser Information"@en ;
 	rdfs:comment "Specifies information about the particular Web Browser."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:browserUserProfile
+uco-observable:browserUserProfile
 	a owl:DatatypeProperty ;
 	rdfs:label "Browser User Profile"@en ;
 	rdfs:comment "Specifies the web browser user profile for which the URL history entry was created."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:byteOrder
+uco-observable:byteOrder
 	a owl:DatatypeProperty ;
 	rdfs:label "byteOrder"@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:EndiannessTypeVocab
+			uco-vocabulary:EndiannessTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:byteStringValue
+uco-observable:byteStringValue
 	a owl:DatatypeProperty ;
 	rdfs:label "byteStringValue"@en ;
 	rdfs:comment "Specifies the raw, byte-string representation of the extracted string."@en ;
 	rdfs:range xsd:base64Binary ;
 	.
 
-observable:callType
+uco-observable:callType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "callType"@en ;
 	rdfs:comment "The type of a phone call,for example incoming, outgoing, missed."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:camera
+uco-observable:camera
 	a owl:ObjectProperty ;
 	rdfs:label "camera"@en ;
 	rdfs:comment "The name/make of the camera that was used for taking the picture."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:canEscalatePrivs
+uco-observable:canEscalatePrivs
 	a owl:DatatypeProperty ;
 	rdfs:label "canEscalatePrivs"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:captureCellSite
+uco-observable:captureCellSite
 	a owl:ObjectProperty ;
 	rdfs:label "captureCellSite"@en ;
 	rdfs:comment "Specifies the cell site accessed."@en ;
-	rdfs:range observable:CellSite ;
+	rdfs:range uco-observable:CellSite ;
 	.
 
-observable:carrier
+uco-observable:carrier
 	a owl:ObjectProperty ;
 	rdfs:label "carrier"@en ;
 	rdfs:comment "Telecommunications service provider that sold the SIM card."@en ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-observable:categories
+uco-observable:categories
 	a owl:DatatypeProperty ;
 	rdfs:label "categories"@en ;
 	rdfs:comment "Categories applied to the object."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cc
+uco-observable:cc
 	a owl:ObjectProperty ;
 	rdfs:label "cc"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:cellSiteCountryCode
+uco-observable:cellSiteCountryCode
 	a owl:DatatypeProperty ;
 	rdfs:label "cellSiteCountryCode"@en ;
 	rdfs:comment "The country code represents the country of the cell site. For GSM, this is the Mobile Country Code (MCC)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cellSiteIdentifier
+uco-observable:cellSiteIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "cellSiteIdentifier"@en ;
 	rdfs:comment "Specifies the unique number used to identify each Cell Site within a location area code."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cellSiteLocationAreaCode
+uco-observable:cellSiteLocationAreaCode
 	a owl:DatatypeProperty ;
 	rdfs:label "cellSiteLocationAreaCode"@en ;
 	rdfs:comment "The location area code is a unique number of current location area of the cell site. A location area is a set of cell site that are grouped together to optimize signalling. For GSM, this is the LAC."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cellSiteNetworkCode
+uco-observable:cellSiteNetworkCode
 	a owl:DatatypeProperty ;
 	rdfs:label "cellSiteNetworkCode"@en ;
 	rdfs:comment "This code identifies the mobile operator of the cell site. For GSM, this is the Mobile Network Code (MNC) and for CMDA this is the network identifier (NID)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cellSiteType
+uco-observable:cellSiteType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "cellSiteType"@en ;
 	rdfs:comment "Specifies the technology used by the Cell Site (e.g., GSM, CDMA, or LTE)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:certificateIssuer
+uco-observable:certificateIssuer
 	a owl:ObjectProperty ;
 	rdfs:label "certificateIssuer"@en ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-observable:certificatePolicies
+uco-observable:certificatePolicies
 	a owl:DatatypeProperty ;
 	rdfs:label "certificatePolicies"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:certificateSubject
+uco-observable:certificateSubject
 	a owl:ObjectProperty ;
 	rdfs:label "certificateSubject"@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-observable:characteristics
+uco-observable:characteristics
 	a owl:DatatypeProperty ;
 	rdfs:label "characteristics"@en ;
 	rdfs:comment "Specifies the flags that indicate the fileâ€™s characteristics."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:checksum
+uco-observable:checksum
 	a owl:DatatypeProperty ;
 	rdfs:label "checksum"@en ;
 	rdfs:comment "Specifies the checksum of the PE binary."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:clockSetting
+uco-observable:clockSetting
 	a owl:DatatypeProperty ;
 	rdfs:label "clockSetting"@en ;
 	rdfs:comment "The generalizedTime value on the mobile device when it was processed."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:clusterSize
+uco-observable:clusterSize
 	a owl:DatatypeProperty ;
 	rdfs:label "clusterSize"@en ;
 	rdfs:comment "The size of cluster allocation units in a file system."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:columnName
+uco-observable:columnName
 	a owl:DatatypeProperty ;
 	rdfs:label "columnName"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:comClassID
+uco-observable:comClassID
 	a owl:DatatypeProperty ;
 	rdfs:label "comClassID"@en ;
 	rdfs:comment "Specifies the ID of the COM action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380613(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:comData
+uco-observable:comData
 	a owl:DatatypeProperty ;
 	rdfs:label "comData"@en ;
 	rdfs:comment "Specifies the data associated with the COM handler. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380613(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:comment
+uco-observable:comment
 	a owl:DatatypeProperty ;
 	rdfs:label "comment"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:compressionMethod
+uco-observable:compressionMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "compressionMethod"@en ;
 	rdfs:comment "The algorithm used to compress the data."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:compressionRatio
+uco-observable:compressionRatio
 	a owl:DatatypeProperty ;
 	rdfs:label "compressionRatio"@en ;
 	rdfs:comment "The compression ratio of the compressed data."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-observable:contact
+uco-observable:contact
 	a owl:ObjectProperty ;
 	rdfs:label "contact"@en ;
 	rdfs:comment "Contact specifies information characterizing contact details for a single entity."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:contactAddress
+uco-observable:contactAddress
 	a owl:ObjectProperty ;
 	rdfs:label "contactAddress"@en ;
 	rdfs:comment "Contact address specifies information characterizing a geolocation address of a contact entity."@en ;
-	rdfs:range observable:ContactAddress ;
+	rdfs:range uco-observable:ContactAddress ;
 	.
 
-observable:contactAddressScope
+uco-observable:contactAddressScope
 	a owl:DatatypeProperty ;
 	rdfs:label "contactAddressScope"@en ;
 	rdfs:comment "Contact address scope specifies the relevant scope (home, work, school, etc) for a geolocation address of a contact entity."@en ;
@@ -9786,26 +9786,26 @@ observable:contactAddressScope
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:ContactAddressScopeVocab
+			uco-vocabulary:ContactAddressScopeVocab
 		) ;
 	] ;
 	.
 
-observable:contactAffiliation
+uco-observable:contactAffiliation
 	a owl:ObjectProperty ;
 	rdfs:label "contactAffiliation"@en ;
 	rdfs:comment "Contact affiliation specifies information characterizing details of an organizational affiliation for a single contact entity."@en ;
-	rdfs:range observable:ContactAffiliation ;
+	rdfs:range uco-observable:ContactAffiliation ;
 	.
 
-observable:contactEmail
+uco-observable:contactEmail
 	a owl:ObjectProperty ;
 	rdfs:label "contactEmail"@en ;
 	rdfs:comment "Contact email specifies information characterizing details for contacting a contact entity by email."@en ;
-	rdfs:range observable:ContactEmail ;
+	rdfs:range uco-observable:ContactEmail ;
 	.
 
-observable:contactEmailScope
+uco-observable:contactEmailScope
 	a owl:DatatypeProperty ;
 	rdfs:label "contactEmailScope"@en ;
 	rdfs:comment "Contact email scope specifies the relevant scope (home, work, school, etc) of details for contacting a contact entity by email."@en ;
@@ -9813,68 +9813,68 @@ observable:contactEmailScope
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:ContactEmailScopeVocab
+			uco-vocabulary:ContactEmailScopeVocab
 		) ;
 	] ;
 	.
 
-observable:contactGroup
+uco-observable:contactGroup
 	a owl:DatatypeProperty ;
 	rdfs:label "contactGroup"@en ;
 	rdfs:comment "Contact group specifies the name/tag of a particular named/tagged grouping of contacts."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:contactID
+uco-observable:contactID
 	a owl:DatatypeProperty ;
 	rdfs:label "contactID"@en ;
 	rdfs:comment "Specifies an ID for the contact."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:contactMessaging
+uco-observable:contactMessaging
 	a owl:ObjectProperty ;
 	rdfs:label "contactMessaging"@en ;
 	rdfs:comment "Contact messaging specifies information characterizing details for contacting a contact entity by digital messaging."@en ;
-	rdfs:range observable:ContactMessaging ;
+	rdfs:range uco-observable:ContactMessaging ;
 	.
 
-observable:contactMessagingPlatform
+uco-observable:contactMessagingPlatform
 	a owl:ObjectProperty ;
 	rdfs:label "contactMessagingPlatform"@en ;
 	rdfs:comment "A contact messaging platform specifies a digital messaging platform associated with a contact."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:contactNote
+uco-observable:contactNote
 	a owl:DatatypeProperty ;
 	rdfs:label "contactNote"@en ;
 	rdfs:comment "Contact note specifies a comment/note associated with a given contact."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:contactOrganization
+uco-observable:contactOrganization
 	a owl:ObjectProperty ;
 	rdfs:label "contactOrganization"@en ;
 	rdfs:comment "The name of the organization a contact works for or is assocciated with."@en ;
-	rdfs:range identity:Organization ;
+	rdfs:range uco-identity:Organization ;
 	.
 
-observable:contactPhone
+uco-observable:contactPhone
 	a owl:ObjectProperty ;
 	rdfs:label "contactPhone"@en ;
 	rdfs:comment "Contact phone specifies information characterizing details for contacting a contact entity by telephone."@en ;
-	rdfs:range observable:ContactPhone ;
+	rdfs:range uco-observable:ContactPhone ;
 	.
 
-observable:contactPhoneNumber
+uco-observable:contactPhoneNumber
 	a owl:ObjectProperty ;
 	rdfs:label "contactPhoneNumber"@en ;
 	rdfs:comment "Contact phone number specifies a telephone service account number for contacting a contact entity by telephone."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:contactPhoneScope
+uco-observable:contactPhoneScope
 	a owl:DatatypeProperty ;
 	rdfs:label "contactPhoneScope"@en ;
 	rdfs:comment "Contact phone scope specifies the relevant scope (home, work, school, etc) of details for contacting a contact entity by telephone."@en ;
@@ -9882,33 +9882,33 @@ observable:contactPhoneScope
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:ContactPhoneScopeVocab
+			uco-vocabulary:ContactPhoneScopeVocab
 		) ;
 	] ;
 	.
 
-observable:contactProfile
+uco-observable:contactProfile
 	a owl:ObjectProperty ;
 	rdfs:label "contactProfile"@en ;
 	rdfs:comment "Contact profile specifies information characterizing details for contacting a contact entity by online service."@en ;
-	rdfs:range observable:ContactProfile ;
+	rdfs:range uco-observable:ContactProfile ;
 	.
 
-observable:contactProfilePlatform
+uco-observable:contactProfilePlatform
 	a owl:ObjectProperty ;
 	rdfs:label "contactProfilePlatform"@en ;
 	rdfs:comment "A contact profile platform specifies an online service platform associated with a contact."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:contactSIP
+uco-observable:contactSIP
 	a owl:ObjectProperty ;
 	rdfs:label "contactSIP"@en ;
 	rdfs:comment "Contact SIP specifies information characterizing details for contacting a contact entity by Session Initiation Protocol (SIP)."@en ;
-	rdfs:range observable:ContactSIP ;
+	rdfs:range uco-observable:ContactSIP ;
 	.
 
-observable:contactSIPScope
+uco-observable:contactSIPScope
 	a owl:DatatypeProperty ;
 	rdfs:label "contactSIPScope"@en ;
 	rdfs:comment "Contact SIP scope specifies the relevant scope (home, work, school, etc) of details for contacting a contact entity by Session Initiation Protocol (SIP)."@en ;
@@ -9916,19 +9916,19 @@ observable:contactSIPScope
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:ContactSIPScopeVocab
+			uco-vocabulary:ContactSIPScopeVocab
 		) ;
 	] ;
 	.
 
-observable:contactURL
+uco-observable:contactURL
 	a owl:ObjectProperty ;
 	rdfs:label "contactURL"@en ;
 	rdfs:comment "Contact URL specifies information characterizing details for contacting a contact entity by Uniform Resource Locator (URL)."@en ;
-	rdfs:range observable:ContactURL ;
+	rdfs:range uco-observable:ContactURL ;
 	.
 
-observable:contactURLScope
+uco-observable:contactURLScope
 	a owl:DatatypeProperty ;
 	rdfs:label "contactURLScope"@en ;
 	rdfs:comment "Contact url scope specifies the relevant scope (homepage, home, work, school, etc) of details for contacting a contact entity by Uniform Resource Locator (URL)."@en ;
@@ -9936,106 +9936,106 @@ observable:contactURLScope
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:ContactURLScopeVocab
+			uco-vocabulary:ContactURLScopeVocab
 		) ;
 	] ;
 	.
 
-observable:contentDisposition
+uco-observable:contentDisposition
 	a owl:DatatypeProperty ;
 	rdfs:label "contentDisposition"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:contentRecoveredStatus
+uco-observable:contentRecoveredStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "contentRecoveredStatus"@en ;
 	rdfs:comment "Specifies the recoverability status of the content of an object."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:RecoveredObjectStatusVocab
+			uco-vocabulary:RecoveredObjectStatusVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:contentType
+uco-observable:contentType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "contentType"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:context
+uco-observable:context
 	a owl:DatatypeProperty ;
 	rdfs:label "context"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:controlCode
+uco-observable:controlCode
 	a owl:DatatypeProperty ;
 	rdfs:label "controlCode"@en ;
 	rdfs:comment "Specifies the actual control code that was sent to the observable object."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cookieDomain
+uco-observable:cookieDomain
 	a owl:ObjectProperty ;
 	rdfs:label "cookieDomain"@en ;
 	rdfs:comment "The domain for which the cookie is stored, for example nfi.minjus.nl."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:cookieName
+uco-observable:cookieName
 	a owl:DatatypeProperty ;
 	rdfs:label "cookieName"@en ;
 	rdfs:comment "The name of the cookie."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cookiePath
+uco-observable:cookiePath
 	a owl:DatatypeProperty ;
 	rdfs:label "cookiePath"@en ;
 	rdfs:comment "String representation of the path of the cookie."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cpeid
+uco-observable:cpeid
 	a owl:DatatypeProperty ;
 	rdfs:label "cpeid"@en ;
 	rdfs:comment "Specifies the Common Platform Enumeration identifier for the software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cpu
+uco-observable:cpu
 	a owl:DatatypeProperty ;
 	rdfs:label "cpu"@en ;
 	rdfs:comment "Specifies the name of the CPU used by the system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cpuFamily
+uco-observable:cpuFamily
 	a owl:DatatypeProperty ;
 	rdfs:label "cpuFamily"@en ;
 	rdfs:comment "Specifies the name of the CPU family used by the system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:creationDate
+uco-observable:creationDate
 	a owl:DatatypeProperty ;
 	rdfs:label "creationDate"@en ;
 	rdfs:comment "Specifies the date in which the registered domain was created."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:creationFlags
+uco-observable:creationFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "creationFlags"@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:creationTime
+uco-observable:creationTime
 	a
 		owl:DatatypeProperty ,
 		owl:DeprecatedProperty
@@ -10044,1046 +10044,1046 @@ observable:creationTime
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:creationTime-deprecation-shape
+uco-observable:creationTime-deprecation-shape
 	a sh:NodeShape ;
 	sh:property [
 		a sh:PropertyShape ;
 		sh:maxCount "0"^^xsd:integer ;
-		sh:message "observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  observable:observableCreatedTime should be used instead."@en ;
-		sh:path observable:creationTime ;
+		sh:message "uco-observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  uco-observable:observableCreatedTime should be used instead."@en ;
+		sh:path uco-observable:creationTime ;
 		sh:severity sh:Warning ;
 	] ;
-	sh:targetSubjectsOf observable:creationTime ;
+	sh:targetSubjectsOf uco-observable:creationTime ;
 	.
 
-observable:creator
+uco-observable:creator
 	a owl:ObjectProperty ;
 	rdfs:label "creator"@en ;
 	rdfs:comment "Specifies the name of the creator of the registry key."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:creatorUser
+uco-observable:creatorUser
 	a owl:ObjectProperty ;
 	rdfs:label "creatorUser"@en ;
 	rdfs:comment "The user that created/owns the process."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:crlDistributionPoints
+uco-observable:crlDistributionPoints
 	a owl:DatatypeProperty ;
 	rdfs:label "crlDistributionPoints"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:currentSystemDate
+uco-observable:currentSystemDate
 	a owl:DatatypeProperty ;
 	rdfs:label "currentSystemDate"@en ;
 	rdfs:comment "Specifies the current date on the system."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:currentWorkingDirectory
+uco-observable:currentWorkingDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "currentWorkingDirectory"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:cyberAction
+uco-observable:cyberAction
 	a owl:ObjectProperty ;
 	rdfs:label "cyberAction"@en ;
 	rdfs:comment "The action taken in response to the event."@en ;
-	rdfs:range observable:ObservableAction ;
+	rdfs:range uco-observable:ObservableAction ;
 	.
 
-observable:data
+uco-observable:data
 	a owl:DatatypeProperty ;
 	rdfs:label "data"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:dataPayload
+uco-observable:dataPayload
 	a owl:DatatypeProperty ;
 	rdfs:label "dataPayload"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:dataPayloadReferenceURL
+uco-observable:dataPayloadReferenceURL
 	a owl:ObjectProperty ;
 	rdfs:label "dataPayloadReferenceURL"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:dataType
+uco-observable:dataType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "dataType"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:depEnabled
+uco-observable:depEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "depEnabled"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:descriptions
+uco-observable:descriptions
 	a owl:DatatypeProperty ;
 	rdfs:label "descriptions"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:destination
+uco-observable:destination
 	a owl:DatatypeProperty ;
 	rdfs:label "destination"@en ;
 	rdfs:comment "The destination of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:destinationFlags
+uco-observable:destinationFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "destinationFlags"@en ;
 	rdfs:comment "Specifies the destination TCP flags."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:destinationPort
+uco-observable:destinationPort
 	a owl:DatatypeProperty ;
 	rdfs:label "destinationPort"@en ;
 	rdfs:comment "Specifies the destination port used in the connection, as an integer in the range of 0 - 65535."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:deviceType
+uco-observable:deviceType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "deviceType"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:dhcpLeaseExpires
+uco-observable:dhcpLeaseExpires
 	a owl:DatatypeProperty ;
 	rdfs:label "dhcpLeaseExpires"@en ;
 	rdfs:comment "Specifies the date/time that the DHCP lease obtained on the network interface expires."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:dhcpLeaseObtained
+uco-observable:dhcpLeaseObtained
 	a owl:DatatypeProperty ;
 	rdfs:label "dhcpLeaseObtained"@en ;
 	rdfs:comment "Specifies the date/time that the DHCP lease was obtained on the network interface."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:dhcpServer
+uco-observable:dhcpServer
 	a owl:ObjectProperty ;
 	rdfs:label "dhcpServer"@en ;
 	rdfs:comment "Specifies the list of DHCP server IP Addresses used by the network interface."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:diskPartitionType
+uco-observable:diskPartitionType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "diskPartitionType"@en ;
 	rdfs:comment "Specifies the type of partition being characterized."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:diskSize
+uco-observable:diskSize
 	a owl:DatatypeProperty ;
 	rdfs:label "diskSize"@en ;
 	rdfs:comment "The size of the disk, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:diskType
+uco-observable:diskType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "diskType"@en ;
 	rdfs:comment "The type of disk being characterized, e.g., removable."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:displayName
+uco-observable:displayName
 	a owl:DatatypeProperty ;
 	rdfs:label "displayName"@en ;
 	rdfs:comment "Display name specifies the name to display for some entity within a user interface."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:dllCharacteristics
+uco-observable:dllCharacteristics
 	a owl:DatatypeProperty ;
 	rdfs:label "dllCharacteristics"@en ;
 	rdfs:comment "Specifies the flags that characterize the PE binary."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:dnssec
+uco-observable:dnssec
 	a owl:DatatypeProperty ;
 	rdfs:label "dnssec"@en ;
 	rdfs:comment "Specifies the DNSSEC property associated with a Whois entry. Acceptable values are: 'Signed' or 'Unsigned'."@en ;
-	rdfs:range vocabulary:WhoisDNSSECTypeVocab ;
+	rdfs:range uco-vocabulary:WhoisDNSSECTypeVocab ;
 	.
 
-observable:documentInformationDictionary
+uco-observable:documentInformationDictionary
 	a owl:ObjectProperty ;
 	rdfs:label "documentInformationDictionary"@en ;
-	rdfs:range types:ControlledDictionary ;
+	rdfs:range uco-types:ControlledDictionary ;
 	.
 
-observable:domain
+uco-observable:domain
 	a owl:DatatypeProperty ;
 	rdfs:label "domain"@en ;
 	rdfs:comment "The domain(s) that the system belongs to."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:domainID
+uco-observable:domainID
 	a owl:DatatypeProperty ;
 	rdfs:label "domainID"@en ;
 	rdfs:comment "Specifies the domain id for the domain associated with a Whois entry."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:domainName
+uco-observable:domainName
 	a owl:ObjectProperty ;
 	rdfs:label "domainName"@en ;
 	rdfs:comment "Specifies the corresponding domain name for a whois entry."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:driveLetter
+uco-observable:driveLetter
 	a owl:DatatypeProperty ;
 	rdfs:label "driveLetter"@en ;
 	rdfs:comment "Specifies the drive letter of a windows volume."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:driveType
+uco-observable:driveType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "driveType"@en ;
 	rdfs:comment "Specifies the drive type of a windows volume."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:WindowsDriveTypeVocab
+			uco-vocabulary:WindowsDriveTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:dst
+uco-observable:dst
 	a owl:ObjectProperty ;
 	rdfs:label "dst"@en ;
 	rdfs:comment "Specifies the destination(s) of the network connection."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:dstBytes
+uco-observable:dstBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "dstBytes"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:dstPackets
+uco-observable:dstPackets
 	a owl:DatatypeProperty ;
 	rdfs:label "dstPackets"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:dstPayload
+uco-observable:dstPayload
 	a owl:ObjectProperty ;
 	rdfs:label "dstPayload"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:duration
+uco-observable:duration
 	a owl:DatatypeProperty ;
 	rdfs:label "duration"@en ;
 	rdfs:comment "The duration of the phone call in seconds."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:effectiveGroup
+uco-observable:effectiveGroup
 	a owl:DatatypeProperty ;
 	rdfs:label "effectiveGroup"@en ;
 	rdfs:comment "Specifies the name of the effective group used in the user session."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:effectiveGroupID
+uco-observable:effectiveGroupID
 	a owl:DatatypeProperty ;
 	rdfs:label "effectiveGroupID"@en ;
 	rdfs:comment "Specifies the effective group ID of the group used in the user session."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:effectiveUser
+uco-observable:effectiveUser
 	a owl:ObjectProperty ;
 	rdfs:label "effectiveUser"@en ;
 	rdfs:comment "Specifies the effective user details used in the user session."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:elevation
+uco-observable:elevation
 	a owl:DatatypeProperty ;
 	rdfs:label "elevation"@en ;
 	rdfs:comment "The angle in degrees of the antenna from the local horizontal plane."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-observable:emailAddress
+uco-observable:emailAddress
 	a owl:ObjectProperty ;
 	rdfs:label "emailAddress"@en ;
 	rdfs:comment "An email address."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:encoding
+uco-observable:encoding
 	a owl:DatatypeProperty ;
 	rdfs:label "Encoding"@en ;
 	rdfs:comment "The encoding method used for the extracted string."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:encodingMethod
+uco-observable:encodingMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "encodingMethod"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:encryptionIV
+uco-observable:encryptionIV
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionIV"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:encryptionKey
+uco-observable:encryptionKey
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionKey"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:encryptionMethod
+uco-observable:encryptionMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionMethod"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:encryptionMode
+uco-observable:encryptionMode
 	a owl:DatatypeProperty ;
 	rdfs:label "encryptionMode"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:endTime
+uco-observable:endTime
 	a owl:DatatypeProperty ;
 	rdfs:label "endTime"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:englishTranslation
+uco-observable:englishTranslation
 	a owl:DatatypeProperty ;
 	rdfs:label "englishTranslation"@en ;
 	rdfs:comment "Specifies the English translation of the string, if it is not written in English."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:entropy
+uco-observable:entropy
 	a owl:DatatypeProperty ;
 	rdfs:label "entropy"@en ;
 	rdfs:comment "Shannon entropy (a measure of randomness) of the data."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-observable:entryID
+uco-observable:entryID
 	a owl:DatatypeProperty ;
 	rdfs:label "entryID"@en ;
 	rdfs:comment "A unique identifier for the file within the filesystem."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:environmentVariables
+uco-observable:environmentVariables
 	a owl:ObjectProperty ;
 	rdfs:label "environmentVariables"@en ;
 	rdfs:comment "A list of environment variables associated with the process. "@en ;
-	rdfs:range types:Dictionary ;
+	rdfs:range uco-types:Dictionary ;
 	.
 
-observable:eventRecordDevice
+uco-observable:eventRecordDevice
 	a owl:ObjectProperty ;
 	rdfs:label "device"@en ;
 	rdfs:comment "The device on which the log entry was generated."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:eventRecordID
+uco-observable:eventRecordID
 	a owl:DatatypeProperty ;
 	rdfs:label "eventRecordID"@en ;
 	rdfs:comment "The identifier of the event record."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:eventRecordRaw
+uco-observable:eventRecordRaw
 	a owl:DatatypeProperty ;
 	rdfs:label "eventRecordRaw"@en ;
 	rdfs:comment "The complete raw content of the event record."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:eventRecordServiceName
+uco-observable:eventRecordServiceName
 	a owl:DatatypeProperty ;
 	rdfs:label "eventServiceName"@en ;
 	rdfs:comment "The service that generated the event record. A single application can have multiple services generating event records."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:eventRecordText
+uco-observable:eventRecordText
 	a owl:DatatypeProperty ;
 	rdfs:label "eventRecordText"@en ;
 	rdfs:comment "The textual representation of the event."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:eventStatus
+uco-observable:eventStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "eventStatus"@en ;
 	rdfs:comment "The status of the event, for instance accepted, pending or cancelled."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:eventType
+uco-observable:eventType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "eventType"@en ;
 	rdfs:comment "The type of the event, for example 'information', 'warning' or 'error'."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:execArguments
+uco-observable:execArguments
 	a owl:DatatypeProperty ;
 	rdfs:label "execArguments"@en ;
 	rdfs:comment "Specifies the arguments associated with the command-line operation launched by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:execProgramHashes
+uco-observable:execProgramHashes
 	a owl:ObjectProperty ;
 	rdfs:label "execProgramHashes"@en ;
 	rdfs:comment "Specifies the hashes of the executable file launched by the action."@en ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:execProgramPath
+uco-observable:execProgramPath
 	a owl:DatatypeProperty ;
 	rdfs:label "execProgramPath"@en ;
 	rdfs:comment "Specifies the path to the executable file launched by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:execWorkingDirectory
+uco-observable:execWorkingDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "execWorkingDirectory"@en ;
 	rdfs:comment "Specifies the directory that contains either the executable file or the files that are used by the executable file launched by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:exifData
+uco-observable:exifData
 	a owl:ObjectProperty ;
 	rdfs:label "exifData"@en ;
-	rdfs:range types:ControlledDictionary ;
+	rdfs:range uco-types:ControlledDictionary ;
 	.
 
-observable:exitCode
+uco-observable:exitCode
 	a owl:DatatypeProperty ;
 	rdfs:label "exitCode"@en ;
 	rdfs:comment "Specifies the last exit code of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381245(v=vs.85).aspx."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:exitStatus
+uco-observable:exitStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "exitStatus"@en ;
 	rdfs:comment "A small number passed from the process to the parent process when it has finished executing. In general, 0 indicates successful termination, any other number indicates a failure."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:exitTime
+uco-observable:exitTime
 	a owl:DatatypeProperty ;
 	rdfs:label "exitTime"@en ;
 	rdfs:comment "The time at which the process exited."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:expirationDate
+uco-observable:expirationDate
 	a owl:DatatypeProperty ;
 	rdfs:label "expirationDate"@en ;
 	rdfs:comment "Specifies the date in which the registered domain will expire."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:expirationTime
+uco-observable:expirationTime
 	a owl:DatatypeProperty ;
 	rdfs:label "expirationTime"@en ;
 	rdfs:comment "The date and time at which the validity of the object expires."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:extDeletionTime
+uco-observable:extDeletionTime
 	a owl:DatatypeProperty ;
 	rdfs:label "extDeletionTime"@en ;
 	rdfs:comment "Specifies the time at which the file represented by an Inode was 'deleted'."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:extFileType
+uco-observable:extFileType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "extFileType"@en ;
 	rdfs:comment "Specifies the EXT file type (FIFO, Directory, Regular file, Symbolic link, etc) for the Inode."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:extFlags
+uco-observable:extFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "extFlags"@en ;
 	rdfs:comment "Specifies user flags to further protect (limit its use and modification) the file represented by an Inode."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:extHardLinkCount
+uco-observable:extHardLinkCount
 	a owl:DatatypeProperty ;
 	rdfs:label "extHardLinkCount"@en ;
 	rdfs:comment "Specifies a count of how many hard links point to an Inode."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:extInodeChangeTime
+uco-observable:extInodeChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "extInodeChangeTime"@en ;
 	rdfs:comment "The date and time at which the file Inode metadata was last modified."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:extInodeID
+uco-observable:extInodeID
 	a owl:DatatypeProperty ;
 	rdfs:label "extInodeID"@en ;
 	rdfs:comment "Specifies a single Inode identifier."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:extPermissions
+uco-observable:extPermissions
 	a owl:DatatypeProperty ;
 	rdfs:label "extPermissions"@en ;
 	rdfs:comment "Specifies the read/write/execute permissions for the file represented by an EXT Inode."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:extSGID
+uco-observable:extSGID
 	a owl:DatatypeProperty ;
 	rdfs:label "extSGID"@en ;
 	rdfs:comment "Specifies the group ID for the file represented by an Inode."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:extSUID
+uco-observable:extSUID
 	a owl:DatatypeProperty ;
 	rdfs:label "extSUID"@en ;
 	rdfs:comment "Specifies the user ID that 'owns' the file represented by an Inode."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:extendedKeyUsage
+uco-observable:extendedKeyUsage
 	a owl:DatatypeProperty ;
 	rdfs:label "extendedKeyUsage"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:extension
+uco-observable:extension
 	a owl:DatatypeProperty ;
 	rdfs:label "extension"@en ;
 	rdfs:comment "The file name extension: everything after the last dot. Not present if the file has no dot in its name."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:favoritesCount
+uco-observable:favoritesCount
 	a owl:DatatypeProperty ;
 	rdfs:label "Favorites Count"@en-US ;
 	rdfs:comment "Specifies the number of times that this profile has favorited a tweet."@en-US ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:fileAlignment
+uco-observable:fileAlignment
 	a owl:DatatypeProperty ;
 	rdfs:label "fileAlignment"@en ;
 	rdfs:comment "Specifies the factor (in bytes) that is used to align the raw data of sections in the image file."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:fileHeaderHashes
+uco-observable:fileHeaderHashes
 	a owl:ObjectProperty ;
 	rdfs:label "fileHeaderHashes"@en ;
 	rdfs:comment "Specifies any hashes that were computed for the file header."@en ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:fileName
+uco-observable:fileName
 	a owl:DatatypeProperty ;
 	rdfs:label "fileName"@en ;
 	rdfs:comment "Specifies the name associated with a file in a file system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:filePath
+uco-observable:filePath
 	a owl:DatatypeProperty ;
 	rdfs:label "filePath"@en ;
 	rdfs:comment "Specifies the file path for the location of a file within a filesystem."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:fileSystemType
+uco-observable:fileSystemType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "fileSystemType"@en ;
 	rdfs:comment "The specific type of a file system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:firstLoginTime
+uco-observable:firstLoginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "firstLoginTime"@en ;
 	rdfs:comment "The date and time of the first login of the account."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:firstName
+uco-observable:firstName
 	a owl:DatatypeProperty ;
 	rdfs:label "firstName"@en ;
 	rdfs:comment "The first name of a person."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:firstRun
+uco-observable:firstRun
 	a owl:DatatypeProperty ;
 	rdfs:label "firstRun"@en ;
 	rdfs:comment "Timestamp of when the prefetch application was first run."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:firstVisit
+uco-observable:firstVisit
 	a owl:DatatypeProperty ;
 	rdfs:label "First Visit Time"@en ;
 	rdfs:comment "Specifies the date/time that the URL referred to by the URL field was first visited."@en-US ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:flags
+uco-observable:flags
 	a owl:DatatypeProperty ;
 	rdfs:label "flags"@en ;
 	rdfs:comment "Specifies any flags that modify the behavior of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381248(v=vs.85).aspx."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:TaskFlagVocab
+			uco-vocabulary:TaskFlagVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:followersCount
+uco-observable:followersCount
 	a owl:DatatypeProperty ;
 	rdfs:label "Followers Count"@en-US ;
 	rdfs:comment "Specifies the followers count associated with the twitter profile."@en-US ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:format
+uco-observable:format
 	a owl:DatatypeProperty ;
 	rdfs:label "format"@en ;
 	rdfs:comment "The format of the audio. For example: mp3 or flac."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:fragment
+uco-observable:fragment
 	a owl:DatatypeProperty ;
 	rdfs:label "fragment"@en ;
 	rdfs:comment "Fragment pointing to a specific part in the resource."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:fragmentIndex
+uco-observable:fragmentIndex
 	a owl:DatatypeProperty ;
 	rdfs:label "fragmentIndex"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:freeSpace
+uco-observable:freeSpace
 	a owl:DatatypeProperty ;
 	rdfs:label "freeSpace"@en ;
 	rdfs:comment "The amount of free space on the disk, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:friendsCount
+uco-observable:friendsCount
 	a owl:DatatypeProperty ;
 	rdfs:label "Friends Count"@en-US ;
 	rdfs:comment "Specifies the friends count associated with the twitter profile."@en-US ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:from
+uco-observable:from
 	a owl:ObjectProperty ;
 	rdfs:label "from"@en ;
 	rdfs:comment "The phone number of the initiating party."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:fromURLVisit
+uco-observable:fromURLVisit
 	a owl:ObjectProperty ;
 	rdfs:label "From URL Visit"@en ;
 	rdfs:comment "Specifies the URL visit origination point (i.e., URL) of the URL captured in the URL history entry, if applicable."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:fullValue
+uco-observable:fullValue
 	a owl:DatatypeProperty ;
 	rdfs:label "fullValue"@en ;
 	rdfs:comment "The full string value of the URL."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:geoLocationEntry
+uco-observable:geoLocationEntry
 	a owl:ObjectProperty ;
 	rdfs:label "geoLocationEntry"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:geolocationAddress
+uco-observable:geolocationAddress
 	a owl:ObjectProperty ;
 	rdfs:label "geolocationAddress"@en ;
 	rdfs:comment "An administrative address for a particular geolocation."@en ;
-	rdfs:range location:Location ;
+	rdfs:range uco-location:Location ;
 	.
 
-observable:gid
+uco-observable:gid
 	a owl:DatatypeProperty ;
 	rdfs:label "gid"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:globalFlagList
+uco-observable:globalFlagList
 	a owl:ObjectProperty ;
 	rdfs:label "globalFlagList"@en ;
 	rdfs:comment "A list of global flags. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549557(v=vs.85).aspx."@en ;
-	rdfs:range observable:GlobalFlagType ;
+	rdfs:range uco-observable:GlobalFlagType ;
 	.
 
-observable:gpu
+uco-observable:gpu
 	a owl:DatatypeProperty ;
 	rdfs:label "gpu"@en ;
 	rdfs:comment "Specifies the name of the GPU used by the system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:gpuFamily
+uco-observable:gpuFamily
 	a owl:DatatypeProperty ;
 	rdfs:label "gpuFamily"@en ;
 	rdfs:comment "Specifies the name of the GPU family used by the system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:groupName
+uco-observable:groupName
 	a owl:DatatypeProperty ;
 	rdfs:label "groupName"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:groups
+uco-observable:groups
 	a owl:DatatypeProperty ;
 	rdfs:label "groups"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:hasChanged
+uco-observable:hasChanged
 	a owl:DatatypeProperty ;
 	rdfs:label "hasChanged"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:hash
+uco-observable:hash
 	a owl:ObjectProperty ;
 	rdfs:label "hash"@en ;
 	rdfs:comment "Hash values of the data."@en ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:hashes
+uco-observable:hashes
 	a owl:ObjectProperty ;
 	rdfs:label "hashes"@en ;
 	rdfs:comment "Specifies any hashes computed over the section."@en ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:headerRaw
+uco-observable:headerRaw
 	a owl:ObjectProperty ;
 	rdfs:label "headerRaw"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:hexadecimalValue
+uco-observable:hexadecimalValue
 	a owl:DatatypeProperty ;
 	rdfs:label "hexadecimalValue"@en ;
 	rdfs:comment "The hexadecimal value of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:hiveType
+uco-observable:hiveType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "hiveType"@en ;
 	rdfs:comment "The type of a registry hive."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:homeDirectory
+uco-observable:homeDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "homeDirectory"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:horizontalBeamWidth
+uco-observable:horizontalBeamWidth
 	a owl:DatatypeProperty ;
 	rdfs:label "horizontalBeamWidth"@en ;
 	rdfs:comment "The width of the antenna beam in degrees."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:host
+uco-observable:host
 	a owl:ObjectProperty ;
 	rdfs:label "host"@en ;
 	rdfs:comment "Domain name or IP address where the resource is located."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:hostname
+uco-observable:hostname
 	a owl:DatatypeProperty ;
 	rdfs:label "hostname"@en ;
 	rdfs:comment "Specifies the hostname of the system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:httpMesageBodyLength
+uco-observable:httpMesageBodyLength
 	a owl:DatatypeProperty ;
 	rdfs:label "httpMesageBodyLength"@en ;
 	rdfs:comment "Specifies the length of an HTTP message body in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:httpMessageBodyData
+uco-observable:httpMessageBodyData
 	a owl:ObjectProperty ;
 	rdfs:label "httpMessageBodyData"@en ;
 	rdfs:comment "Specifies the data contained in an HTTP message body."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:httpRequestHeader
+uco-observable:httpRequestHeader
 	a owl:ObjectProperty ;
 	rdfs:label "httpRequestHeader"@en ;
 	rdfs:comment "Specifies all of the HTTP header fields that may be found in the HTTP client request"@en ;
-	rdfs:range types:Dictionary ;
+	rdfs:range uco-types:Dictionary ;
 	.
 
-observable:iComHandlerAction
+uco-observable:iComHandlerAction
 	a owl:ObjectProperty ;
 	rdfs:label "iComHandlerAction"@en ;
 	rdfs:comment "Specifies the data associated with the task action-fired COM handler."@en ;
-	rdfs:range observable:IComHandlerActionType ;
+	rdfs:range uco-observable:IComHandlerActionType ;
 	.
 
-observable:iEmailAction
+uco-observable:iEmailAction
 	a owl:ObjectProperty ;
 	rdfs:label "iEmailAction"@en ;
 	rdfs:comment "Specifies an action that sends an e-mail, which in this context refers to actual email message sent. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380693(v=vs.85).aspx."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:iExecAction
+uco-observable:iExecAction
 	a owl:ObjectProperty ;
 	rdfs:label "iExecAction"@en ;
 	rdfs:comment "Specifies an action that executes a command-line operation. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380715(v=vs.85).aspx."@en ;
-	rdfs:range observable:IExecActionType ;
+	rdfs:range uco-observable:IExecActionType ;
 	.
 
-observable:iShowMessageAction
+uco-observable:iShowMessageAction
 	a owl:ObjectProperty ;
 	rdfs:label "iShowMessageAction"@en ;
 	rdfs:comment "Specifies an action that shows a message box when a task is activated. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381302(v=vs.85).aspx."@en ;
-	rdfs:range observable:IShowMessageActionType ;
+	rdfs:range uco-observable:IShowMessageActionType ;
 	.
 
-observable:icmpCode
+uco-observable:icmpCode
 	a owl:DatatypeProperty ;
 	rdfs:label "icmpCode"@en ;
 	rdfs:comment "Specifies the ICMP code byte."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:icmpType
+uco-observable:icmpType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "icmpType"@en ;
 	rdfs:comment "Specifies the ICMP type byte."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:imageBase
+uco-observable:imageBase
 	a owl:DatatypeProperty ;
 	rdfs:label "imageBase"@en ;
 	rdfs:comment "Specifies the address that is relative to the image base of the beginning-of-data section when it is loaded into memory."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:imageCompressionMethod
+uco-observable:imageCompressionMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "imageCompressionMethod"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:imageName
+uco-observable:imageName
 	a owl:DatatypeProperty ;
 	rdfs:label "imageName"@en ;
 	rdfs:comment "Specifies the image name for the task."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:imageType
+uco-observable:imageType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "imageType"@en ;
 	rdfs:comment "The type of the image, e.g. EnCase, RAW or LocalFolder."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:impHash
+uco-observable:impHash
 	a owl:DatatypeProperty ;
 	rdfs:label "impHash"@en ;
 	rdfs:comment "Specifies the special import hash, or â€˜imphashâ€™, calculated for the PE Binary based on its imported libraries and functions. "@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:inReplyTo
+uco-observable:inReplyTo
 	a owl:DatatypeProperty ;
 	rdfs:label "inReplyTo"@en ;
 	rdfs:comment "One of more unique identifiers for identifying the email(s) this email is a reply to."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:inetLocation
+uco-observable:inetLocation
 	a owl:ObjectProperty ;
 	rdfs:label "Internet Location"@en-US ;
 	rdfs:comment "Specifies a location on the Internet."@en-US ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:inhibitAnyPolicy
+uco-observable:inhibitAnyPolicy
 	a owl:DatatypeProperty ;
 	rdfs:label "inhibitAnyPolicy"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:installDate
+uco-observable:installDate
 	a owl:DatatypeProperty ;
 	rdfs:label "installDate"@en ;
 	rdfs:comment "Specifies the date the operating system or application was installed."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:installedVersionHistory
+uco-observable:installedVersionHistory
 	a owl:ObjectProperty ;
 	rdfs:label "installedVersionHistory"@en ;
 	rdfs:comment "Specifies the history of installed application version(s)."@en ;
-	rdfs:range observable:ApplicationVersion ;
+	rdfs:range uco-observable:ApplicationVersion ;
 	.
 
-observable:interceptedCallState
+uco-observable:interceptedCallState
 	a owl:DatatypeProperty ;
 	rdfs:label "interceptedCallState"@en ;
 	rdfs:comment "State of the call in a Call Detail Record (e.g. idle)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:ip
+uco-observable:ip
 	a owl:ObjectProperty ;
 	rdfs:label "ip"@en ;
 	rdfs:comment "Specifies the list of IP addresses used by the network interface."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:ipAddress
+uco-observable:ipAddress
 	a owl:ObjectProperty ;
 	rdfs:label "ipAddress"@en ;
 	rdfs:comment "Specifies the corresponding ip address for a whois entry. Usually corresponds to a name server lookup."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:ipGateway
+uco-observable:ipGateway
 	a owl:ObjectProperty ;
 	rdfs:label "ipGateway"@en ;
 	rdfs:comment "Specifies the list of IP Gateway IP Addresses used by the network interface."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:ipfix
+uco-observable:ipfix
 	a owl:ObjectProperty ;
 	rdfs:label "ipfix"@en ;
 	rdfs:comment "Specifies any IP Flow Information Export (IPFIX) data for the network traffic flow."@en ;
-	rdfs:range types:Dictionary ;
+	rdfs:range uco-types:Dictionary ;
 	.
 
-observable:isADBRootEnabled
+uco-observable:isADBRootEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "isADBRootEnabled"@en ;
 	rdfs:comment "Root access through the Android Debug Bridge (ADB) daemon observed to be enabled. [based on https://developer.android.com/studio/command-line/adb]"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isActive
+uco-observable:isActive
 	a owl:DatatypeProperty ;
 	rdfs:label "isActive"@en ;
 	rdfs:comment "Indicates whether the network connection is still active."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isDirectory
+uco-observable:isDirectory
 	a owl:DatatypeProperty ;
 	rdfs:label "isDirectory"@en ;
 	rdfs:comment "Specifies whether a file entry represents a directory."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isDisabled
+uco-observable:isDisabled
 	a owl:DatatypeProperty ;
 	rdfs:label "isDisabled"@en ;
 	rdfs:comment "Is the digital account disabled?"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isEnabled
+uco-observable:isEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "isEnabled"@en ;
 	rdfs:comment "Specifies whether the trigger is enabled."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isEncrypted
+uco-observable:isEncrypted
 	a owl:DatatypeProperty ;
 	rdfs:label "isEncrypted"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isHidden
+uco-observable:isHidden
 	a owl:DatatypeProperty ;
 	rdfs:label "isHidden"@en ;
 	rdfs:comment """The isHidden property specifies whether the process is hidden or not.
@@ -11091,169 +11091,169 @@ observable:isHidden
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isInjected
+uco-observable:isInjected
 	a owl:DatatypeProperty ;
 	rdfs:label "isInjected"@en ;
 	rdfs:comment "The isInjected property specifies whether or not the particular memory object has had data/code injected into it by another process."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isLimitAdTrackingEnabled
+uco-observable:isLimitAdTrackingEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "isLimitAdTrackingEnabled"@en ;
 	rdfs:comment "Limits advertising tracking if enabled. [based on https://developer.android.com/reference/androidx/ads/identifier/AdvertisingIdInfo]"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isMapped
+uco-observable:isMapped
 	a owl:DatatypeProperty ;
 	rdfs:label "isMapped"@en ;
 	rdfs:comment "The isMapped property specifies whether or not the particular memory object has been assigned a byte-for-byte correlation with some portion of a file or file-like resource."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isMimeEncoded
+uco-observable:isMimeEncoded
 	a owl:DatatypeProperty ;
 	rdfs:label "isMimeEncoded"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isMultipart
+uco-observable:isMultipart
 	a owl:DatatypeProperty ;
 	rdfs:label "isMultipart"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isNamed
+uco-observable:isNamed
 	a owl:DatatypeProperty ;
 	rdfs:label "isNamed"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isOptimized
+uco-observable:isOptimized
 	a owl:DatatypeProperty ;
 	rdfs:label "isOptimized"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isPrivate
+uco-observable:isPrivate
 	a owl:DatatypeProperty ;
 	rdfs:label "isPrivate"@en ;
 	rdfs:comment "Is the event marked as private?"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isPrivileged
+uco-observable:isPrivileged
 	a owl:DatatypeProperty ;
 	rdfs:label "isPrivileged"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isProtected
+uco-observable:isProtected
 	a owl:DatatypeProperty ;
 	rdfs:label "isProtected"@en ;
 	rdfs:comment "The isProtected property specifies whether or not the particular memory object is protected (read/write only from the process that allocated it)."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isRead
+uco-observable:isRead
 	a owl:DatatypeProperty ;
 	rdfs:label "isRead"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isSURootEnabled
+uco-observable:isSURootEnabled
 	a owl:DatatypeProperty ;
 	rdfs:label "isSURootEnabled"@en ;
 	rdfs:comment "Root access through Linux SU binary observed to be enabled. [based on https://en.wikipedia.org/wiki/Rooting_(Android)]"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isSecure
+uco-observable:isSecure
 	a owl:DatatypeProperty ;
 	rdfs:label "isSecure"@en ;
 	rdfs:comment "Is the cookie secure? If the cookie is secure it cannot be delivered over an unencrypted session such as http."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isSelfSigned
+uco-observable:isSelfSigned
 	a owl:DatatypeProperty ;
 	rdfs:label "isSelfSigned"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isServiceAccount
+uco-observable:isServiceAccount
 	a owl:DatatypeProperty ;
 	rdfs:label "isServiceAccount"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isTLD
+uco-observable:isTLD
 	a owl:DatatypeProperty ;
 	rdfs:label "isTLD"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:isVolatile
+uco-observable:isVolatile
 	a owl:DatatypeProperty ;
 	rdfs:label "isVolatile"@en ;
 	rdfs:comment "The isVolatile property specifies whether or not the particular memory object is volatile."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:issuer
+uco-observable:issuer
 	a owl:DatatypeProperty ;
 	rdfs:label "issuer"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:issuerAlternativeName
+uco-observable:issuerAlternativeName
 	a owl:DatatypeProperty ;
 	rdfs:label "issuerAlternativeName"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:issuerHash
+uco-observable:issuerHash
 	a owl:ObjectProperty ;
 	rdfs:label "issuerHash"@en ;
 	rdfs:comment "A hash calculated on the certificate issuer name."@en ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:key
+uco-observable:key
 	a owl:DatatypeProperty ;
 	rdfs:label "key"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:keyUsage
+uco-observable:keyUsage
 	a owl:DatatypeProperty ;
 	rdfs:label "keyUsage"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:keypadUnlockCode
+uco-observable:keypadUnlockCode
 	a owl:DatatypeProperty ;
 	rdfs:label "keypadUnlockCode"@en ;
 	rdfs:comment "A code or password set on a device for security that must be entered to gain access to the device."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:keywordSearchTerm
+uco-observable:keywordSearchTerm
 	a owl:DatatypeProperty ;
 	rdfs:label "Keyword Search Term"@en ;
 	rdfs:comment "Specifies a string representing a keyword search term contained within the URL field."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:labels
+uco-observable:labels
 	a owl:DatatypeProperty ;
 	rdfs:label "labels"@en ;
 	rdfs:comment "Named and colored label."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:language
+uco-observable:language
 	a owl:DatatypeProperty ;
 	rdfs:label "language"@en ;
 	rdfs:comment """Specifies the language the string is written in, e.g. English.
@@ -11261,348 +11261,348 @@ observable:language
 	rdfs:range xsd:string ;
 	.
 
-observable:lastLoginTime
+uco-observable:lastLoginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "lastLoginTime"@en ;
 	rdfs:comment "The date and time of the last login of the account."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:lastName
+uco-observable:lastName
 	a owl:DatatypeProperty ;
 	rdfs:label "lastName"@en ;
 	rdfs:comment "The last name of a person."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:lastRun
+uco-observable:lastRun
 	a owl:DatatypeProperty ;
 	rdfs:label "lastRun"@en ;
 	rdfs:comment "Timestamp of when the prefetch application was last run."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:lastShutdownDate
+uco-observable:lastShutdownDate
 	a owl:DatatypeProperty ;
 	rdfs:label "lastShutdownDate"@en ;
 	rdfs:comment "Specifies the date on which the device was last shutdown."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:lastTimeContacted
+uco-observable:lastTimeContacted
 	a owl:DatatypeProperty ;
 	rdfs:label "lastTimeContacted"@en ;
 	rdfs:comment "Last time contacted specifies the date and time that a particular contact was last contacted."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:lastVisit
+uco-observable:lastVisit
 	a owl:DatatypeProperty ;
 	rdfs:label "Last Visit Time"@en ;
 	rdfs:comment "Specifies the date/time that the URL referred to by the URL field was last visited."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:length
+uco-observable:length
 	a owl:DatatypeProperty ;
 	rdfs:label "length"@en ;
 	rdfs:comment "Specifies the length, in characters, of the extracted string."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:libraryType
+uco-observable:libraryType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "libraryType"@en ;
 	rdfs:comment "Specifies the type of library being characterized."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:listedCount
+uco-observable:listedCount
 	a owl:DatatypeProperty ;
 	rdfs:label "listedCount"@en ;
 	rdfs:comment "Specifies the number of public lists that this profile is associated with."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:loaderFlags
+uco-observable:loaderFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "loaderFlags"@en ;
 	rdfs:comment "Specifies the reserved loader flags"@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:localTime
+uco-observable:localTime
 	a owl:DatatypeProperty ;
 	rdfs:label "localTime"@en ;
 	rdfs:comment "Specifies the local time on the system."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:location
+uco-observable:location
 	a owl:ObjectProperty ;
 	rdfs:label "location"@en ;
 	rdfs:comment "An associated location."@en ;
-	rdfs:range location:Location ;
+	rdfs:range uco-location:Location ;
 	.
 
-observable:loginTime
+uco-observable:loginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "loginTime"@en ;
 	rdfs:comment "Specifies the date/time of the login for the user session."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:logoutTime
+uco-observable:logoutTime
 	a owl:DatatypeProperty ;
 	rdfs:label "logoutTime"@en ;
 	rdfs:comment "Specifies the date/time of the logout for the user session."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:lookupDate
+uco-observable:lookupDate
 	a owl:DatatypeProperty ;
 	rdfs:label "lookupDate"@en ;
 	rdfs:comment "Specifies the date and time that the Whois record was queried."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:macAddress
+uco-observable:macAddress
 	a owl:ObjectProperty ;
 	rdfs:label "macAddress"@en ;
 	rdfs:comment "Specifies the MAC or hardware address of the physical network card. "@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:machine
+uco-observable:machine
 	a owl:DatatypeProperty ;
 	rdfs:label "machine"@en ;
 	rdfs:comment "Specifies the type of target machine."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:magic
+uco-observable:magic
 	a owl:DatatypeProperty ;
 	rdfs:label "magic"@en ;
 	rdfs:comment "Specifies the value that indicates the type of the PE binary."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:magicNumber
+uco-observable:magicNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "magicNumber"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:majorImageVersion
+uco-observable:majorImageVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorImageVersion"@en ;
 	rdfs:comment "Specifies the major version number of the image."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:majorLinkerVersion
+uco-observable:majorLinkerVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorLinkerVersion"@en ;
 	rdfs:comment "Specifies the linker major version number."@en ;
 	rdfs:range xsd:byte ;
 	.
 
-observable:majorOSVersion
+uco-observable:majorOSVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorOSVersion"@en ;
 	rdfs:comment "Specifies the major version number of the required operating system."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:majorSubsystemVersion
+uco-observable:majorSubsystemVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "majorSubsystemVersion"@en ;
 	rdfs:comment "Specifies the major version number of the subsystem."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:manuallyEnteredCount
+uco-observable:manuallyEnteredCount
 	a owl:DatatypeProperty ;
 	rdfs:label "Manually-Entered Count"@en ;
 	rdfs:comment "Specifies the number of times the URL referred to by the URL field was manually entered into the browser's address field by the user. This field is only applicable for URL history entries generated by Google's Chrome browser."@en ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:manufacturer
+uco-observable:manufacturer
 	a owl:ObjectProperty ;
 	rdfs:label "manufacturer"@en ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-observable:maxRunTime
+uco-observable:maxRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "maxRunTime"@en ;
 	rdfs:comment "Specifies the maximum run time of the scheduled task before terminating, in milliseconds. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381874(v=vs.85).aspx."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:messageID
+uco-observable:messageID
 	a owl:DatatypeProperty ;
 	rdfs:label "messageID"@en ;
 	rdfs:comment "An unique identifier for the message."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:messageText
+uco-observable:messageText
 	a owl:DatatypeProperty ;
 	rdfs:label "messageText"@en ;
 	rdfs:comment "The contents of the message."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:messageThread
+uco-observable:messageThread
 	a owl:ObjectProperty ;
 	rdfs:label "messageThread"@en ;
-	rdfs:range types:Thread ;
+	rdfs:range uco-types:Thread ;
 	.
 
-observable:messageType
+uco-observable:messageType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "messageType"@en ;
 	rdfs:comment "Message type specifies what sort of message (email, chat, SMS, etc) a Message is."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:messagingAddress
+uco-observable:messagingAddress
 	a owl:ObjectProperty ;
 	rdfs:label "messagingAddress"@en ;
 	rdfs:comment "A messaging address specifies details of an identifier for digital messsaging communication."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:metadataChangeTime
+uco-observable:metadataChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "metadataChangeTime"@en ;
 	rdfs:comment "The date and time at which the file metadata was last modified."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:metadataRecoveredStatus
+uco-observable:metadataRecoveredStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "metadataRecoveredStatus"@en ;
 	rdfs:comment "Specifies the recoverability status of the metadata of an object."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:RecoveredObjectStatusVocab
+			uco-vocabulary:RecoveredObjectStatusVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:mftFileID
+uco-observable:mftFileID
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileID"@en ;
 	rdfs:comment "Specifies the record number for the file within an NTFS Master File Table."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:mftFileNameAccessedTime
+uco-observable:mftFileNameAccessedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameAccessedTime"@en ;
 	rdfs:comment "The access date and time recorded in an MFT entry $File_Name attribute."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:mftFileNameCreatedTime
+uco-observable:mftFileNameCreatedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameCreatedTime"@en ;
 	rdfs:comment "The creation date and time recorded in an MFT entry $File_Name attribute."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:mftFileNameLength
+uco-observable:mftFileNameLength
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameLength"@en ;
 	rdfs:comment " Specifies the length of an NTFS file name, in unicode characters."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:mftFileNameModifiedTime
+uco-observable:mftFileNameModifiedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameModifiedTime"@en ;
 	rdfs:comment "The modification date and time recorded in an MFT entry $File_Name attribute."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:mftFileNameRecordChangeTime
+uco-observable:mftFileNameRecordChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFileNameRecordChangeTime"@en ;
 	rdfs:comment "The metadata modification date and time recorded in an MFT entry $File_Name attribute."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:mftFlags
+uco-observable:mftFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "mftFlags"@en ;
 	rdfs:comment "Specifies basic permissions for the file (Read-Only, Hidden, Archive, Compressed, etc.)."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:mftParentID
+uco-observable:mftParentID
 	a owl:DatatypeProperty ;
 	rdfs:label "mftParentID"@en ;
 	rdfs:comment "Specifies the record number within an NTFS Master File Table for parent directory of the file."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:mftRecordChangeTime
+uco-observable:mftRecordChangeTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mftRecordChangeTime"@en ;
 	rdfs:comment "The date and time at which an NTFS file metadata was last modified."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:middleName
+uco-observable:middleName
 	a owl:DatatypeProperty ;
 	rdfs:label "middleName"@en ;
 	rdfs:comment "The middle name of a person."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:mimeClass
+uco-observable:mimeClass
 	a owl:DatatypeProperty ;
 	rdfs:label "mimeClass"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:mimeType
+uco-observable:mimeType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "mimeType"@en ;
 	rdfs:comment "MIME type of the data. For example 'text/html' or 'audio/mp3'."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:minorImageVersion
+uco-observable:minorImageVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorImageVersion"@en ;
 	rdfs:comment "Specifies the minor version number of the image."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:minorLinkerVersion
+uco-observable:minorLinkerVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorLinkerVersion"@en ;
 	rdfs:comment "Specifies the linker minor version number."@en ;
 	rdfs:range xsd:byte ;
 	.
 
-observable:minorOSVersion
+uco-observable:minorOSVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorOSVersion"@en ;
 	rdfs:comment "Specifies the minor version number of the required operating system."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:minorSubsystemVersion
+uco-observable:minorSubsystemVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "minorSubsystemVersion"@en ;
 	rdfs:comment """Specifies the minor version number of the subsystem.
@@ -11610,518 +11610,518 @@ observable:minorSubsystemVersion
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:mockLocationsAllowed
+uco-observable:mockLocationsAllowed
 	a owl:DatatypeProperty ;
 	rdfs:label "mockLocationsAllowed"@en ;
 	rdfs:comment "???."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:model
+uco-observable:model
 	a owl:DatatypeProperty ;
 	rdfs:label "model"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:modifiedTime
+uco-observable:modifiedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "modifiedTime"@en ;
 	rdfs:comment "The date and time at which the Object was last modified."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:mostRecentRunTime
+uco-observable:mostRecentRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "mostRecentRunTime"@en ;
 	rdfs:comment "Specifies the most recent run date/time of this scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381254(v=vs.85).aspx."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:mountPoint
+uco-observable:mountPoint
 	a owl:DatatypeProperty ;
 	rdfs:label "mountPoint"@en ;
 	rdfs:comment "Specifies the mount point of the partition."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:msProductID
+uco-observable:msProductID
 	a owl:DatatypeProperty ;
 	rdfs:label "msProductID"@en ;
 	rdfs:comment "The Microsoft Product ID. See also: http://support.microsoft.com/gp/pidwin."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:msProductName
+uco-observable:msProductName
 	a owl:DatatypeProperty ;
 	rdfs:label "msProductName"@en ;
 	rdfs:comment "The Microsoft ProductName of the current installation of Windows. This is typically found in HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion!ProductName."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:mutexName
+uco-observable:mutexName
 	a owl:DatatypeProperty ;
 	rdfs:label "mutexName"@en ;
 	rdfs:comment "Specifies the name identifier for a specific instance of a mechanism that enforces limits on access to a resource when there are many threads of execution ."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:nameConstraints
+uco-observable:nameConstraints
 	a owl:DatatypeProperty ;
 	rdfs:label "nameConstraints"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:namePhonetic
+uco-observable:namePhonetic
 	a owl:DatatypeProperty ;
 	rdfs:label "namePhonetic"@en ;
 	rdfs:comment "Name phonetic specifies the phonetic pronunciation of the name of a person."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:namePrefix
+uco-observable:namePrefix
 	a owl:DatatypeProperty ;
 	rdfs:label "namePrefix"@en ;
 	rdfs:comment "Name prefix specifies an honorific prefix (coming ordinally before first/given name) for the name of a person."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:nameRecoveredStatus
+uco-observable:nameRecoveredStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "nameRecoveredStatus"@en ;
 	rdfs:comment "Specifies the recoverability status of the name of an object."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:RecoveredObjectStatusVocab
+			uco-vocabulary:RecoveredObjectStatusVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:nameServer
+uco-observable:nameServer
 	a owl:ObjectProperty ;
 	rdfs:label "nameServer"@en ;
 	rdfs:comment "Specifies a list of name server entries for a Whois entry."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:nameSuffix
+uco-observable:nameSuffix
 	a owl:DatatypeProperty ;
 	rdfs:label "nameSuffix"@en ;
 	rdfs:comment "Name suffix specifies an suffix (coming ordinally after last/family name) for the name of a person."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:netBIOSName
+uco-observable:netBIOSName
 	a owl:DatatypeProperty ;
 	rdfs:label "netBIOSName"@en ;
 	rdfs:comment "Specifies the NetBIOS (Network Basic Input/Output System) name of the Windows system. This is not the same as the host name."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:network
+uco-observable:network
 	a owl:DatatypeProperty ;
 	rdfs:label "network"@en ;
 	rdfs:comment "???."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:networkInterface
+uco-observable:networkInterface
 	a owl:ObjectProperty ;
 	rdfs:label "networkInterface"@en ;
 	rdfs:comment "Specifies the list of network interfaces present on the system."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:newObject
+uco-observable:newObject
 	a owl:ObjectProperty ;
 	rdfs:label "newObject"@en ;
 	rdfs:comment "Specifies the observable object and its properties as they are after the state change effect occurred."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:nextRunTime
+uco-observable:nextRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "nextRunTime"@en ;
 	rdfs:comment "Specifies the next run date/time of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381257(v=vs.85).aspx."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:nickname
+uco-observable:nickname
 	a owl:DatatypeProperty ;
 	rdfs:label "nickname"@en ;
 	rdfs:comment "Nickname specifies an alternate, unofficial and typically informal name for a person independent of their official name."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:ntfsHardLinkCount
+uco-observable:ntfsHardLinkCount
 	a owl:DatatypeProperty ;
 	rdfs:label "ntfsHardLinkCount"@en ;
 	rdfs:comment "Specifies the number of directory entries that reference an NTFS file record."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:ntfsOwnerID
+uco-observable:ntfsOwnerID
 	a owl:DatatypeProperty ;
 	rdfs:label "ntfsOwnerID"@en ;
 	rdfs:comment "Specifies the identifier of the file owner, from the security index."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:ntfsOwnerSID
+uco-observable:ntfsOwnerSID
 	a owl:DatatypeProperty ;
 	rdfs:label "ntfsOwnerSID"@en ;
 	rdfs:comment "Specifies the security ID (key in the $SII Index and $SDS DataStream in the file $Secure) for an NTFS file."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:number
+uco-observable:number
 	a owl:DatatypeProperty ;
 	rdfs:label "number"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:numberOfLaunches
+uco-observable:numberOfLaunches
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfLaunches"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:numberOfRVAAndSizes
+uco-observable:numberOfRVAAndSizes
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfRVAAndSizes"@en ;
 	rdfs:comment "Specifies the number of data-directory entries in the remainder of the optional header."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:numberOfSections
+uco-observable:numberOfSections
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfSections"@en ;
 	rdfs:comment "Specifies the number of sections in the PE binary, as a non-negative integer."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:numberOfSubkeys
+uco-observable:numberOfSubkeys
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfSubkeys"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:numberOfSymbols
+uco-observable:numberOfSymbols
 	a owl:DatatypeProperty ;
 	rdfs:label "numberOfSymbols"@en ;
 	rdfs:comment "Specifies the number of entries in the symbol table of the PE binary, as a non-negative integer."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:numberTimesContacted
+uco-observable:numberTimesContacted
 	a owl:DatatypeProperty ;
 	rdfs:label "numberTimesContacted"@en ;
 	rdfs:comment "Number times contacted specifies the number of times a particular contact has been contacted."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:objectGUID
+uco-observable:objectGUID
 	a owl:DatatypeProperty ;
 	rdfs:label "objectGUID"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:observableCreatedTime
+uco-observable:observableCreatedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "observableCreatedTime"@en ;
 	rdfs:comment "The date and time at which the observable object being characterized was created. This time pertains to an intrinsic characteristic of the observable object, and would be consistent across independent characterizations or observations of the observable object."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:oldObject
+uco-observable:oldObject
 	a owl:ObjectProperty ;
 	rdfs:label "oldObject"@en ;
 	rdfs:comment "Specifies the observable object and its properties as they were before the state change effect occurred."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:openFileDescriptor
+uco-observable:openFileDescriptor
 	a owl:DatatypeProperty ;
 	rdfs:label "openFileDescriptor"@en ;
 	rdfs:comment "Specifies a listing of the current file descriptors used by the Unix process."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:operatingSystem
+uco-observable:operatingSystem
 	a owl:ObjectProperty ;
 	rdfs:label "operatingSystem"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:optionalHeader
+uco-observable:optionalHeader
 	a owl:ObjectProperty ;
 	rdfs:label "optionalHeader"@en ;
 	rdfs:comment "Specifies the PE optional header of the PE binary."@en ;
-	rdfs:range observable:WindowsPEOptionalHeader ;
+	rdfs:range uco-observable:WindowsPEOptionalHeader ;
 	.
 
-observable:options
+uco-observable:options
 	a owl:DatatypeProperty ;
 	rdfs:label "options"@en ;
 	rdfs:comment "Specifies any options used when mounting the volume."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:organizationDepartment
+uco-observable:organizationDepartment
 	a owl:DatatypeProperty ;
 	rdfs:label "organizationDepartment"@en ;
 	rdfs:comment "Specifies a particular suborganization (division, branch, office, etc.) that exists within a larger organization."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:organizationLocation
+uco-observable:organizationLocation
 	a owl:ObjectProperty ;
 	rdfs:label "organizationLocation"@en ;
 	rdfs:comment "Specifies a geolocation address of an organization."@en ;
-	rdfs:range observable:ContactAddress ;
+	rdfs:range uco-observable:ContactAddress ;
 	.
 
-observable:organizationPosition
+uco-observable:organizationPosition
 	a owl:DatatypeProperty ;
 	rdfs:label "organizationPosition"@en ;
 	rdfs:comment "Specifies the title or role that a person plays within an organization."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:osInstallDate
+uco-observable:osInstallDate
 	a owl:DatatypeProperty ;
 	rdfs:label "osInstallDate"@en ;
 	rdfs:comment "Specifies the date on which the operating system (OS) was installed."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:osLastUpgradeDate
+uco-observable:osLastUpgradeDate
 	a owl:DatatypeProperty ;
 	rdfs:label "osLastUpgradeDate"@en ;
 	rdfs:comment "Specifies the date on which the operating system (OS) was last upgraded."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:otherHeaders
+uco-observable:otherHeaders
 	a owl:ObjectProperty ;
 	rdfs:label "otherHeaders"@en ;
-	rdfs:range types:Dictionary ;
+	rdfs:range uco-types:Dictionary ;
 	.
 
-observable:owner
+uco-observable:owner
 	a owl:ObjectProperty ;
 	rdfs:label "owner"@en ;
 	rdfs:comment "Specifies the owner of an Observable Object."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-observable:ownerSID
+uco-observable:ownerSID
 	a owl:DatatypeProperty ;
 	rdfs:label "ownerSID"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:pageTitle
+uco-observable:pageTitle
 	a owl:DatatypeProperty ;
 	rdfs:label "Page Title"@en ;
 	rdfs:comment "Specifies the title of a web page."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:parameterAddress
+uco-observable:parameterAddress
 	a owl:DatatypeProperty ;
 	rdfs:label "parameterAddress"@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:parameters
+uco-observable:parameters
 	a owl:DatatypeProperty ;
 	rdfs:label "parameters"@en ;
 	rdfs:comment "Specifies the command line parameters used to launch the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381875(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:parent
+uco-observable:parent
 	a owl:ObjectProperty ;
 	rdfs:label "parent"@en ;
 	rdfs:comment "The process that created this process."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:participant
+uco-observable:participant
 	a owl:ObjectProperty ;
 	rdfs:label "participant"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:partition
+uco-observable:partition
 	a owl:ObjectProperty ;
 	rdfs:label "partition"@en ;
 	rdfs:comment "The partitions that reside on the disk."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:partitionID
+uco-observable:partitionID
 	a owl:DatatypeProperty ;
 	rdfs:label "partitionID"@en ;
 	rdfs:comment "Specifies the identifier of the partition, as provided by the containing partition table.  This identifier is the index value within the partition table, and is expected to be an incrementing alphanumeric value (numeric in most partition systems), not a GUID or UUID.  Sorting partitions by this index should first attempt to sort a numeric cast of the value."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:partitionLength
+uco-observable:partitionLength
 	a owl:DatatypeProperty ;
 	rdfs:label "partitionLength"@en ;
 	rdfs:comment "Specifies the length of the partition, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:partitionOffset
+uco-observable:partitionOffset
 	a owl:DatatypeProperty ;
 	rdfs:label "partitionOffset"@en ;
 	rdfs:comment "Specifies the starting offset of the partition, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:password
+uco-observable:password
 	a owl:DatatypeProperty ;
 	rdfs:label "password"@en ;
 	rdfs:comment "Specifies an authentication password."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:passwordLastChanged
+uco-observable:passwordLastChanged
 	a owl:DatatypeProperty ;
 	rdfs:label "passwordLastChanged"@en ;
 	rdfs:comment "The date and time that the password was last changed."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:passwordType
+uco-observable:passwordType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "passwordType"@en ;
 	rdfs:comment "The type of password, for instance plain-text or encrypted."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:path
+uco-observable:path
 	a owl:DatatypeProperty ;
 	rdfs:label "path"@en ;
 	rdfs:comment "Specifies the location of one object within another containing object."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:pdfCreationDate
+uco-observable:pdfCreationDate
 	a owl:DatatypeProperty ;
 	rdfs:label "pdfCreationDate"@en ;
 	rdfs:comment "The PDF CreationDate property is defined in ISO 32000-1:2008 as 'The date and time the document was created, in human-readable form' (Table 317).  As a UCO property, its value is converted to xsd:dateTime."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:pdfId0
+uco-observable:pdfId0
 	a owl:DatatypeProperty ;
 	rdfs:label "pdfId0"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:pdfId1
+uco-observable:pdfId1
 	a owl:DatatypeProperty ;
 	rdfs:label "pdfId1"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:pdfModDate
+uco-observable:pdfModDate
 	a owl:DatatypeProperty ;
 	rdfs:label "pdfModDate"@en ;
 	rdfs:comment "The PDF ModDate property is defined in ISO 32000-1:2008 as 'The date and time the document was most recently modified, in human-readable form' (Table 317).  As a UCO property, its value is converted to xsd:dateTime."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:peType
+uco-observable:peType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "peType"@en ;
 	rdfs:comment "Specifies the type of the PE binary."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:phoneActivationTime
+uco-observable:phoneActivationTime
 	a owl:DatatypeProperty ;
 	rdfs:label "phoneActivationTime"@en ;
 	rdfs:comment "The date and time that a device was activated."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:phoneNumber
+uco-observable:phoneNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "phoneNumber"@en ;
 	rdfs:comment "A phone number(account)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:pictureHeight
+uco-observable:pictureHeight
 	a owl:DatatypeProperty ;
 	rdfs:label "pictureHeight"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:pictureType
+uco-observable:pictureType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "pictureType"@en ;
 	rdfs:comment "The type of a picture, for example a thumbnail."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:pictureWidth
+uco-observable:pictureWidth
 	a owl:DatatypeProperty ;
 	rdfs:label "pictureWidth"@en ;
 	rdfs:comment "The width of the picture in pixels."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:pid
+uco-observable:pid
 	a owl:DatatypeProperty ;
 	rdfs:label "pid"@en ;
 	rdfs:comment "The Process ID, or PID, of the process."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:pointerToSymbolTable
+uco-observable:pointerToSymbolTable
 	a owl:DatatypeProperty ;
 	rdfs:label "pointerToSymbolTable"@en ;
 	rdfs:comment "Specifies the file offset of the COFF symbol table."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:policyConstraints
+uco-observable:policyConstraints
 	a owl:DatatypeProperty ;
 	rdfs:label "policyConstraints"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:policyMappings
+uco-observable:policyMappings
 	a owl:DatatypeProperty ;
 	rdfs:label "policyMappings"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:port
+uco-observable:port
 	a owl:DatatypeProperty ;
 	rdfs:label "port"@en ;
 	rdfs:comment "Port on which communication takes place."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:prefetchHash
+uco-observable:prefetchHash
 	a owl:DatatypeProperty ;
 	rdfs:label "prefetchHash"@en ;
 	rdfs:comment "An eight character hash of the location from which the application was run."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:priority
+uco-observable:priority
 	a owl:DatatypeProperty ;
 	rdfs:label "priority"@en ;
 	rdfs:comment "The priority of the email."@en ;
@@ -12130,213 +12130,213 @@ observable:priority
 		owl:unionOf (
 			xsd:integer
 			xsd:string
-			vocabulary:TaskPriorityVocab
+			uco-vocabulary:TaskPriorityVocab
 		) ;
 	] ;
 	.
 
-observable:privateKeyUsagePeriodNotAfter
+uco-observable:privateKeyUsagePeriodNotAfter
 	a owl:DatatypeProperty ;
 	rdfs:label "privateKeyUsagePeriodNotAfter"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:privateKeyUsagePeriodNotBefore
+uco-observable:privateKeyUsagePeriodNotBefore
 	a owl:DatatypeProperty ;
 	rdfs:label "privateKeyUsagePeriodNotBefore"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:processorArchitecture
+uco-observable:processorArchitecture
 	a owl:DatatypeProperty ;
 	rdfs:label "processorArchitecture"@en ;
 	rdfs:comment "Specifies the specific architecture (e.g. x86) used by the CPU of the system."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:profile
+uco-observable:profile
 	a owl:ObjectProperty ;
 	rdfs:label "profile"@en ;
 	rdfs:comment "A profile specifies a particular online service profile."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:profileAccount
+uco-observable:profileAccount
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Account"@en-US ;
 	rdfs:comment "Specifies the online service account associated with the profile."@en-US ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:profileBackgroundHash
+uco-observable:profileBackgroundHash
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Background Hash"@en-US ;
 	rdfs:comment "Specifies hashes of the background associated with the profile."@en-US ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:profileBackgroundLocation
+uco-observable:profileBackgroundLocation
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Background Location"@en-US ;
 	rdfs:comment "Specifies the network location of the background associated with the profile."@en-US ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:profileBannerHash
+uco-observable:profileBannerHash
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Banner Hash"@en-US ;
 	rdfs:comment "Specifies hashes of the banner associated with the profile."@en-US ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:profileBannerLocation
+uco-observable:profileBannerLocation
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Banner Location"@en-US ;
 	rdfs:comment "Specifies the network location of the banner associated with the profile."@en-US ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:profileCreated
+uco-observable:profileCreated
 	a owl:DatatypeProperty ;
 	rdfs:label "Profile Created"@en-US ;
 	rdfs:comment "Specifies the date and time the profile was created."@en-US ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:profileIdentity
+uco-observable:profileIdentity
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Identity"@en-US ;
 	rdfs:comment "Specifies the identity associated with the profile."@en-US ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-observable:profileImageHash
+uco-observable:profileImageHash
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Image Hash"@en-US ;
 	rdfs:comment "Specifies hashes of the profile image associated with the profile."@en-US ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:profileImageLocation
+uco-observable:profileImageLocation
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Image Location"@en-US ;
 	rdfs:comment "Specifies the network location of the profile image associated with the profile."@en-US ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:profileIsProtected
+uco-observable:profileIsProtected
 	a owl:DatatypeProperty ;
 	rdfs:label "Is_Protected"@en-US ;
 	rdfs:comment "Specifies whether the twitter profile is protected."@en-US ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:profileIsVerified
+uco-observable:profileIsVerified
 	a owl:DatatypeProperty ;
 	rdfs:label "Is_Verified"@en-US ;
 	rdfs:comment "Specifies whether the twitter profile is verified."@en-US ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:profileLanguage
+uco-observable:profileLanguage
 	a owl:DatatypeProperty ;
 	rdfs:label "Profile Language"@en-US ;
 	rdfs:comment "Specifies the language associated with the profile. When present, it MUST be a language code conformant to RFC 5646/BCP47."@en-US ;
 	rdfs:range xsd:string ;
 	.
 
-observable:profileService
+uco-observable:profileService
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Service"@en-US ;
 	rdfs:comment "Specifies the online service associated with the profile."@en-US ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:profileWebsite
+uco-observable:profileWebsite
 	a owl:ObjectProperty ;
 	rdfs:label "Profile Website"@en-US ;
 	rdfs:comment "Specifies the website URL associated with the profile."@en-US ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:properties
+uco-observable:properties
 	a owl:DatatypeProperty ;
 	rdfs:label "properties"@en ;
 	rdfs:comment "Specifies the properties that were enumerated as a result of the action on the observable object."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:propertyName
+uco-observable:propertyName
 	a owl:DatatypeProperty ;
 	rdfs:label "propertyName"@en ;
 	rdfs:comment "Specifies the Name of the property being read."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:protocols
+uco-observable:protocols
 	a owl:ObjectProperty ;
 	rdfs:label "protocols"@en ;
 	rdfs:comment "Specifies the protocols involved in the network connection, along with their corresponding state. "@en ;
-	rdfs:range types:ControlledDictionary ;
+	rdfs:range uco-types:ControlledDictionary ;
 	.
 
-observable:query
+uco-observable:query
 	a owl:DatatypeProperty ;
 	rdfs:label "query"@en ;
 	rdfs:comment "Query passed to the resource."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:rangeOffset
+uco-observable:rangeOffset
 	a owl:DatatypeProperty ;
 	rdfs:label "rangeOffset"@en ;
 	rdfs:comment "The offset at which the start of data can be found, relative to the rangeOffsetType defined."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:rangeOffsetType
+uco-observable:rangeOffsetType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "rangeOffsetType"@en ;
 	rdfs:comment "The type of offset defined for the range (e.g., image, file, address)."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:rangeSize
+uco-observable:rangeSize
 	a owl:DatatypeProperty ;
 	rdfs:label "rangeSize"@en ;
 	rdfs:comment "The size of the data in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:receivedLines
+uco-observable:receivedLines
 	a owl:DatatypeProperty ;
 	rdfs:label "receivedLines"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:receivedTime
+uco-observable:receivedTime
 	a owl:DatatypeProperty ;
 	rdfs:label "receivedTime"@en ;
 	rdfs:comment "The date and time at which the message received. "@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:recordFieldIsNull
+uco-observable:recordFieldIsNull
 	a owl:DatatypeProperty ;
 	rdfs:label "recordFieldIsNull"@en ;
 	rdfs:comment "Whether the specified database record field is null."@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:recordFieldName
+uco-observable:recordFieldName
 	a owl:DatatypeProperty ;
 	rdfs:label "recordFieldName"@en ;
 	rdfs:comment "A field name of a database record value being identified."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:recordFieldValue
+uco-observable:recordFieldValue
 	a owl:DatatypeProperty ;
 	rdfs:label "recordFieldValue"@en ;
 	rdfs:comment "The field value of a specified database record."@en ;
@@ -12351,7 +12351,7 @@ observable:recordFieldValue
 	] ;
 	.
 
-observable:recordRowID
+uco-observable:recordRowID
 	a owl:DatatypeProperty ;
 	rdfs:label "recordRowID"@en ;
 	rdfs:comment "The unique ID that identifies a database record, supplied by the originating database engine."@en ;
@@ -12364,49 +12364,49 @@ observable:recordRowID
 	] ;
 	.
 
-observable:recurrence
+uco-observable:recurrence
 	a owl:DatatypeProperty ;
 	rdfs:label "recurrence"@en ;
 	rdfs:comment "Recurrence of the event."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:references
+uco-observable:references
 	a owl:ObjectProperty ;
 	rdfs:label "references"@en ;
 	rdfs:comment "A list of email message identifiers this email relates to."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:referralURL
+uco-observable:referralURL
 	a owl:ObjectProperty ;
 	rdfs:label "referralURL"@en ;
 	rdfs:comment "Specifies the corresponding referral URL for a registrar."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:referrerUrl
+uco-observable:referrerUrl
 	a owl:ObjectProperty ;
 	rdfs:label "referrerURL"@en ;
 	rdfs:comment "Specifies the origination point (i.e., URL) of a URL request."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:regionEndAddress
+uco-observable:regionEndAddress
 	a owl:DatatypeProperty ;
 	rdfs:label "regionEndAddress"@en ;
 	rdfs:comment "The regionEndAddress property specifies the ending address of the particular memory region."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:regionSize
+uco-observable:regionSize
 	a owl:DatatypeProperty ;
 	rdfs:label "regionSize"@en ;
 	rdfs:comment "The regionSize property specifies the size of the particular memory region, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:regionStartAddress
+uco-observable:regionStartAddress
 	a owl:DatatypeProperty ;
 	rdfs:label "regionStartAddress"@en ;
 	rdfs:comment """The regionStartAddress property specifies the starting address of the particular memory region.
@@ -12414,20 +12414,20 @@ observable:regionStartAddress
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:regionalInternetRegistry
+uco-observable:regionalInternetRegistry
 	a owl:DatatypeProperty ;
 	rdfs:label "regionalInternetRegistry"@en ;
 	rdfs:comment "specifies the name of the Regional Internet Registry (RIR) which allocated the IP address contained in a WHOIS entry."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:RegionalRegistryTypeVocab
+			uco-vocabulary:RegionalRegistryTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:regionalInternetRegistry-shape-value-not-vocabulary-member
+uco-observable:regionalInternetRegistry-shape-value-not-vocabulary-member
 	a sh:PropertyShape ;
 	sh:in (
 		"APNIC"
@@ -12437,93 +12437,93 @@ observable:regionalInternetRegistry-shape-value-not-vocabulary-member
 		"RIPE NCC"
 	) ;
 	sh:message "Value is not member of the vocabulary RegionalRegistryTypeVocab." ;
-	sh:path observable:regionalInternetRegistry ;
+	sh:path uco-observable:regionalInternetRegistry ;
 	sh:severity sh:Info ;
 	.
 
-observable:regionalInternetRegistry-shape-value-outside-default-vocabulary
+uco-observable:regionalInternetRegistry-shape-value-outside-default-vocabulary
 	a sh:PropertyShape ;
 	sh:deactivated "true"^^xsd:boolean ;
-	sh:path observable:regionalInternetRegistry ;
+	sh:path uco-observable:regionalInternetRegistry ;
 	.
 
-observable:registeredOrganization
+uco-observable:registeredOrganization
 	a owl:ObjectProperty ;
 	rdfs:label "registeredOrganization"@en ;
 	rdfs:comment "The organization that this copy of Windows is registered to."@en ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-observable:registeredOwner
+uco-observable:registeredOwner
 	a owl:ObjectProperty ;
 	rdfs:label "registeredOwner"@en ;
 	rdfs:comment "The person or organization that is the registered owner of this copy of Windows."@en ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-observable:registrantContactInfo
+uco-observable:registrantContactInfo
 	a owl:ObjectProperty ;
 	rdfs:label "registrantContactInfo"@en ;
 	rdfs:comment "Specifies contact info for the registrant of a domain within a WHOIS entity."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:registrantIDs
+uco-observable:registrantIDs
 	a owl:DatatypeProperty ;
 	rdfs:label "registrantIDs"@en ;
 	rdfs:comment "Specifies the registrant IDs associated with a domain lookup."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:registrarGUID
+uco-observable:registrarGUID
 	a owl:DatatypeProperty ;
 	rdfs:label "registrarGUID"@en ;
 	rdfs:comment "Specifies the Registrar GUID field of a Whois entry."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:registrarID
+uco-observable:registrarID
 	a owl:DatatypeProperty ;
 	rdfs:label "registrarID"@en ;
 	rdfs:comment "Specifies the Registrar ID field of a Whois entry."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:registrarInfo
+uco-observable:registrarInfo
 	a owl:ObjectProperty ;
 	rdfs:label "registrarInfo"@en ;
 	rdfs:comment "Specifies registrar info that would be returned from a registrar lookup."@en ;
-	rdfs:range observable:WhoisRegistrarInfoType ;
+	rdfs:range uco-observable:WhoisRegistrarInfoType ;
 	.
 
-observable:registrarName
+uco-observable:registrarName
 	a owl:DatatypeProperty ;
 	rdfs:label "registrarName"@en ;
 	rdfs:comment "The name of the registrar organization."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:registryValues
+uco-observable:registryValues
 	a owl:ObjectProperty ;
 	rdfs:label "registryValues"@en ;
 	rdfs:comment "The values that were enumerated as a result of the action on the object."@en ;
-	rdfs:range observable:WindowsRegistryValue ;
+	rdfs:range uco-observable:WindowsRegistryValue ;
 	.
 
-observable:remarks
+uco-observable:remarks
 	a owl:DatatypeProperty ;
 	rdfs:label "remarks"@en ;
 	rdfs:comment "Specifies any remarks associated with this Whois entry."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:remindTime
+uco-observable:remindTime
 	a owl:DatatypeProperty ;
 	rdfs:label "remindTime"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:requestMethod
+uco-observable:requestMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "requestMethod"@en ;
 	rdfs:comment """Specifies the HTTP method portion of the HTTP request line, as a lowercase string.
@@ -12531,308 +12531,308 @@ observable:requestMethod
 	rdfs:range xsd:string ;
 	.
 
-observable:requestValue
+uco-observable:requestValue
 	a owl:DatatypeProperty ;
 	rdfs:label "requestValue"@en ;
 	rdfs:comment "Specifies the value (typically a resource path) portion of the HTTP request line."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:requestVersion
+uco-observable:requestVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "requestVersion"@en ;
 	rdfs:comment "Specifies the HTTP version portion of the HTTP request line, as a lowercase string."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:rowCondition
+uco-observable:rowCondition
 	a owl:DatatypeProperty ;
 	rdfs:label "rowCondition"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:rowIndex
+uco-observable:rowIndex
 	a owl:DatatypeProperty ;
 	rdfs:label "rowIndex"@en ;
 	rdfs:range xsd:positiveInteger ;
 	.
 
-observable:ruid
+uco-observable:ruid
 	a owl:DatatypeProperty ;
 	rdfs:label "ruid"@en ;
 	rdfs:comment "Specifies the real user ID, which represents the Unix user who created the process."@en ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:runningStatus
+uco-observable:runningStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "runningStatus"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:scheme
+uco-observable:scheme
 	a owl:DatatypeProperty ;
 	rdfs:label "scheme"@en ;
 	rdfs:comment "Identifies the type of URL."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:sectionAlignment
+uco-observable:sectionAlignment
 	a owl:DatatypeProperty ;
 	rdfs:label "sectionAlignment"@en ;
 	rdfs:comment "Specifies the alignment (in bytes) of PE sections when they are loaded into memory."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sections
+uco-observable:sections
 	a owl:ObjectProperty ;
 	rdfs:label "sections"@en ;
 	rdfs:comment "Specifies metadata about the sections in the PE file."@en ;
-	rdfs:range observable:WindowsPESection ;
+	rdfs:range uco-observable:WindowsPESection ;
 	.
 
-observable:sectorSize
+uco-observable:sectorSize
 	a owl:DatatypeProperty ;
 	rdfs:label "sectorSize"@en ;
 	rdfs:comment "The sector size of the volume in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:securityAttributes
+uco-observable:securityAttributes
 	a owl:DatatypeProperty ;
 	rdfs:label "securityAttributes"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:sender
+uco-observable:sender
 	a owl:ObjectProperty ;
 	rdfs:label "sender"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:sentTime
+uco-observable:sentTime
 	a owl:DatatypeProperty ;
 	rdfs:label "sentTime"@en ;
 	rdfs:comment "The date and time at which the message sent."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:serialNumber
+uco-observable:serialNumber
 	a owl:DatatypeProperty ;
 	rdfs:label "serialNumber"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:serverName
+uco-observable:serverName
 	a owl:ObjectProperty ;
 	rdfs:label "serverName"@en ;
 	rdfs:comment "Specifies the corresponding server name for a whois entry. This usually corresponds to a name server lookup."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:serviceName
+uco-observable:serviceName
 	a owl:DatatypeProperty ;
 	rdfs:label "serviceName"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:serviceStatus
+uco-observable:serviceStatus
 	a owl:DatatypeProperty ;
 	rdfs:label "serviceStatus"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:serviceType
+uco-observable:serviceType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "serviceType"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:sessionID
+uco-observable:sessionID
 	a owl:DatatypeProperty ;
 	rdfs:label "sessionID"@en ;
 	rdfs:comment "An identifier for the session from which the message originates."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:shell
+uco-observable:shell
 	a owl:DatatypeProperty ;
 	rdfs:label "shell"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:showMessageBody
+uco-observable:showMessageBody
 	a owl:DatatypeProperty ;
 	rdfs:label "showMessageBody"@en ;
 	rdfs:comment "Specifies the message text that is displayed in the body of the message box by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381302(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:showMessageTitle
+uco-observable:showMessageTitle
 	a owl:DatatypeProperty ;
 	rdfs:label "showMessageTitle"@en ;
 	rdfs:comment "Specifies the title of the message box shown by the action. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381302(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:sid
+uco-observable:sid
 	a owl:DatatypeProperty ;
 	rdfs:label "sid"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:signalStrength
+uco-observable:signalStrength
 	a owl:DatatypeProperty ;
 	rdfs:label "signalStrength"@en ;
 	rdfs:comment "The strength of the antenna signal."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:signature
+uco-observable:signature
 	a owl:DatatypeProperty ;
 	rdfs:label "signature"@en ;
 	rdfs:comment "A"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:signatureAlgorithm
+uco-observable:signatureAlgorithm
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureAlgorithm"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:signatureDescription
+uco-observable:signatureDescription
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureDescription"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:signatureExists
+uco-observable:signatureExists
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureExists"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:signatureVerified
+uco-observable:signatureVerified
 	a owl:DatatypeProperty ;
 	rdfs:label "signatureVerified"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:sipAddress
+uco-observable:sipAddress
 	a owl:ObjectProperty ;
 	rdfs:label "sipAddress"@en ;
 	rdfs:comment "A SIP address specifies Session Initiation Protocol (SIP) identifier."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:size
+uco-observable:size
 	a owl:DatatypeProperty ;
 	rdfs:label "size"@en ;
 	rdfs:comment "Specifies the size of the section, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:sizeInBytes
+uco-observable:sizeInBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeInBytes"@en ;
 	rdfs:comment "The size of the data in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:sizeOfCode
+uco-observable:sizeOfCode
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfCode"@en ;
 	rdfs:comment "Specifies the size of the code (text) section. If there are multiple such sections, this refers to the sum of the sizes of each section."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfHeaders
+uco-observable:sizeOfHeaders
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfHeaders"@en ;
 	rdfs:comment "Specifies the combined size of the MS-DOS, PE header, and section headers, rounded up a multiple of the value specified in the file_alignment header."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfHeapCommit
+uco-observable:sizeOfHeapCommit
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfHeapCommit"@en ;
 	rdfs:comment "Specifies the size of the local heap space to commit."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfHeapReserve
+uco-observable:sizeOfHeapReserve
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfHeapReserve"@en ;
 	rdfs:comment "Specifies the size of the local heap space to reserve."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfImage
+uco-observable:sizeOfImage
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfImage"@en ;
 	rdfs:comment "Specifies the size, in bytes, of the image, including all headers, as the image is loaded in memory."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfInitializedData
+uco-observable:sizeOfInitializedData
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfInitializedData"@en ;
 	rdfs:comment "Specifies the size of the initialized data section. If there are multiple such sections, this refers to the sum of the sizes of each section."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfOptionalHeader
+uco-observable:sizeOfOptionalHeader
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfOptionalHeader"@en ;
 	rdfs:comment "Specifies the size of the optional header of the PE binary. "@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:sizeOfStackCommit
+uco-observable:sizeOfStackCommit
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfStackCommit"@en ;
 	rdfs:comment "Specifies the size of the stack to commit."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfStackReserve
+uco-observable:sizeOfStackReserve
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfStackReserve"@en ;
 	rdfs:comment "Specifies the size of the stack to reserve."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:sizeOfUninitializedData
+uco-observable:sizeOfUninitializedData
 	a owl:DatatypeProperty ;
 	rdfs:label "sizeOfUninitializedData"@en ;
 	rdfs:comment "Specifies the size of the uninitialized data section. If there are multiple such sections, this refers to the sum of the sizes of each section."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:skew
+uco-observable:skew
 	a owl:DatatypeProperty ;
 	rdfs:label "skew"@en ;
 	rdfs:comment "The angle in degrees of the radial rotation around its main beam direction."@en ;
 	rdfs:range xsd:decimal ;
 	.
 
-observable:sourceApplication
+uco-observable:sourceApplication
 	a owl:ObjectProperty ;
 	rdfs:label "sourceApplication"@en ;
 	rdfs:comment "Source application specifies the software application that a particular contact or contact list is associated with."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:sourceFlags
+uco-observable:sourceFlags
 	a owl:DatatypeProperty ;
 	rdfs:label "sourceFlags"@en ;
 	rdfs:comment "Specifies the source TCP flags."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:sourcePort
+uco-observable:sourcePort
 	a owl:DatatypeProperty ;
 	rdfs:label "sourcePort"@en ;
 	rdfs:comment """Specifies the source port used in the connection, as an integer in the range of 0 - 65535.
@@ -12840,103 +12840,103 @@ observable:sourcePort
 	rdfs:range xsd:integer ;
 	.
 
-observable:spaceLeft
+uco-observable:spaceLeft
 	a owl:DatatypeProperty ;
 	rdfs:label "spaceLeft"@en ;
 	rdfs:comment "Specifies the amount of space left on the partition, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:spaceUsed
+uco-observable:spaceUsed
 	a owl:DatatypeProperty ;
 	rdfs:label "spaceUsed"@en ;
 	rdfs:comment "Specifies the amount of space used on the partition, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:sponsoringRegistrar
+uco-observable:sponsoringRegistrar
 	a owl:DatatypeProperty ;
 	rdfs:label "sponsoringRegistrar"@en ;
 	rdfs:comment "Specifies the name of the sponsoring registrar for a domain."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:src
+uco-observable:src
 	a owl:ObjectProperty ;
 	rdfs:label "src"@en ;
 	rdfs:comment "Specifies the source(s) of the network connection."@en ;
-	rdfs:range core:UcoObject ;
+	rdfs:range uco-core:UcoObject ;
 	.
 
-observable:srcBytes
+uco-observable:srcBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "srcBytes"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:srcPackets
+uco-observable:srcPackets
 	a owl:DatatypeProperty ;
 	rdfs:label "srcPackets"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:srcPayload
+uco-observable:srcPayload
 	a owl:ObjectProperty ;
 	rdfs:label "srcPayload"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:ssid
+uco-observable:ssid
 	a owl:DatatypeProperty ;
 	rdfs:label "ssid"@en ;
 	rdfs:comment "Network identifier."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:stackSize
+uco-observable:stackSize
 	a owl:DatatypeProperty ;
 	rdfs:label "stackSize"@en ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:startAddress
+uco-observable:startAddress
 	a owl:DatatypeProperty ;
 	rdfs:label "startAddress"@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-observable:startCommandLine
+uco-observable:startCommandLine
 	a owl:DatatypeProperty ;
 	rdfs:label "startCommandLine"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:startTime
+uco-observable:startTime
 	a owl:DatatypeProperty ;
 	rdfs:label "startTime"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:startType
+uco-observable:startType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "startType"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:startupInfo
+uco-observable:startupInfo
 	a owl:ObjectProperty ;
 	rdfs:label "startupInfo"@en ;
-	rdfs:range types:Dictionary ;
+	rdfs:range uco-types:Dictionary ;
 	.
 
-observable:state
+uco-observable:state
 	a owl:DatatypeProperty ;
 	rdfs:label "State"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:status
+uco-observable:status
 	a owl:DatatypeProperty ;
 	rdfs:label "status"@en ;
 	rdfs:comment "Specifies a list of statuses for a given Whois entry."@en ;
@@ -12944,562 +12944,562 @@ observable:status
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:TaskStatusVocab
-			vocabulary:WhoisStatusTypeVocab
+			uco-vocabulary:TaskStatusVocab
+			uco-vocabulary:WhoisStatusTypeVocab
 		) ;
 	] ;
 	.
 
-observable:statusesCount
+uco-observable:statusesCount
 	a owl:DatatypeProperty ;
 	rdfs:label "Statuses Count"@en-US ;
 	rdfs:comment "Specifies the number of tweets that this profile has issued."@en-US ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:storageCapacityInBytes
+uco-observable:storageCapacityInBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "storageCapacityInBytes"@en ;
 	rdfs:comment "The number of bytes that can be stored on a SIM card."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:stringValue
+uco-observable:stringValue
 	a owl:DatatypeProperty ;
 	rdfs:label "stringValue"@en ;
 	rdfs:comment "Specifies the actual value of the extracted string."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:strings
+uco-observable:strings
 	a owl:ObjectProperty ;
 	rdfs:label "strings"@en ;
-	rdfs:range observable:ExtractedString ;
+	rdfs:range uco-observable:ExtractedString ;
 	.
 
-observable:subject
+uco-observable:subject
 	a owl:DatatypeProperty ;
 	rdfs:label "subject"@en ;
 	rdfs:comment "The subject of the email."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:subjectAlternativeName
+uco-observable:subjectAlternativeName
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectAlternativeName"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:subjectDirectoryAttributes
+uco-observable:subjectDirectoryAttributes
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectDirectoryAttributes"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:subjectHash
+uco-observable:subjectHash
 	a owl:ObjectProperty ;
 	rdfs:label "subjectHash"@en ;
 	rdfs:comment "A hash calculated on the certificate subject name."@en ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:subjectKeyIdentifier
+uco-observable:subjectKeyIdentifier
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectKeyIdentifier"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:subjectPublicKeyAlgorithm
+uco-observable:subjectPublicKeyAlgorithm
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectPublicKeyAlgorithm"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:subjectPublicKeyExponent
+uco-observable:subjectPublicKeyExponent
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectPublicKeyExponent"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:subjectPublicKeyModulus
+uco-observable:subjectPublicKeyModulus
 	a owl:DatatypeProperty ;
 	rdfs:label "subjectPublicKeyModulus"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:subsystem
+uco-observable:subsystem
 	a owl:DatatypeProperty ;
 	rdfs:label "subsystem"@en ;
 	rdfs:comment "Specifies the subsystem (e.g., GUI, device driver, etc.) that is required to run this image."@en ;
 	rdfs:range xsd:unsignedShort ;
 	.
 
-observable:swid
+uco-observable:swid
 	a owl:DatatypeProperty ;
 	rdfs:label "swid"@en ;
 	rdfs:comment "Specifies the SWID tag for the software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:symbolicName
+uco-observable:symbolicName
 	a owl:DatatypeProperty ;
 	rdfs:label "symbolicName"@en ;
 	rdfs:comment "The symbolic name of a global flag. See also: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549646(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:systemTime
+uco-observable:systemTime
 	a owl:DatatypeProperty ;
 	rdfs:label "systemTime"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:tableName
+uco-observable:tableName
 	a owl:DatatypeProperty ;
 	rdfs:label "tableName"@en ;
 	rdfs:comment "The table containing a specified database record."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:tableSchema
+uco-observable:tableSchema
 	a owl:DatatypeProperty ;
 	rdfs:label "tableSchema"@en ;
 	rdfs:comment "The schema that contains the identified database record."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:targetFile
+uco-observable:targetFile
 	a owl:ObjectProperty ;
 	rdfs:label "targetFile"@en ;
 	rdfs:comment "Specifies the file targeted by a symbolic link."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:taskComment
+uco-observable:taskComment
 	a owl:DatatypeProperty ;
 	rdfs:label "taskComment"@en ;
 	rdfs:comment "Specifies a comment for the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381232(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:taskCreator
+uco-observable:taskCreator
 	a owl:DatatypeProperty ;
 	rdfs:label "taskCreator"@en ;
 	rdfs:comment "Specifies the name of the creator of the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381235(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:text
+uco-observable:text
 	a owl:DatatypeProperty ;
 	rdfs:label "text"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:threadID
+uco-observable:threadID
 	a owl:DatatypeProperty ;
 	rdfs:label "threadID"@en ;
 	rdfs:range xsd:nonNegativeInteger ;
 	.
 
-observable:thumbprintHash
+uco-observable:thumbprintHash
 	a owl:ObjectProperty ;
 	rdfs:label "thumbprintHash"@en ;
 	rdfs:comment "A hash calculated on the entire certificate including signature."@en ;
-	rdfs:range types:Hash ;
+	rdfs:range uco-types:Hash ;
 	.
 
-observable:timeDateStamp
+uco-observable:timeDateStamp
 	a owl:DatatypeProperty ;
 	rdfs:label "timeDateStamp"@en ;
 	rdfs:comment "Specifies the time when the PE binary was created."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:timesExecuted
+uco-observable:timesExecuted
 	a owl:DatatypeProperty ;
 	rdfs:label "timesExecuted"@en ;
 	rdfs:comment "The number of times the prefetch application has executed."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:timezoneDST
+uco-observable:timezoneDST
 	a owl:DatatypeProperty ;
 	rdfs:label "timezoneDST"@en ;
 	rdfs:comment "Specifies the time zone used by the system, taking daylight savings time (DST) into account."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:timezoneStandard
+uco-observable:timezoneStandard
 	a owl:DatatypeProperty ;
 	rdfs:label "timezoneStandard"@en ;
 	rdfs:comment "Specifies the time zone used by the system, without taking daylight savings time (DST) into account."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:to
+uco-observable:to
 	a owl:ObjectProperty ;
 	rdfs:label "to"@en ;
 	rdfs:comment "The receiver's phone number."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:totalFragments
+uco-observable:totalFragments
 	a owl:DatatypeProperty ;
 	rdfs:label "totalFragments"@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:totalRam
+uco-observable:totalRam
 	a owl:DatatypeProperty ;
 	rdfs:label "totalRam"@en ;
 	rdfs:comment "Specifies the total amount of physical memory present on the system, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:totalSpace
+uco-observable:totalSpace
 	a owl:DatatypeProperty ;
 	rdfs:label "totalSpace"@en ;
 	rdfs:comment "Specifies the total amount of space available on the partition, in bytes."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:totalStorageCapacityInBytes
+uco-observable:totalStorageCapacityInBytes
 	a owl:DatatypeProperty ;
 	rdfs:label "totalStorageCapacityInBytes"@en ;
 	rdfs:comment "The maximum number of bytes that can be stored on a storage device."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:triggerBeginTime
+uco-observable:triggerBeginTime
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerBeginTime"@en ;
 	rdfs:comment "Specifies the date/time that the trigger is activated."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:triggerDelay
+uco-observable:triggerDelay
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerDelay"@en ;
 	rdfs:comment "Specifies the delay that takes place between when the task is registered and when the task is started."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:triggerEndTime
+uco-observable:triggerEndTime
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerEndTime"@en ;
 	rdfs:comment "Specifies the date/time that the trigger is deactivated."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:triggerFrequency
+uco-observable:triggerFrequency
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerFrequency"@en ;
 	rdfs:comment "Specifies the frequency at which the trigger repeats."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:TriggerFrequencyVocab
+			uco-vocabulary:TriggerFrequencyVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:triggerList
+uco-observable:triggerList
 	a owl:ObjectProperty ;
 	rdfs:label "triggerList"@en ;
 	rdfs:comment "Specifies a set of triggers used by the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383264(v=vs.85).aspx."@en ;
-	rdfs:range observable:TriggerType ;
+	rdfs:range uco-observable:TriggerType ;
 	.
 
-observable:triggerMaxRunTime
+uco-observable:triggerMaxRunTime
 	a owl:DatatypeProperty ;
 	rdfs:label "triggerMaxRunTime"@en ;
 	rdfs:comment "The maximum amount of time that the task launched by the trigger is allowed to run. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383868(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:triggerSessionChangeType
+uco-observable:triggerSessionChangeType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "triggerSessionChangeType"@en ;
 	rdfs:comment "Specifies the type of Terminal Server session change that would trigger a task launch. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381298(v=vs.85).aspx."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:triggerType
+uco-observable:triggerType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "triggerType"@en ;
 	rdfs:comment "Specifies the type of the task trigger."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:TriggerTypeVocab
+			uco-vocabulary:TriggerTypeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:twitterHandle
+uco-observable:twitterHandle
 	a owl:DatatypeProperty ;
 	rdfs:label "Twitter Handle"@en-US ;
 	rdfs:comment "Specifies the twitter handle associated with the profile."@en-US ;
 	rdfs:range xsd:string ;
 	.
 
-observable:twitterId
+uco-observable:twitterId
 	a owl:DatatypeProperty ;
 	rdfs:label "Twitter ID"@en-US ;
 	rdfs:comment "Specifies the twitter id associated with the profile."@en-US ;
 	rdfs:range xsd:string ;
 	.
 
-observable:uninstallDate
+uco-observable:uninstallDate
 	a owl:DatatypeProperty ;
 	rdfs:label "uninstallDate"@en ;
 	rdfs:comment "Specifies the date the operating system or application was uninstalled."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:updatedDate
+uco-observable:updatedDate
 	a owl:DatatypeProperty ;
 	rdfs:label "updatedDate"@en ;
 	rdfs:comment "Specifies the date in which the registered domain information was last updated."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:uptime
+uco-observable:uptime
 	a owl:DatatypeProperty ;
 	rdfs:label "uptime"@en ;
 	rdfs:comment "Specifies the duration that represents the current amount of time that the system has been up."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:url
+uco-observable:url
 	a owl:ObjectProperty ;
 	rdfs:label "url"@en ;
 	rdfs:comment "Specifies a URL associated with a particular observable object or facet."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:urlHistoryEntry
+uco-observable:urlHistoryEntry
 	a owl:ObjectProperty ;
 	rdfs:label "URL History Entries"@en ;
 	rdfs:comment "Specifies a URL history record stored in the browser's history."@en ;
-	rdfs:range observable:URLHistoryEntry ;
+	rdfs:range uco-observable:URLHistoryEntry ;
 	.
 
-observable:urlTargeted
+uco-observable:urlTargeted
 	a owl:DatatypeProperty ;
 	rdfs:label "urlTargeted"@en ;
 	rdfs:comment "The target of the bookmark."@en ;
 	rdfs:range xsd:anyURI ;
 	.
 
-observable:urlTransitionType
+uco-observable:urlTransitionType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "Transition Type"@en ;
 	rdfs:comment "Specifies how a browser navigated to a particular URL on a particular visit."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:URLTransitionTypeVocab
+			uco-vocabulary:URLTransitionTypeVocab
 		) ;
 	] ;
 	.
 
-observable:userLocationString
+uco-observable:userLocationString
 	a owl:DatatypeProperty ;
 	rdfs:label "User Location String"@en-US ;
 	rdfs:comment "Specifies the user-provided location string associated with the profile."@en-US ;
 	rdfs:range xsd:string ;
 	.
 
-observable:userName
+uco-observable:userName
 	a owl:DatatypeProperty ;
 	rdfs:label "userName"@en ;
 	rdfs:comment "Username used to authenticate to this resource."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:validityNotAfter
+uco-observable:validityNotAfter
 	a owl:DatatypeProperty ;
 	rdfs:label "validityNotAfter"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:validityNotBefore
+uco-observable:validityNotBefore
 	a owl:DatatypeProperty ;
 	rdfs:label "validityNotBefore"@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:value
+uco-observable:value
 	a owl:DatatypeProperty ;
 	rdfs:label "value"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:values
+uco-observable:values
 	a owl:DatatypeProperty ;
 	rdfs:label "values"@en ;
 	rdfs:comment "The values that were enumerated as a result of the action on the object."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:version
+uco-observable:version
 	a owl:DatatypeProperty ;
 	rdfs:label "version"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:visibility
+uco-observable:visibility
 	a owl:DatatypeProperty ;
 	rdfs:label "visibility"@en ;
 	rdfs:range xsd:boolean ;
 	.
 
-observable:visitCount
+uco-observable:visitCount
 	a owl:DatatypeProperty ;
 	rdfs:label "visitCount"@en ;
 	rdfs:comment "Specifies the number of times a URL has been visited by a particular web browser."@en ;
 	rdfs:range xsd:integer ;
 	.
 
-observable:visitDuration
+uco-observable:visitDuration
 	a owl:DatatypeProperty ;
 	rdfs:label "Visit Duration"@en ;
 	rdfs:comment "Specifies the duration of a specific visit of a URL within a particular browser."@en ;
 	rdfs:range xsd:duration ;
 	.
 
-observable:visitTime
+uco-observable:visitTime
 	a owl:DatatypeProperty ;
 	rdfs:label "Visit Time"@en ;
 	rdfs:comment "Specifies the date/time of a specific visit of a URL within a particular browser."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-observable:volume
+uco-observable:volume
 	a owl:ObjectProperty ;
 	rdfs:label "volume"@en ;
 	rdfs:comment "The volume from which the prefetch application was run. If the applicatin was run from multiple volumes, there will be a separate prefetch file for each."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:volumeID
+uco-observable:volumeID
 	a owl:DatatypeProperty ;
 	rdfs:label "volumeID"@en ;
 	rdfs:comment "The unique identifier of the volume."@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:whoisContactType
+uco-observable:whoisContactType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "whoisContactType"@en ;
 	rdfs:comment "Specifies what type of WHOIS contact this is."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
 			xsd:string
-			vocabulary:WhoisContactTypeVocab
+			uco-vocabulary:WhoisContactTypeVocab
 		) ;
 	] ;
 	.
 
-observable:whoisServer
+uco-observable:whoisServer
 	a owl:ObjectProperty ;
 	rdfs:label "whoisServer"@en ;
 	rdfs:comment "Specifies the corresponding whois server for a registrar."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:win32VersionValue
+uco-observable:win32VersionValue
 	a owl:DatatypeProperty ;
 	rdfs:label "win32VersionValue"@en ;
 	rdfs:comment "Specifies the reserved win32 version value."@en ;
 	rdfs:range xsd:unsignedInt ;
 	.
 
-observable:windowTitle
+uco-observable:windowTitle
 	a owl:DatatypeProperty ;
 	rdfs:label "windowTitle"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:windowsDirectory
+uco-observable:windowsDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "windowsDirectory"@en ;
 	rdfs:comment "The Windows_Directory field specifies the fully-qualified path to the Windows install directory."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:windowsSystemDirectory
+uco-observable:windowsSystemDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "windowsSystemDirectory"@en ;
 	rdfs:comment "The Windows_System_Directory field specifies the fully-qualified path to the Windows system directory."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:windowsTempDirectory
+uco-observable:windowsTempDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "windowsTempDirectory"@en ;
 	rdfs:comment "The Windows_Temp_Directory field specifies the fully-qualified path to the Windows temporary files directory."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:windowsVolumeAttributes
+uco-observable:windowsVolumeAttributes
 	a owl:DatatypeProperty ;
 	rdfs:label "windowsVolumeAttributes"@en ;
 	rdfs:comment "Specifies the attributes of a windows volume."@en ;
-	rdfs:range vocabulary:WindowsVolumeAttributeVocab ;
+	rdfs:range uco-vocabulary:WindowsVolumeAttributeVocab ;
 	.
 
-observable:wirelessNetworkSecurityMode
+uco-observable:wirelessNetworkSecurityMode
 	a owl:DatatypeProperty ;
 	rdfs:label "wirelessNetworkSecurityMode"@en ;
 	rdfs:comment "Specifies the security mode of a wireless network (None, WEP, WPA, etc)."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:WirelessNetworkSecurityModeVocab
+			uco-vocabulary:WirelessNetworkSecurityModeVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-observable:workItemData
+uco-observable:workItemData
 	a owl:ObjectProperty ;
 	rdfs:label "workItemData"@en ;
 	rdfs:comment "Specifies application defined data associated with the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381271(v=vs.85).aspx."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:workingDirectory
+uco-observable:workingDirectory
 	a owl:ObjectProperty ;
 	rdfs:label "workingDirectory"@en ;
 	rdfs:comment "Specifies the working directory for the scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381878(v=vs.85).aspx."@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 
-observable:x509v3extensions
+uco-observable:x509v3extensions
 	a owl:ObjectProperty ;
 	rdfs:label "x509V3Extensions"@en ;
-	rdfs:range observable:X509V3ExtensionsFacet ;
+	rdfs:range uco-observable:X509V3ExtensionsFacet ;
 	.
 
-observable:xMailer
+uco-observable:xMailer
 	a owl:DatatypeProperty ;
 	rdfs:label "xMailer"@en ;
 	rdfs:range xsd:string ;
 	.
 
-observable:xOriginatingIP
+uco-observable:xOriginatingIP
 	a owl:ObjectProperty ;
 	rdfs:label "xOriginatingIP"@en ;
-	rdfs:range observable:ObservableObject ;
+	rdfs:range uco-observable:ObservableObject ;
 	.
 

--- a/ontology/uco/pattern/pattern.ttl
+++ b/ontology/uco/pattern/pattern.ttl
@@ -1,65 +1,65 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/core/1.3.0
 
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix pattern: <https://ontology.unifiedcyberontology.org/uco/pattern/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-pattern: <https://ontology.unifiedcyberontology.org/uco/pattern/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/pattern>
 	a owl:Ontology ;
 	rdfs:label "uco-pattern"@en ;
-	owl:backwardCompatibleWith pattern:1.2.0 ;
-	owl:imports core:1.3.0 ;
-	owl:priorVersion pattern:1.2.0 ;
-	owl:versionIRI pattern:1.3.0 ;
+	owl:backwardCompatibleWith uco-pattern:1.2.0 ;
+	owl:imports uco-core:1.3.0 ;
+	owl:priorVersion uco-pattern:1.2.0 ;
+	owl:versionIRI uco-pattern:1.3.0 ;
 	.
 
-pattern:LogicalPattern
+uco-pattern:LogicalPattern
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf pattern:Pattern ;
+	rdfs:subClassOf uco-pattern:Pattern ;
 	rdfs:label "LogicalPattern"@en ;
 	rdfs:comment "A logical pattern is a grouping of characteristics unique to an informational pattern expressed via a structured pattern expression following the rules of logic."@en ;
 	sh:property [
-		sh:datatype pattern:PatternExpression ;
+		sh:datatype uco-pattern:PatternExpression ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:Literal ;
-		sh:path pattern:patternExpression ;
+		sh:path uco-pattern:patternExpression ;
 	] ;
-	sh:targetClass pattern:LogicalPattern ;
+	sh:targetClass uco-pattern:LogicalPattern ;
 	.
 
-pattern:Pattern
+uco-pattern:Pattern
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Pattern"@en ;
 	rdfs:comment "A pattern is a combination of properties, acts, tendencies, etc., forming a consistent or characteristic arrangement."@en ;
-	sh:targetClass pattern:Pattern ;
+	sh:targetClass uco-pattern:Pattern ;
 	.
 
-pattern:PatternExpression
+uco-pattern:PatternExpression
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "PatternExpression"@en ;
 	rdfs:comment "A pattern expression is a grouping of characteristics unique to an explicit logical expression defining a pattern (e.g., regular expression, SQL Select expression, etc.)."@en ;
-	sh:targetClass pattern:PatternExpression ;
+	sh:targetClass uco-pattern:PatternExpression ;
 	.
 
-pattern:patternExpression
+uco-pattern:patternExpression
 	a owl:DatatypeProperty ;
 	rdfs:label "patternExpression"@en ;
 	rdfs:comment "An explicit logical pattern expression."@en ;
-	rdfs:range pattern:PatternExpression ;
+	rdfs:range uco-pattern:PatternExpression ;
 	.
 

--- a/ontology/uco/role/role.ttl
+++ b/ontology/uco/role/role.ttl
@@ -1,63 +1,63 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/core/1.3.0
 
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix role: <https://ontology.unifiedcyberontology.org/uco/role/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-role: <https://ontology.unifiedcyberontology.org/uco/role/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/role>
 	a owl:Ontology ;
 	rdfs:label "uco-role"@en ;
-	owl:backwardCompatibleWith role:1.2.0 ;
-	owl:imports core:1.3.0 ;
-	owl:priorVersion role:1.2.0 ;
-	owl:versionIRI role:1.3.0 ;
+	owl:backwardCompatibleWith uco-role:1.2.0 ;
+	owl:imports uco-core:1.3.0 ;
+	owl:priorVersion uco-role:1.2.0 ;
+	owl:versionIRI uco-role:1.3.0 ;
 	.
 
-role:BenevolentRole
+uco-role:BenevolentRole
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf role:Role ;
+	rdfs:subClassOf uco-role:Role ;
 	rdfs:label "BenevolentRole"@en ;
 	rdfs:comment "A benevolent role is a role with positive and/or beneficial intent."@en ;
-	sh:targetClass role:BenevolentRole ;
+	sh:targetClass uco-role:BenevolentRole ;
 	.
 
-role:MaliciousRole
+uco-role:MaliciousRole
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf role:Role ;
+	rdfs:subClassOf uco-role:Role ;
 	rdfs:label "MaliciousRole"@en ;
 	rdfs:comment "A malicious role is a role with malevolent intent."@en ;
-	sh:targetClass role:MaliciousRole ;
+	sh:targetClass uco-role:MaliciousRole ;
 	.
 
-role:NeutralRole
+uco-role:NeutralRole
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf role:Role ;
+	rdfs:subClassOf uco-role:Role ;
 	rdfs:label "NeutralRole"@en ;
 	rdfs:comment "A neutral role is a role with impartial intent."@en ;
-	sh:targetClass role:NeutralRole ;
+	sh:targetClass uco-role:NeutralRole ;
 	.
 
-role:Role
+uco-role:Role
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Role"@en ;
 	rdfs:comment "A role is a usual or customary function based on contextual perspective."@en ;
-	sh:targetClass role:Role ;
+	sh:targetClass uco-role:Role ;
 	.
 

--- a/ontology/uco/time/time.ttl
+++ b/ontology/uco/time/time.ttl
@@ -1,30 +1,30 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/core/1.3.0
 
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix time: <https://ontology.unifiedcyberontology.org/uco/time/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-time: <https://ontology.unifiedcyberontology.org/uco/time/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/time>
 	a owl:Ontology ;
 	rdfs:label "uco-time"@en ;
-	owl:backwardCompatibleWith time:1.2.0 ;
-	owl:imports core:1.3.0 ;
-	owl:priorVersion time:1.2.0 ;
-	owl:versionIRI time:1.3.0 ;
+	owl:backwardCompatibleWith uco-time:1.2.0 ;
+	owl:imports uco-core:1.3.0 ;
+	owl:priorVersion uco-time:1.2.0 ;
+	owl:versionIRI uco-time:1.3.0 ;
 	.
 
-time:Time
+uco-time:Time
 	a rdfs:Datatype ;
 	.
 
-time:TimeRange
+uco-time:TimeRange
 	a rdfs:Datatype ;
 	.
 
-time:Timestamp
+uco-time:Timestamp
 	a rdfs:Datatype ;
 	.
 

--- a/ontology/uco/tool/tool.ttl
+++ b/ontology/uco/tool/tool.ttl
@@ -1,139 +1,139 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/configuration/1.3.0
 # imports: https://ontology.unifiedcyberontology.org/uco/identity/1.3.0
 
-@prefix configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
-@prefix identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix tool: <https://ontology.unifiedcyberontology.org/uco/tool/> .
+@prefix uco-configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
+@prefix uco-tool: <https://ontology.unifiedcyberontology.org/uco/tool/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/tool>
 	a owl:Ontology ;
 	rdfs:label "uco-tool"@en ;
-	owl:backwardCompatibleWith tool:1.2.0 ;
+	owl:backwardCompatibleWith uco-tool:1.2.0 ;
 	owl:imports
-		configuration:1.3.0 ,
-		identity:1.3.0
+		uco-configuration:1.3.0 ,
+		uco-identity:1.3.0
 		;
-	owl:priorVersion tool:1.2.0 ;
-	owl:versionIRI tool:1.3.0 ;
+	owl:priorVersion uco-tool:1.2.0 ;
+	owl:versionIRI uco-tool:1.3.0 ;
 	.
 
-tool:AnalyticTool
+uco-tool:AnalyticTool
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf tool:Tool ;
+	rdfs:subClassOf uco-tool:Tool ;
 	rdfs:label "AnalyticTool"@en ;
 	rdfs:comment "An analytic tool is an artifact of hardware and/or software utilized to accomplish a task or purpose of explanation, interpretation or logical reasoning."@en ;
-	sh:targetClass tool:AnalyticTool ;
+	sh:targetClass uco-tool:AnalyticTool ;
 	.
 
-tool:BuildFacet
+uco-tool:BuildFacet
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:Facet ;
+	rdfs:subClassOf uco-core:Facet ;
 	rdfs:label "BuildFacet"@en ;
 	rdfs:comment "A build facet is a grouping of characteristics unique to a particular version of a software."@en ;
 	sh:property [
-		sh:class tool:BuildInformationType ;
+		sh:class uco-tool:BuildInformationType ;
 		sh:maxCount "1"^^xsd:integer ;
 		sh:nodeKind sh:IRI ;
-		sh:path tool:buildInformation ;
+		sh:path uco-tool:buildInformation ;
 	] ;
-	sh:targetClass tool:BuildFacet ;
+	sh:targetClass uco-tool:BuildFacet ;
 	.
 
-tool:BuildInformationType
+uco-tool:BuildInformationType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "BuildInformationType"@en ;
 	rdfs:comment "A build information type is a grouping of characteristics that describe how a particular version of software was converted from source code to executable code."@en ;
 	sh:property
 		[
-			sh:class configuration:Configuration ;
+			sh:class uco-configuration:Configuration ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path tool:buildConfiguration ;
+			sh:path uco-tool:buildConfiguration ;
 		] ,
 		[
-			sh:class tool:BuildUtilityType ;
+			sh:class uco-tool:BuildUtilityType ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path tool:buildUtility ;
+			sh:path uco-tool:buildUtility ;
 		] ,
 		[
-			sh:class tool:CompilerType ;
+			sh:class uco-tool:CompilerType ;
 			sh:nodeKind sh:IRI ;
-			sh:path tool:compilers ;
+			sh:path uco-tool:compilers ;
 		] ,
 		[
-			sh:class tool:LibraryType ;
+			sh:class uco-tool:LibraryType ;
 			sh:nodeKind sh:IRI ;
-			sh:path tool:libraries ;
+			sh:path uco-tool:libraries ;
 		] ,
 		[
 			sh:datatype xsd:dateTime ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:compilationDate ;
+			sh:path uco-tool:compilationDate ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:buildID ;
+			sh:path uco-tool:buildID ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:buildLabel ;
+			sh:path uco-tool:buildLabel ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:buildOutputLog ;
+			sh:path uco-tool:buildOutputLog ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:buildProject ;
+			sh:path uco-tool:buildProject ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:buildScript ;
+			sh:path uco-tool:buildScript ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:buildVersion ;
+			sh:path uco-tool:buildVersion ;
 		]
 		;
-	sh:targetClass tool:BuildInformationType ;
+	sh:targetClass uco-tool:BuildInformationType ;
 	.
 
-tool:BuildUtilityType
+uco-tool:BuildUtilityType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "BuildUtilityType"@en ;
 	rdfs:comment "A build utility type characterizes the tool used to convert from source code to executable code for a particular version of software."@en ;
 	sh:property
@@ -141,30 +141,30 @@ tool:BuildUtilityType
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:buildUtilityName ;
+			sh:path uco-tool:buildUtilityName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:cpeid ;
+			sh:path uco-tool:cpeid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:swid ;
+			sh:path uco-tool:swid ;
 		]
 		;
-	sh:targetClass tool:BuildUtilityType ;
+	sh:targetClass uco-tool:BuildUtilityType ;
 	.
 
-tool:CompilerType
+uco-tool:CompilerType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "CompilerType"@en ;
 	rdfs:comment "A compiler type is a grouping of characteristics unique to a specific program that translates computer code written in one programming language (the source language) into another language (the target language). Typically a program that translates source code from a high-level programming language to a lower-level language (e.g., assembly language, object code, or machine code) to create an executable program. [based on https://en.wikipedia.org/wiki/Compiler]"@en ;
 	sh:property
@@ -172,66 +172,66 @@ tool:CompilerType
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:compilerInformalDescription ;
+			sh:path uco-tool:compilerInformalDescription ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:cpeid ;
+			sh:path uco-tool:cpeid ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:swid ;
+			sh:path uco-tool:swid ;
 		]
 		;
-	sh:targetClass tool:CompilerType ;
+	sh:targetClass uco-tool:CompilerType ;
 	.
 
-tool:ConfiguredTool
+uco-tool:ConfiguredTool
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf tool:Tool ;
+	rdfs:subClassOf uco-tool:Tool ;
 	rdfs:label "ConfiguredTool"@en ;
 	rdfs:comment "A ConfiguredTool is a Tool that is known to be configured to run in a more specified manner than some unconfigured or less-configured Tool."@en ;
 	sh:property
 		[
-			sh:class configuration:Configuration ;
+			sh:class uco-configuration:Configuration ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path configuration:usesConfiguration ;
+			sh:path uco-configuration:usesConfiguration ;
 		] ,
 		[
-			sh:class tool:Tool ;
+			sh:class uco-tool:Tool ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
-			sh:path configuration:isConfigurationOf ;
+			sh:path uco-configuration:isConfigurationOf ;
 		]
 		;
-	sh:targetClass tool:ConfiguredTool ;
+	sh:targetClass uco-tool:ConfiguredTool ;
 	.
 
-tool:DefensiveTool
+uco-tool:DefensiveTool
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf tool:Tool ;
+	rdfs:subClassOf uco-tool:Tool ;
 	rdfs:label "DefensiveTool"@en ;
 	rdfs:comment "A defensive tool is an artifact of hardware and/or software utilized to accomplish a task or purpose of guarding."@en ;
-	sh:targetClass tool:DefensiveTool ;
+	sh:targetClass uco-tool:DefensiveTool ;
 	.
 
-tool:LibraryType
+uco-tool:LibraryType
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "LibraryType"@en ;
 	rdfs:comment "A library type is a grouping of characteristics unique to a collection of resources incorporated into the build of a software."@en ;
 	sh:property
@@ -239,227 +239,227 @@ tool:LibraryType
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:libraryName ;
+			sh:path uco-tool:libraryName ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:libraryVersion ;
+			sh:path uco-tool:libraryVersion ;
 		]
 		;
-	sh:targetClass tool:LibraryType ;
+	sh:targetClass uco-tool:LibraryType ;
 	.
 
-tool:MaliciousTool
+uco-tool:MaliciousTool
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf tool:Tool ;
+	rdfs:subClassOf uco-tool:Tool ;
 	rdfs:label "MaliciousTool"@en ;
 	rdfs:comment "A malicious tool is an artifact of hardware and/or software utilized to accomplish a malevolent task or purpose."@en ;
-	sh:targetClass tool:MaliciousTool ;
+	sh:targetClass uco-tool:MaliciousTool ;
 	.
 
-tool:Tool
+uco-tool:Tool
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	rdfs:label "Tool"@en ;
 	rdfs:comment "A tool is an element of hardware and/or software utilized to carry out a particular function."@en ;
 	sh:property
 		[
-			sh:class identity:Identity ;
+			sh:class uco-identity:Identity ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:IRI ;
-			sh:path tool:creator ;
+			sh:path uco-tool:creator ;
 		] ,
 		[
 			sh:datatype xsd:anyURI ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:references ;
+			sh:path uco-tool:references ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:servicePack ;
+			sh:path uco-tool:servicePack ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:toolType ;
+			sh:path uco-tool:toolType ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path tool:version ;
+			sh:path uco-tool:version ;
 		]
 		;
-	sh:targetClass tool:Tool ;
+	sh:targetClass uco-tool:Tool ;
 	.
 
-tool:buildConfiguration
+uco-tool:buildConfiguration
 	a owl:ObjectProperty ;
 	rdfs:label "buildConfiguration"@en ;
 	rdfs:comment "How the build utility was configured for a particular build of a particular software."@en ;
-	rdfs:range configuration:Configuration ;
+	rdfs:range uco-configuration:Configuration ;
 	.
 
-tool:buildID
+uco-tool:buildID
 	a owl:DatatypeProperty ;
 	rdfs:label "buildID"@en ;
 	rdfs:comment "An externally defined unique identifier for a particular build of a software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:buildInformation
+uco-tool:buildInformation
 	a owl:ObjectProperty ;
 	rdfs:label "buildInformation"@en ;
 	rdfs:comment "Describes how a particular tool was built."@en ;
-	rdfs:range tool:BuildInformationType ;
+	rdfs:range uco-tool:BuildInformationType ;
 	.
 
-tool:buildLabel
+uco-tool:buildLabel
 	a owl:DatatypeProperty ;
 	rdfs:label "buildLabel"@en ;
 	rdfs:comment "Relevant label for a particular build of a particular software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:buildOutputLog
+uco-tool:buildOutputLog
 	a owl:DatatypeProperty ;
 	rdfs:label "buildOutputLog"@en ;
 	rdfs:comment "The output log of the build process for a software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:buildProject
+uco-tool:buildProject
 	a owl:DatatypeProperty ;
 	rdfs:label "buildProject"@en ;
 	rdfs:comment "The project name of a build of a software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:buildScript
+uco-tool:buildScript
 	a owl:DatatypeProperty ;
 	rdfs:label "buildScript"@en ;
 	rdfs:comment "The actual build script for a particular build of a particular software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:buildUtility
+uco-tool:buildUtility
 	a owl:ObjectProperty ;
 	rdfs:label "buildUtility"@en ;
 	rdfs:comment "Identifies the utility used to build a software."@en ;
-	rdfs:range tool:BuildUtilityType ;
+	rdfs:range uco-tool:BuildUtilityType ;
 	.
 
-tool:buildUtilityName
+uco-tool:buildUtilityName
 	a owl:DatatypeProperty ;
 	rdfs:label "buildUtilityName"@en ;
 	rdfs:comment "The informally defined name of the utility used to build a particular software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:buildVersion
+uco-tool:buildVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "buildVersion"@en ;
 	rdfs:comment "The appropriate version descriptor of a particular build of a particular software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:compilationDate
+uco-tool:compilationDate
 	a owl:DatatypeProperty ;
 	rdfs:label "compilationDate"@en ;
 	rdfs:comment "The compilation date for the build of a software."@en ;
 	rdfs:range xsd:dateTime ;
 	.
 
-tool:compilerInformalDescription
+uco-tool:compilerInformalDescription
 	a owl:DatatypeProperty ;
 	rdfs:label "compilerInformalDescription"@en ;
 	rdfs:comment "An informal description of a compiler."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:compilers
+uco-tool:compilers
 	a owl:ObjectProperty ;
 	rdfs:label "compilers"@en ;
 	rdfs:comment "The compilers utilized during a particular build of a particular software."@en ;
-	rdfs:range tool:CompilerType ;
+	rdfs:range uco-tool:CompilerType ;
 	.
 
-tool:cpeid
+uco-tool:cpeid
 	a owl:DatatypeProperty ;
 	rdfs:label "cpeid"@en ;
 	rdfs:comment "Specifies the Common Platform Enumeration identifier for the software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:creator
+uco-tool:creator
 	a owl:ObjectProperty ;
 	rdfs:label "creator"@en ;
 	rdfs:comment "The creator organization for a particular tool."@en ;
-	rdfs:range identity:Identity ;
+	rdfs:range uco-identity:Identity ;
 	.
 
-tool:libraries
+uco-tool:libraries
 	a owl:ObjectProperty ;
 	rdfs:label "libraries"@en ;
 	rdfs:comment "The libraries incorporated into a particular build of a software."@en ;
-	rdfs:range tool:LibraryType ;
+	rdfs:range uco-tool:LibraryType ;
 	.
 
-tool:libraryName
+uco-tool:libraryName
 	a owl:DatatypeProperty ;
 	rdfs:label "libraryName"@en ;
 	rdfs:comment "The name of the library."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:libraryVersion
+uco-tool:libraryVersion
 	a owl:DatatypeProperty ;
 	rdfs:label "libraryVersion"@en ;
 	rdfs:comment "The version of the library."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:references
+uco-tool:references
 	a owl:DatatypeProperty ;
 	rdfs:label "references"@en ;
 	rdfs:comment "References to information describing a particular tool."@en ;
 	rdfs:range xsd:anyURI ;
 	.
 
-tool:servicePack
+uco-tool:servicePack
 	a owl:DatatypeProperty ;
 	rdfs:label "servicePack"@en ;
 	rdfs:comment "An appropriate service pack descriptor for a particular tool."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:swid
+uco-tool:swid
 	a owl:DatatypeProperty ;
 	rdfs:label "swid"@en ;
 	rdfs:comment "Specifies the SWID tag for the software."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:toolType
+uco-tool:toolType
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf core:informalType ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "toolType"@en ;
 	rdfs:comment "The type of tool."@en ;
 	rdfs:range xsd:string ;
 	.
 
-tool:version
+uco-tool:version
 	a owl:DatatypeProperty ;
 	rdfs:label "version"@en ;
 	rdfs:comment "An appropriate version descriptor of a particular tool."@en ;

--- a/ontology/uco/types/types.ttl
+++ b/ontology/uco/types/types.ttl
@@ -3,93 +3,93 @@
 # imports: https://ontology.unifiedcyberontology.org/uco/vocabulary/1.3.0
 
 @prefix co: <http://purl.org/co/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix uco-co: <https://ontology.unifiedcyberontology.org/co/> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/types>
 	a owl:Ontology ;
 	rdfs:label "uco-types"@en ;
-	owl:backwardCompatibleWith types:1.2.0 ;
+	owl:backwardCompatibleWith uco-types:1.2.0 ;
 	owl:imports
 		uco-co:1.3.0 ,
-		core:1.3.0 ,
-		vocabulary:1.3.0
+		uco-core:1.3.0 ,
+		uco-vocabulary:1.3.0
 		;
-	owl:priorVersion types:1.2.0 ;
-	owl:versionIRI types:1.3.0 ;
+	owl:priorVersion uco-types:1.2.0 ;
+	owl:versionIRI uco-types:1.3.0 ;
 	.
 
-types:ControlledDictionary
+uco-types:ControlledDictionary
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf types:Dictionary ;
+	rdfs:subClassOf uco-types:Dictionary ;
 	rdfs:label "ControlledDictionary"@en ;
 	rdfs:comment "A controlled dictionary is a list of (term/key, value) pairs where each term/key exists no more than once and is constrained to an explicitly defined set of values."@en ;
 	sh:property [
-		sh:class types:ControlledDictionaryEntry ;
-		sh:path types:entry ;
+		sh:class uco-types:ControlledDictionaryEntry ;
+		sh:path uco-types:entry ;
 	] ;
-	sh:targetClass types:ControlledDictionary ;
+	sh:targetClass uco-types:ControlledDictionary ;
 	.
 
-types:ControlledDictionaryEntry
+uco-types:ControlledDictionaryEntry
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf types:DictionaryEntry ;
+	rdfs:subClassOf uco-types:DictionaryEntry ;
 	rdfs:label "ControlledDictionaryEntry"@en ;
 	rdfs:comment "A controlled dictionary entry is a single (term/key, value) pair where the term/key is constrained to an explicitly defined set of values."@en ;
-	sh:targetClass types:ControlledDictionaryEntry ;
+	sh:targetClass uco-types:ControlledDictionaryEntry ;
 	.
 
-types:Dictionary
+uco-types:Dictionary
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "Dictionary"@en ;
-	rdfs:comment "A dictionary is list of (term/key, value) pairs with each term/key having an expectation to exist no more than once.  types:Dictionary alone does not validate this expectation, but validation is available.  For use cases where this expectation must be validated, the subclass types:ProperDictionary should be used instead of types:Dictionary.  For instances where this expectation has been found to be violated, the subclass types:ImproperDictionary should be used instead of types:Dictionary."@en ;
+	rdfs:comment "A dictionary is list of (term/key, value) pairs with each term/key having an expectation to exist no more than once.  uco-types:Dictionary alone does not validate this expectation, but validation is available.  For use cases where this expectation must be validated, the subclass uco-types:ProperDictionary should be used instead of uco-types:Dictionary.  For instances where this expectation has been found to be violated, the subclass uco-types:ImproperDictionary should be used instead of uco-types:Dictionary."@en ;
 	sh:property [
-		sh:class types:DictionaryEntry ;
+		sh:class uco-types:DictionaryEntry ;
 		sh:nodeKind sh:IRI ;
-		sh:path types:entry ;
+		sh:path uco-types:entry ;
 	] ;
-	sh:targetClass types:Dictionary ;
+	sh:targetClass uco-types:Dictionary ;
 	.
 
-types:Dictionary-keyUniqueness-shape
+uco-types:Dictionary-keyUniqueness-shape
 	a sh:NodeShape ;
-	sh:description "This shape is separated from the types:Dictionary class-shape in order to associate a warning-severity SPARQL-based shape."@en ;
+	sh:description "This shape is separated from the uco-types:Dictionary class-shape in order to associate a warning-severity SPARQL-based shape."@en ;
 	sh:severity sh:Warning ;
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the types:ImproperDictionary class and types:repeatsKey property."@en ;
+		sh:message "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the uco-types:ImproperDictionary class and uco-types:repeatsKey property."@en ;
 		sh:select """
-			PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+			PREFIX uco-types: <https://ontology.unifiedcyberontology.org/uco/types/>
 			SELECT $this ?value
 			WHERE {
 				$this
-					types:entry/types:key ?value ;
+					uco-types:entry/uco-types:key ?value ;
 					.
 				FILTER NOT EXISTS {
 					$this
-						a types:ImproperDictionary ;
+						a uco-types:ImproperDictionary ;
 						.
 				}
 				FILTER NOT EXISTS {
 					$this
-						a types:ProperDictionary ;
+						a uco-types:ProperDictionary ;
 						.
 				}
 			}
@@ -97,15 +97,15 @@ types:Dictionary-keyUniqueness-shape
 			HAVING (COUNT(?value) > 1)
 			""" ;
 	] ;
-	sh:targetClass types:Dictionary ;
+	sh:targetClass uco-types:Dictionary ;
 	.
 
-types:DictionaryEntry
+uco-types:DictionaryEntry
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "DictionaryEntry"@en ;
 	rdfs:comment "A dictionary entry is a single (term/key, value) pair."@en ;
 	sh:property
@@ -114,53 +114,53 @@ types:DictionaryEntry
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path types:key ;
+			sh:path uco-types:key ;
 		] ,
 		[
 			sh:datatype xsd:string ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path types:value ;
+			sh:path uco-types:value ;
 		]
 		;
-	sh:targetClass types:DictionaryEntry ;
+	sh:targetClass uco-types:DictionaryEntry ;
 	.
 
-types:Hash
+uco-types:Hash
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf core:UcoInherentCharacterizationThing ;
+	rdfs:subClassOf uco-core:UcoInherentCharacterizationThing ;
 	rdfs:label "Hash"@en ;
 	rdfs:comment "A hash is a grouping of characteristics unique to the result of applying a mathematical algorithm that maps data of arbitrary size to a bit string (the 'hash') and is a one-way function, that is, a function which is practically infeasible to invert. This is commonly used for integrity checking of data. [based on https://en.wikipedia.org/wiki/Cryptographic_hash_function]"@en ;
 	sh:property
-		types:Hash-hashMethod-in-shape ,
+		uco-types:Hash-hashMethod-in-shape ,
 		[
 			sh:datatype xsd:hexBinary ;
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path types:hashValue ;
+			sh:path uco-types:hashValue ;
 		] ,
 		[
 			sh:datatype xsd:string ;
-			sh:message "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:path types:hashMethod ;
+			sh:message "As of UCO 1.4.0, the datatype to use for uco-types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:path uco-types:hashMethod ;
 			sh:severity sh:Warning ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path types:hashMethod ;
+			sh:path uco-types:hashMethod ;
 		]
 		;
-	sh:targetClass types:Hash ;
+	sh:targetClass uco-types:Hash ;
 	.
 
-types:Hash-hashMethod-in-shape
+uco-types:Hash-hashMethod-in-shape
 	a sh:PropertyShape ;
 	sh:in (
 		"MD5"
@@ -177,213 +177,213 @@ types:Hash-hashMethod-in-shape
 		"SSDEEP"
 	) ;
 	sh:message "Value is not member of the vocabulary HashNameVocab." ;
-	sh:path types:hashMethod ;
+	sh:path uco-types:hashMethod ;
 	sh:severity sh:Info ;
 	.
 
-types:Identifier
+uco-types:Identifier
 	a rdfs:Datatype ;
 	rdfs:comment "An identifier is a string conformant to the specified UUID-based format for UCO object identifiers."@en ;
 	.
 
-types:ImproperDictionary
+uco-types:ImproperDictionary
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf types:Dictionary ;
+	rdfs:subClassOf uco-types:Dictionary ;
 	rdfs:label "ImproperDictionary"@en ;
-	owl:disjointWith types:ProperDictionary ;
+	owl:disjointWith uco-types:ProperDictionary ;
 	sh:property [
 		sh:datatype xsd:string ;
 		sh:nodeKind sh:Literal ;
-		sh:path types:repeatsKey ;
+		sh:path uco-types:repeatsKey ;
 	] ;
-	sh:targetClass types:ImproperDictionary ;
+	sh:targetClass uco-types:ImproperDictionary ;
 	.
 
-types:ImproperDictionary-disjointWith-ProperDictionary-shape
+uco-types:ImproperDictionary-disjointWith-ProperDictionary-shape
 	a sh:NodeShape ;
-	sh:message "types:ImproperDictionary and types:ProperDictionary are disjoint classes."@en ;
+	sh:message "uco-types:ImproperDictionary and uco-types:ProperDictionary are disjoint classes."@en ;
 	sh:not [
 		a sh:NodeShape ;
-		sh:class types:ProperDictionary ;
+		sh:class uco-types:ProperDictionary ;
 	] ;
-	sh:targetClass types:ImproperDictionary ;
+	sh:targetClass uco-types:ImproperDictionary ;
 	.
 
-types:NativeFormatString
+uco-types:NativeFormatString
 	a rdfs:Datatype ;
 	rdfs:comment "Specifies data in its native format of some external language. The data may be encoded in Base64 per [RFC4648]. Data encoded in Base64 must be denoted as such using the encoded property."@en ;
 	.
 
-types:ProperDictionary
+uco-types:ProperDictionary
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf types:Dictionary ;
+	rdfs:subClassOf uco-types:Dictionary ;
 	rdfs:label "ProperDictionary"@en ;
 	rdfs:comment "A proper dictionary is list of (term/key, value) pairs with each term/key existing no more than once."@en ;
-	owl:disjointWith types:ImproperDictionary ;
+	owl:disjointWith uco-types:ImproperDictionary ;
 	sh:sparql [
 		a sh:SPARQLConstraint ;
 		sh:message "A key in a proper dictionary can appear no more than once."@en ;
 		sh:select """
-			PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+			PREFIX uco-types: <https://ontology.unifiedcyberontology.org/uco/types/>
 			SELECT $this ?value
 			WHERE {
 				$this
-					types:entry/types:key ?value ;
+					uco-types:entry/uco-types:key ?value ;
 					.
 			}
 			GROUP BY ?value
 			HAVING (COUNT(?value) > 1)
 		""" ;
 	] ;
-	sh:targetClass types:ProperDictionary ;
+	sh:targetClass uco-types:ProperDictionary ;
 	.
 
-types:StructuredText
+uco-types:StructuredText
 	a rdfs:Datatype ;
 	rdfs:comment "Expresses string-based data in some information structuring format (e.g., HTML5)."@en ;
 	.
 
-types:Thread
+uco-types:Thread
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
 		co:Bag ,
-		core:UcoThing
+		uco-core:UcoThing
 		;
 	rdfs:label "Thread"@en ;
 	rdfs:comment "A semi-ordered array of items, that can be present in multiple copies.  Implemetation of a UCO Thread is similar to a Collections Ontology List, except a Thread may fork and merge - that is, one of its members may have two or more direct successors, and two or more direct predecessors."@en ;
 	owl:disjointWith co:List ;
 	sh:property [
-		sh:class types:ThreadItem ;
+		sh:class uco-types:ThreadItem ;
 		sh:path co:item ;
 	] ;
 	.
 
-types:Thread-disjointWith-co-List-shape
+uco-types:Thread-disjointWith-co-List-shape
 	a sh:NodeShape ;
-	sh:message "types:Thread and co:List are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
+	sh:message "uco-types:Thread and co:List are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
 	sh:not [
 		a sh:NodeShape ;
 		sh:class co:List ;
 	] ;
 	sh:severity sh:Warning ;
-	sh:targetClass types:Thread ;
+	sh:targetClass uco-types:Thread ;
 	.
 
-types:ThreadItem
+uco-types:ThreadItem
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
 	rdfs:subClassOf
 		co:Item ,
-		core:UcoThing
+		uco-core:UcoThing
 		;
 	rdfs:label "ThreadItem"@en ;
 	rdfs:comment "A ThreadItem is a member of a thread."@en ;
 	owl:disjointWith co:ListItem ;
 	sh:property [
-		sh:class core:UcoObject ;
+		sh:class uco-core:UcoObject ;
 		sh:path co:itemContent ;
 	] ;
 	.
 
-types:ThreadItem-disjointWith-co-ListItem-shape
+uco-types:ThreadItem-disjointWith-co-ListItem-shape
 	a sh:NodeShape ;
-	sh:message "types:ThreadItem and co:ListItem are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
+	sh:message "uco-types:ThreadItem and co:ListItem are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
 	sh:not [
 		a sh:NodeShape ;
 		sh:class co:ListItem ;
 	] ;
 	sh:severity sh:Warning ;
-	sh:targetClass types:ThreadItem ;
+	sh:targetClass uco-types:ThreadItem ;
 	.
 
-types:entry
+uco-types:entry
 	a owl:ObjectProperty ;
 	rdfs:label "entry"@en ;
 	rdfs:comment "A dictionary entry."@en ;
-	rdfs:range types:DictionaryEntry ;
+	rdfs:range uco-types:DictionaryEntry ;
 	.
 
-types:hashMethod
+uco-types:hashMethod
 	a owl:DatatypeProperty ;
 	rdfs:label "hashMethod"@en ;
 	rdfs:comment "A particular cryptographic hashing method (e.g., MD5)."@en ;
 	rdfs:range [
 		a rdfs:Datatype ;
 		owl:unionOf (
-			vocabulary:HashNameVocab
+			uco-vocabulary:HashNameVocab
 			xsd:string
 		) ;
 	] ;
 	.
 
-types:hashValue
+uco-types:hashValue
 	a owl:DatatypeProperty ;
 	rdfs:label "hashValue"@en ;
 	rdfs:comment "A cryptographic hash value."@en ;
 	rdfs:range xsd:hexBinary ;
 	.
 
-types:key
+uco-types:key
 	a owl:DatatypeProperty ;
 	rdfs:label "key"@en ;
 	rdfs:comment "A key property of a single dictionary entry."@en ;
 	rdfs:range xsd:string ;
 	.
 
-types:repeatsKey
+uco-types:repeatsKey
 	a owl:DatatypeProperty ;
 	rdfs:label "repeatsKey"@en ;
 	rdfs:comment "A key found to be repeated in multiple dictionary entries within one dictionary."@en ;
-	rdfs:domain types:ImproperDictionary ;
+	rdfs:domain uco-types:ImproperDictionary ;
 	rdfs:range xsd:string ;
 	.
 
-types:repeatsKey-subjects-shape
+uco-types:repeatsKey-subjects-shape
 	a sh:NodeShape ;
-	sh:class types:ImproperDictionary ;
-	sh:targetSubjectsOf types:repeatsKey ;
+	sh:class uco-types:ImproperDictionary ;
+	sh:targetSubjectsOf uco-types:repeatsKey ;
 	.
 
-types:threadNextItem
+uco-types:threadNextItem
 	a owl:ObjectProperty ;
-	rdfs:subPropertyOf types:threadSuccessor ;
+	rdfs:subPropertyOf uco-types:threadSuccessor ;
 	rdfs:label "threadNextItem"@en ;
 	rdfs:comment "The link to a next item in a thread."@en ;
 	rdfs:seeAlso co:nextItem ;
 	.
 
-types:threadNextItem-subjects-shape
+uco-types:threadNextItem-subjects-shape
 	a sh:PropertyShape ;
-	sh:class types:ThreadItem ;
+	sh:class uco-types:ThreadItem ;
 	sh:nodeKind sh:IRI ;
-	sh:path types:threadNextItem ;
-	sh:targetSubjectsOf types:threadNextItem ;
+	sh:path uco-types:threadNextItem ;
+	sh:targetSubjectsOf uco-types:threadNextItem ;
 	.
 
-types:threadOriginItem
+uco-types:threadOriginItem
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf co:item ;
 	rdfs:label "threadOriginItem"@en ;
 	rdfs:comment "A link to an item of the thread known to have no predecessor."@en ;
-	rdfs:domain types:Thread ;
+	rdfs:domain uco-types:Thread ;
 	rdfs:range [
 		a owl:Class ;
 		owl:intersectionOf (
-			types:ThreadItem
+			uco-types:ThreadItem
 			[
 				a owl:Restriction ;
-				owl:onProperty types:threadPreviousItem ;
+				owl:onProperty uco-types:threadPreviousItem ;
 				owl:cardinality "0"^^xsd:nonNegativeInteger ;
 			]
 		) ;
@@ -391,109 +391,109 @@ types:threadOriginItem
 	rdfs:seeAlso co:firstItem ;
 	.
 
-types:threadOriginItem-subjects-shape
+uco-types:threadOriginItem-subjects-shape
 	a sh:PropertyShape ;
-	sh:class types:ThreadItem ;
+	sh:class uco-types:ThreadItem ;
 	sh:nodeKind sh:IRI ;
-	sh:path types:threadOriginItem ;
-	sh:targetSubjectsOf types:threadOriginItem ;
+	sh:path uco-types:threadOriginItem ;
+	sh:targetSubjectsOf uco-types:threadOriginItem ;
 	.
 
-types:threadOriginItem-subjects-threadPredecessor-shape
+uco-types:threadOriginItem-subjects-threadPredecessor-shape
 	a sh:PropertyShape ;
 	sh:description "An origin item in a thread must not have a predecessor."@en ;
 	sh:maxCount "0"^^xsd:integer ;
 	sh:nodeKind sh:IRI ;
 	sh:path (
-		types:threadOriginItem
-		types:threadPredecessor
+		uco-types:threadOriginItem
+		uco-types:threadPredecessor
 	) ;
-	sh:targetSubjectsOf types:threadOriginItem ;
+	sh:targetSubjectsOf uco-types:threadOriginItem ;
 	.
 
-types:threadOriginItem-subjects-threadPreviousItem-shape
+uco-types:threadOriginItem-subjects-threadPreviousItem-shape
 	a sh:PropertyShape ;
 	sh:description "An origin item in a thread must not have a previous item."@en ;
 	sh:maxCount "0"^^xsd:integer ;
 	sh:nodeKind sh:IRI ;
 	sh:path (
-		types:threadOriginItem
-		types:threadPreviousItem
+		uco-types:threadOriginItem
+		uco-types:threadPreviousItem
 	) ;
-	sh:targetSubjectsOf types:threadOriginItem ;
+	sh:targetSubjectsOf uco-types:threadOriginItem ;
 	.
 
-types:threadPredecessor
+uco-types:threadPredecessor
 	a
 		owl:ObjectProperty ,
 		owl:TransitiveProperty
 		;
 	rdfs:label "threadPredecessor"@en ;
 	rdfs:comment "The link to the preceding item in a thread."@en ;
-	rdfs:domain types:ThreadItem ;
-	rdfs:range types:ThreadItem ;
+	rdfs:domain uco-types:ThreadItem ;
+	rdfs:range uco-types:ThreadItem ;
 	rdfs:seeAlso co:precededBy ;
-	owl:inverseOf types:threadSuccessor ;
+	owl:inverseOf uco-types:threadSuccessor ;
 	.
 
-types:threadPredecessor-subjects-shape
+uco-types:threadPredecessor-subjects-shape
 	a sh:PropertyShape ;
-	sh:class types:ThreadItem ;
+	sh:class uco-types:ThreadItem ;
 	sh:nodeKind sh:IRI ;
-	sh:path types:threadPredecessor ;
-	sh:targetSubjectsOf types:threadPredecessor ;
+	sh:path uco-types:threadPredecessor ;
+	sh:targetSubjectsOf uco-types:threadPredecessor ;
 	.
 
-types:threadPreviousItem
+uco-types:threadPreviousItem
 	a owl:ObjectProperty ;
-	rdfs:subPropertyOf types:threadPredecessor ;
+	rdfs:subPropertyOf uco-types:threadPredecessor ;
 	rdfs:label "threadPreviousItem"@en ;
 	rdfs:comment "A direct link to a previous item in a thread."@en ;
 	rdfs:seeAlso co:previousItem ;
-	owl:inverseOf types:threadNextItem ;
+	owl:inverseOf uco-types:threadNextItem ;
 	.
 
-types:threadPreviousItem-subjects-shape
+uco-types:threadPreviousItem-subjects-shape
 	a sh:PropertyShape ;
-	sh:class types:ThreadItem ;
+	sh:class uco-types:ThreadItem ;
 	sh:nodeKind sh:IRI ;
-	sh:path types:threadPreviousItem ;
-	sh:targetSubjectsOf types:threadPreviousItem ;
+	sh:path uco-types:threadPreviousItem ;
+	sh:targetSubjectsOf uco-types:threadPreviousItem ;
 	.
 
-types:threadSuccessor
+uco-types:threadSuccessor
 	a
 		owl:ObjectProperty ,
 		owl:TransitiveProperty
 		;
 	rdfs:label "threadSuccessor"@en ;
 	rdfs:comment "A link to a following item in a thread."@en ;
-	rdfs:domain types:ThreadItem ;
-	rdfs:range types:ThreadItem ;
+	rdfs:domain uco-types:ThreadItem ;
+	rdfs:range uco-types:ThreadItem ;
 	rdfs:seeAlso co:followedBy ;
 	.
 
-types:threadSuccessor-subjects-shape
+uco-types:threadSuccessor-subjects-shape
 	a sh:PropertyShape ;
-	sh:class types:ThreadItem ;
+	sh:class uco-types:ThreadItem ;
 	sh:nodeKind sh:IRI ;
-	sh:path types:threadSuccessor ;
-	sh:targetSubjectsOf types:threadSuccessor ;
+	sh:path uco-types:threadSuccessor ;
+	sh:targetSubjectsOf uco-types:threadSuccessor ;
 	.
 
-types:threadTerminalItem
+uco-types:threadTerminalItem
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf co:item ;
 	rdfs:label "threadTerminalItem"@en ;
 	rdfs:comment "A link to an item of the thread known to have no successor."@en ;
-	rdfs:domain types:Thread ;
+	rdfs:domain uco-types:Thread ;
 	rdfs:range [
 		a owl:Class ;
 		owl:intersectionOf (
-			types:ThreadItem
+			uco-types:ThreadItem
 			[
 				a owl:Restriction ;
-				owl:onProperty types:threadNextItem ;
+				owl:onProperty uco-types:threadNextItem ;
 				owl:cardinality "0"^^xsd:nonNegativeInteger ;
 			]
 		) ;
@@ -501,39 +501,39 @@ types:threadTerminalItem
 	rdfs:seeAlso co:lastItem ;
 	.
 
-types:threadTerminalItem-subjects-shape
+uco-types:threadTerminalItem-subjects-shape
 	a sh:PropertyShape ;
-	sh:class types:ThreadItem ;
+	sh:class uco-types:ThreadItem ;
 	sh:nodeKind sh:IRI ;
-	sh:path types:threadTerminalItem ;
-	sh:targetSubjectsOf types:threadTerminalItem ;
+	sh:path uco-types:threadTerminalItem ;
+	sh:targetSubjectsOf uco-types:threadTerminalItem ;
 	.
 
-types:threadTerminalItem-subjects-threadNextItem-shape
+uco-types:threadTerminalItem-subjects-threadNextItem-shape
 	a sh:PropertyShape ;
 	sh:description "A terminal item in a thread must not have a next item."@en ;
 	sh:maxCount "0"^^xsd:integer ;
 	sh:nodeKind sh:IRI ;
 	sh:path (
-		types:threadTerminalItem
-		types:threadNextItem
+		uco-types:threadTerminalItem
+		uco-types:threadNextItem
 	) ;
-	sh:targetSubjectsOf types:threadTerminalItem ;
+	sh:targetSubjectsOf uco-types:threadTerminalItem ;
 	.
 
-types:threadTerminalItem-subjects-threadSuccessor-shape
+uco-types:threadTerminalItem-subjects-threadSuccessor-shape
 	a sh:PropertyShape ;
 	sh:description "A terminal item in a thread must not have a successor."@en ;
 	sh:maxCount "0"^^xsd:integer ;
 	sh:nodeKind sh:IRI ;
 	sh:path (
-		types:threadTerminalItem
-		types:threadSuccessor
+		uco-types:threadTerminalItem
+		uco-types:threadSuccessor
 	) ;
-	sh:targetSubjectsOf types:threadTerminalItem ;
+	sh:targetSubjectsOf uco-types:threadTerminalItem ;
 	.
 
-types:value
+uco-types:value
 	a owl:DatatypeProperty ;
 	rdfs:label "value"@en ;
 	rdfs:comment "A specific property value."@en ;

--- a/ontology/uco/victim/victim.ttl
+++ b/ontology/uco/victim/victim.ttl
@@ -3,39 +3,39 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix role: <https://ontology.unifiedcyberontology.org/uco/role/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix victim: <https://ontology.unifiedcyberontology.org/uco/victim/> .
+@prefix uco-role: <https://ontology.unifiedcyberontology.org/uco/role/> .
+@prefix uco-victim: <https://ontology.unifiedcyberontology.org/uco/victim/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/victim>
 	a owl:Ontology ;
 	rdfs:label "uco-victim"@en ;
-	owl:backwardCompatibleWith victim:1.2.0 ;
-	owl:imports role:1.3.0 ;
-	owl:priorVersion victim:1.2.0 ;
-	owl:versionIRI victim:1.3.0 ;
+	owl:backwardCompatibleWith uco-victim:1.2.0 ;
+	owl:imports uco-role:1.3.0 ;
+	owl:priorVersion uco-victim:1.2.0 ;
+	owl:versionIRI uco-victim:1.3.0 ;
 	.
 
-victim:Victim
+uco-victim:Victim
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf role:NeutralRole ;
+	rdfs:subClassOf uco-role:NeutralRole ;
 	rdfs:label "Victim"@en ;
 	rdfs:comment "A victim is a role played by a person or organization that is/was the target of some malicious action."@en ;
-	sh:targetClass victim:Victim ;
+	sh:targetClass uco-victim:Victim ;
 	.
 
-victim:VictimTargeting
+uco-victim:VictimTargeting
 	a
 		owl:Class ,
 		sh:NodeShape
 		;
-	rdfs:subClassOf victim:Victim ;
+	rdfs:subClassOf uco-victim:Victim ;
 	rdfs:label "VictimTargeting"@en ;
 	rdfs:comment "A victim targeting is a grouping of characteristics unique to people or organizations that are the target of some malicious activity."@en ;
-	sh:targetClass victim:VictimTargeting ;
+	sh:targetClass uco-victim:VictimTargeting ;
 	.
 

--- a/ontology/uco/vocabulary/vocabulary.ttl
+++ b/ontology/uco/vocabulary/vocabulary.ttl
@@ -1,18 +1,18 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
+@prefix uco-vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://ontology.unifiedcyberontology.org/uco/vocabulary>
 	a owl:Ontology ;
 	rdfs:label "uco-vocabularies"@en ;
-	owl:backwardCompatibleWith vocabulary:1.2.0 ;
-	owl:priorVersion vocabulary:1.2.0 ;
-	owl:versionIRI vocabulary:1.3.0 ;
+	owl:backwardCompatibleWith uco-vocabulary:1.2.0 ;
+	owl:priorVersion uco-vocabulary:1.2.0 ;
+	owl:versionIRI uco-vocabulary:1.3.0 ;
 	.
 
-vocabulary:AccountTypeVocab
+uco-vocabulary:AccountTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Account Type Vocabulary"@en-US ;
 	owl:equivalentClass [
@@ -30,7 +30,7 @@ vocabulary:AccountTypeVocab
 	] ;
 	.
 
-vocabulary:ActionArgumentNameVocab
+uco-vocabulary:ActionArgumentNameVocab
 	a rdfs:Datatype ;
 	rdfs:label "Action Argument Name Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary for common arguments of cyber actions."@en ;
@@ -92,7 +92,7 @@ vocabulary:ActionArgumentNameVocab
 	] ;
 	.
 
-vocabulary:ActionNameVocab
+uco-vocabulary:ActionNameVocab
 	a rdfs:Datatype ;
 	rdfs:label "Action Name Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common specific cyber action names."@en ;
@@ -284,7 +284,7 @@ vocabulary:ActionNameVocab
 	] ;
 	.
 
-vocabulary:ActionRelationshipTypeVocab
+uco-vocabulary:ActionRelationshipTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Action Relationship Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary for capturing types of relationships between actions."@en-US ;
@@ -302,7 +302,7 @@ vocabulary:ActionRelationshipTypeVocab
 	] ;
 	.
 
-vocabulary:ActionStatusTypeVocab
+uco-vocabulary:ActionStatusTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Action Status Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of action status types."@en-US ;
@@ -320,7 +320,7 @@ vocabulary:ActionStatusTypeVocab
 	] ;
 	.
 
-vocabulary:ActionTypeVocab
+uco-vocabulary:ActionTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Action Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common general action types."@en ;
@@ -442,7 +442,7 @@ vocabulary:ActionTypeVocab
 	] ;
 	.
 
-vocabulary:BitnessVocab
+uco-vocabulary:BitnessVocab
 	a rdfs:Datatype ;
 	rdfs:label "Bitness Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of word sizes that define classes of operating systems."@en ;
@@ -455,7 +455,7 @@ vocabulary:BitnessVocab
 	] ;
 	.
 
-vocabulary:CharacterEncodingVocab
+uco-vocabulary:CharacterEncodingVocab
 	a rdfs:Datatype ;
 	rdfs:label "Character Encoding Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of character encodings."@en ;
@@ -479,7 +479,7 @@ vocabulary:CharacterEncodingVocab
 	] ;
 	.
 
-vocabulary:ContactAddressScopeVocab
+uco-vocabulary:ContactAddressScopeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Contact Address Scope Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of scopes for address entries of digital contacts."@en ;
@@ -493,7 +493,7 @@ vocabulary:ContactAddressScopeVocab
 	] ;
 	.
 
-vocabulary:ContactEmailScopeVocab
+uco-vocabulary:ContactEmailScopeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Contact Email Scope Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of scopes for email entries of digital contacts."@en ;
@@ -508,7 +508,7 @@ vocabulary:ContactEmailScopeVocab
 	] ;
 	.
 
-vocabulary:ContactPhoneScopeVocab
+uco-vocabulary:ContactPhoneScopeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Contact Phone Scope Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of scopes for phone entries of digital contacts."@en ;
@@ -527,7 +527,7 @@ vocabulary:ContactPhoneScopeVocab
 	] ;
 	.
 
-vocabulary:ContactSIPScopeVocab
+uco-vocabulary:ContactSIPScopeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Contact SIP Scope Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of scopes for Session Initiation Protocol (SIP) entries of digital contacts."@en ;
@@ -541,7 +541,7 @@ vocabulary:ContactSIPScopeVocab
 	] ;
 	.
 
-vocabulary:ContactURLScopeVocab
+uco-vocabulary:ContactURLScopeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Contact URL Scope Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of scopes for URL entries of digital contacts."@en ;
@@ -556,7 +556,7 @@ vocabulary:ContactURLScopeVocab
 	] ;
 	.
 
-vocabulary:DiskTypeVocab
+uco-vocabulary:DiskTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Disk Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of disk types."@en ;
@@ -572,7 +572,7 @@ vocabulary:DiskTypeVocab
 	] ;
 	.
 
-vocabulary:EndiannessTypeVocab
+uco-vocabulary:EndiannessTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Endianness Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of byte ordering methods."@en ;
@@ -586,7 +586,7 @@ vocabulary:EndiannessTypeVocab
 	] ;
 	.
 
-vocabulary:HashNameVocab
+uco-vocabulary:HashNameVocab
 	a rdfs:Datatype ;
 	rdfs:label "Hash Name Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of hashing algorithm names."@en-US ;
@@ -609,7 +609,7 @@ vocabulary:HashNameVocab
 	] ;
 	.
 
-vocabulary:LibraryTypeVocab
+uco-vocabulary:LibraryTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Library Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of library types."@en ;
@@ -625,7 +625,7 @@ vocabulary:LibraryTypeVocab
 	] ;
 	.
 
-vocabulary:MemoryBlockTypeVocab
+uco-vocabulary:MemoryBlockTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Memory Block Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of types of memory blocks."@en ;
@@ -641,7 +641,7 @@ vocabulary:MemoryBlockTypeVocab
 	] ;
 	.
 
-vocabulary:ObservableObjectRelationshipVocab
+uco-vocabulary:ObservableObjectRelationshipVocab
 	a rdfs:Datatype ;
 	rdfs:label "Cyber Item Relationship Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of inter-observable object relationships."@en ;
@@ -791,7 +791,7 @@ vocabulary:ObservableObjectRelationshipVocab
 	] ;
 	.
 
-vocabulary:ObservableObjectStateVocab
+uco-vocabulary:ObservableObjectStateVocab
 	a rdfs:Datatype ;
 	rdfs:label "Cyber Item State Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of observable object states."@en ;
@@ -812,7 +812,7 @@ vocabulary:ObservableObjectStateVocab
 	] ;
 	.
 
-vocabulary:PartitionTypeVocab
+uco-vocabulary:PartitionTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Partition Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of partition types. See http://www.win.tue.nl/~aeb/partitions/partition_types-1.html for more information about the various partition types."@en ;
@@ -842,7 +842,7 @@ vocabulary:PartitionTypeVocab
 	] ;
 	.
 
-vocabulary:ProcessorArchVocab
+uco-vocabulary:ProcessorArchVocab
 	a rdfs:Datatype ;
 	rdfs:label "Processor Architecture Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of computer processor architectures."@en ;
@@ -865,7 +865,7 @@ vocabulary:ProcessorArchVocab
 	] ;
 	.
 
-vocabulary:RecoveredObjectStatusVocab
+uco-vocabulary:RecoveredObjectStatusVocab
 	a rdfs:Datatype ;
 	rdfs:label "Recovered Object Status Vocabulary"@en-US ;
 	rdfs:comment "Defines the vocabulary for Recovered Object status of data."@en ;
@@ -880,7 +880,7 @@ vocabulary:RecoveredObjectStatusVocab
 	] ;
 	.
 
-vocabulary:RegionalRegistryTypeVocab
+uco-vocabulary:RegionalRegistryTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Regional Registry Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of Regional Internet Registries (RIRs) names, represented via their respective acronyms."@en ;
@@ -896,7 +896,7 @@ vocabulary:RegionalRegistryTypeVocab
 	] ;
 	.
 
-vocabulary:RegistryDatatypeVocab
+uco-vocabulary:RegistryDatatypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Registry Datatype Vocabulary"@en-US ;
 	owl:equivalentClass [
@@ -919,7 +919,7 @@ vocabulary:RegistryDatatypeVocab
 	] ;
 	.
 
-vocabulary:SIMFormVocab
+uco-vocabulary:SIMFormVocab
 	a rdfs:Datatype ;
 	rdfs:label "SIM Form Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common SIM card form factors."@en ;
@@ -933,7 +933,7 @@ vocabulary:SIMFormVocab
 	] ;
 	.
 
-vocabulary:SIMTypeVocab
+uco-vocabulary:SIMTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "SIM Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of common SIM card types."@en ;
@@ -947,7 +947,7 @@ vocabulary:SIMTypeVocab
 	] ;
 	.
 
-vocabulary:TaskActionTypeVocab
+uco-vocabulary:TaskActionTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Task Action Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of task action types. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa380596(v=vs.85).aspx."@en ;
@@ -962,7 +962,7 @@ vocabulary:TaskActionTypeVocab
 	] ;
 	.
 
-vocabulary:TaskFlagVocab
+uco-vocabulary:TaskFlagVocab
 	a rdfs:Datatype ;
 	rdfs:label "Task Flag Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the run flags for a task scheduler task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx See Also: http://msdn.microsoft.com/en-us/library/microsoft.office.excel.server.addins.computecluster.taskscheduler.taskflags(v=office.12).aspx."@en ;
@@ -986,7 +986,7 @@ vocabulary:TaskFlagVocab
 	] ;
 	.
 
-vocabulary:TaskPriorityVocab
+uco-vocabulary:TaskPriorityVocab
 	a rdfs:Datatype ;
 	rdfs:label "Task Priority Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the priority levels of task scheduler tasks. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383512(v=vs.85).aspx."@en ;
@@ -1003,7 +1003,7 @@ vocabulary:TaskPriorityVocab
 	] ;
 	.
 
-vocabulary:TaskStatusVocab
+uco-vocabulary:TaskStatusVocab
 	a rdfs:Datatype ;
 	rdfs:label "Task Status Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the possible statuses of a scheduled task. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383604(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381263(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa381833(v=vs.85).aspx See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383617(v=vs.85).aspx."@en ;
@@ -1038,7 +1038,7 @@ vocabulary:TaskStatusVocab
 	] ;
 	.
 
-vocabulary:ThreadRunningStatusVocab
+uco-vocabulary:ThreadRunningStatusVocab
 	a rdfs:Datatype ;
 	rdfs:label "Thread Running Status Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the various states that a thread may be in before, during, or after execution. See http://msdn.microsoft.com/en-us/library/system.diagnostics.threadstate(v=vs.110).aspx."@en ;
@@ -1057,7 +1057,7 @@ vocabulary:ThreadRunningStatusVocab
 	] ;
 	.
 
-vocabulary:TimestampPrecisionVocab
+uco-vocabulary:TimestampPrecisionVocab
 	a rdfs:Datatype ;
 	rdfs:label "Timestamp Precision Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of timestamp precision granularities."@en-US ;
@@ -1074,7 +1074,7 @@ vocabulary:TimestampPrecisionVocab
 	] ;
 	.
 
-vocabulary:TrendVocab
+uco-vocabulary:TrendVocab
 	a rdfs:Datatype ;
 	rdfs:label "Trend Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of trend values."@en-US ;
@@ -1087,7 +1087,7 @@ vocabulary:TrendVocab
 	] ;
 	.
 
-vocabulary:TriggerFrequencyVocab
+uco-vocabulary:TriggerFrequencyVocab
 	a rdfs:Datatype ;
 	rdfs:label "Trigger Frequency Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the frequency types that a trigger may use. See also: http://msdn.microsoft.com/en-us/library/windows/desktop/aa383620(v=vs.85).aspx and http://msdn.microsoft.com/en-us/library/windows/desktop/aa383987(v=vs.85).aspx."@en ;
@@ -1106,7 +1106,7 @@ vocabulary:TriggerFrequencyVocab
 	] ;
 	.
 
-vocabulary:TriggerTypeVocab
+uco-vocabulary:TriggerTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Trigger Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of the types of triggers associated with a task."@en ;
@@ -1124,7 +1124,7 @@ vocabulary:TriggerTypeVocab
 	] ;
 	.
 
-vocabulary:URLTransitionTypeVocab
+uco-vocabulary:URLTransitionTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "URL Transition Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of types of URL transitions."@en ;
@@ -1146,7 +1146,7 @@ vocabulary:URLTransitionTypeVocab
 	] ;
 	.
 
-vocabulary:UnixProcessStateVocab
+uco-vocabulary:UnixProcessStateVocab
 	a rdfs:Datatype ;
 	rdfs:label "UNIX Process State Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of Unix process states"@en ;
@@ -1164,7 +1164,7 @@ vocabulary:UnixProcessStateVocab
 	] ;
 	.
 
-vocabulary:WhoisContactTypeVocab
+uco-vocabulary:WhoisContactTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Whois Contact Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of types of registrar contacts listed in a whois entry."@en ;
@@ -1178,7 +1178,7 @@ vocabulary:WhoisContactTypeVocab
 	] ;
 	.
 
-vocabulary:WhoisDNSSECTypeVocab
+uco-vocabulary:WhoisDNSSECTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Whois DNSSEC Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of acceptable values for the DNSSEC field in a Whois entry."@en ;
@@ -1191,7 +1191,7 @@ vocabulary:WhoisDNSSECTypeVocab
 	] ;
 	.
 
-vocabulary:WhoisStatusTypeVocab
+uco-vocabulary:WhoisStatusTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Whois Status Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of all valid statuses for a domain within a whois entry."@en ;
@@ -1221,7 +1221,7 @@ vocabulary:WhoisStatusTypeVocab
 	] ;
 	.
 
-vocabulary:WindowsDriveTypeVocab
+uco-vocabulary:WindowsDriveTypeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Windows Drive Type Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of possible drive types, as enumerated by the WINAPI GetDriveType function: http://msdn.microsoft.com/en-us/library/windows/desktop/aa364939(v=vs.85).aspx."@en ;
@@ -1239,7 +1239,7 @@ vocabulary:WindowsDriveTypeVocab
 	] ;
 	.
 
-vocabulary:WindowsVolumeAttributeVocab
+uco-vocabulary:WindowsVolumeAttributeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Windows Volume Attribute Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of attributes that may be returned by the diskpart attributes command: http://technet.microsoft.com/en-us/library/cc766465(v=ws.10).aspx."@en ;
@@ -1254,7 +1254,7 @@ vocabulary:WindowsVolumeAttributeVocab
 	] ;
 	.
 
-vocabulary:WirelessNetworkSecurityModeVocab
+uco-vocabulary:WirelessNetworkSecurityModeVocab
 	a rdfs:Datatype ;
 	rdfs:label "Wireless Network Security Mode Vocabulary"@en-US ;
 	rdfs:comment "Defines an open-vocabulary of security modes that may be configured for wireless network connections."@en ;

--- a/tests/examples/action_inheritance_PASS.json
+++ b/tests/examples/action_inheritance_PASS.json
@@ -1,39 +1,39 @@
 {
     "@context": {
         "acme": "http://example.org/ontology/acme/core/",
-        "action": "https://ontology.unifiedcyberontology.org/uco/action/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "uco-action": "https://ontology.unifiedcyberontology.org/uco/action/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:action-7acb25ab-0a51-4495-9133-baa69c3be54e",
-            "@type": "action:Action",
-            "core:name": "Open File",
-            "action:actionStatus": "CUSTOM Started"
+            "@type": "uco-action:Action",
+            "uco-core:name": "Open File",
+            "uco-action:actionStatus": "CUSTOM Started"
         },
         {
             "@id": "kb:action-90d02552-333f-49d0-9ca6-2a7004adffef",
-            "@type": "action:Action",
-            "core:name": "Modify File",
-            "action:actionStatus": "Pending"
+            "@type": "uco-action:Action",
+            "uco-core:name": "Modify File",
+            "uco-action:actionStatus": "Pending"
         },
         {
             "@id": "kb:action-b4bd127d-489a-41b1-8395-95204e12c8c9",
-            "@type": "action:Action",
-            "core:name": "Save File",
-            "action:actionStatus": "Pending"
+            "@type": "uco-action:Action",
+            "uco-core:name": "Save File",
+            "uco-action:actionStatus": "Pending"
         },
         {
             "@id": "kb:action-lifecycle-63af1a39-22b6-45d6-a591-eede74657b68",
-            "@type": "action:ActionLifecycle",
-            "core:name": "File Update",
-            "action:phase": {
+            "@type": "uco-action:ActionLifecycle",
+            "uco-core:name": "File Update",
+            "uco-action:phase": {
               "@id": "kb:array-of-action-7443745c-4536-43ac-bd3d-2186581e2acb",
-              "@type": "action:ArrayOfAction",
-              "action:action": [
+              "@type": "uco-action:ArrayOfAction",
+              "uco-action:action": [
                 {
                     "@id": "kb:action-7acb25ab-0a51-4495-9133-baa69c3be54e"
                 },

--- a/tests/examples/action_inheritance_PASS_validation.ttl
+++ b/tests/examples/action_inheritance_PASS_validation.ttl
@@ -1,8 +1,8 @@
-@prefix action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -12,10 +12,10 @@
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/kb/action-7acb25ab-0a51-4495-9133-baa69c3be54e> ;
 		sh:resultMessage "Value is not member of the vocabulary ActionStatusTypeVocab." ;
-		sh:resultPath action:actionStatus ;
+		sh:resultPath uco-action:actionStatus ;
 		sh:resultSeverity sh:Info ;
 		sh:sourceConstraintComponent sh:InConstraintComponent ;
-		sh:sourceShape action:Action-actionStatus-in-shape ;
+		sh:sourceShape uco-action:Action-actionStatus-in-shape ;
 		sh:value "CUSTOM Started" ;
 	] ;
 	.

--- a/tests/examples/action_inheritance_XFAIL.json
+++ b/tests/examples/action_inheritance_XFAIL.json
@@ -1,39 +1,39 @@
 {
     "@context": {
         "acme": "http://example.org/ontology/acme/core/",
-        "action": "https://ontology.unifiedcyberontology.org/uco/action/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
+        "uco-action": "https://ontology.unifiedcyberontology.org/uco/action/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:action-35fada9e-c807-4fa0-87b8-582473115eeb",
-            "@type": "action:Action",
-            "core:name": "Open File",
-            "action:actionStatus": "Pending"
+            "@type": "uco-action:Action",
+            "uco-core:name": "Open File",
+            "uco-action:actionStatus": "Pending"
         },
         {
             "@id": "kb:action-dcb9c6a2-f7b9-454a-b185-44d63244ac1c",
-            "@type": "action:Action",
-            "core:name": "Modify File",
-            "action:actionStatus": "Pending"
+            "@type": "uco-action:Action",
+            "uco-core:name": "Modify File",
+            "uco-action:actionStatus": "Pending"
         },
         {
             "@id": "kb:action-e1bb7bac-5655-48e3-8c62-843ffb7cc17f",
-            "@type": "action:Action",
-            "core:name": "Save File",
-            "action:actionStatus": "Pending"
+            "@type": "uco-action:Action",
+            "uco-core:name": "Save File",
+            "uco-action:actionStatus": "Pending"
         },
         {
             "@id": "kb:action-lifecycle-098ebb7a-949e-4f05-9d7f-1c07260a8e14",
-            "@type": "action:ActionLifecycle",
-            "core:name": "File Update",
-            "action:actionStatus": "Pending",
-            "action:phase": {
+            "@type": "uco-action:ActionLifecycle",
+            "uco-core:name": "File Update",
+            "uco-action:actionStatus": "Pending",
+            "uco-action:phase": {
               "@id": "kb:array-of-action-6f91380f-703f-471e-9be6-cf7499bf44f2",
-              "@type": "action:ArrayOfAction",
-              "action:action": [
+              "@type": "uco-action:ArrayOfAction",
+              "uco-action:action": [
                 "kb:action-35fada9e-c807-4fa0-87b8-582473115eeb",
                 "kb:action-dcb9c6a2-f7b9-454a-b185-44d63244ac1c",
                 "kb:action-e1bb7bac-5655-48e3-8c62-843ffb7cc17f"

--- a/tests/examples/action_inheritance_XFAIL_validation.ttl
+++ b/tests/examples/action_inheritance_XFAIL_validation.ttl
@@ -1,8 +1,8 @@
-@prefix action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -12,57 +12,57 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/action-lifecycle-098ebb7a-949e-4f05-9d7f-1c07260a8e14> ;
-			sh:resultMessage "More than 0 values on kb:action-lifecycle-098ebb7a-949e-4f05-9d7f-1c07260a8e14->action:actionStatus" ;
-			sh:resultPath action:actionStatus ;
+			sh:resultMessage "More than 0 values on kb:action-lifecycle-098ebb7a-949e-4f05-9d7f-1c07260a8e14->uco-action:actionStatus" ;
+			sh:resultPath uco-action:actionStatus ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
 			sh:sourceShape [
 				sh:maxCount "0"^^xsd:integer ;
-				sh:path action:actionStatus ;
+				sh:path uco-action:actionStatus ;
 			] ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/array-of-action-6f91380f-703f-471e-9be6-cf7499bf44f2> ;
-			sh:resultMessage "Value does not have class action:Action" ;
-			sh:resultPath action:action ;
+			sh:resultMessage "Value does not have class uco-action:Action" ;
+			sh:resultPath uco-action:action ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class action:Action ;
+				sh:class uco-action:Action ;
 				sh:minCount "1"^^xsd:integer ;
 				sh:nodeKind sh:IRI ;
-				sh:path action:action ;
+				sh:path uco-action:action ;
 			] ;
 			sh:value "kb:action-35fada9e-c807-4fa0-87b8-582473115eeb" ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/array-of-action-6f91380f-703f-471e-9be6-cf7499bf44f2> ;
-			sh:resultMessage "Value does not have class action:Action" ;
-			sh:resultPath action:action ;
+			sh:resultMessage "Value does not have class uco-action:Action" ;
+			sh:resultPath uco-action:action ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class action:Action ;
+				sh:class uco-action:Action ;
 				sh:minCount "1"^^xsd:integer ;
 				sh:nodeKind sh:IRI ;
-				sh:path action:action ;
+				sh:path uco-action:action ;
 			] ;
 			sh:value "kb:action-dcb9c6a2-f7b9-454a-b185-44d63244ac1c" ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/array-of-action-6f91380f-703f-471e-9be6-cf7499bf44f2> ;
-			sh:resultMessage "Value does not have class action:Action" ;
-			sh:resultPath action:action ;
+			sh:resultMessage "Value does not have class uco-action:Action" ;
+			sh:resultPath uco-action:action ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class action:Action ;
+				sh:class uco-action:Action ;
 				sh:minCount "1"^^xsd:integer ;
 				sh:nodeKind sh:IRI ;
-				sh:path action:action ;
+				sh:path uco-action:action ;
 			] ;
 			sh:value "kb:action-e1bb7bac-5655-48e3-8c62-843ffb7cc17f" ;
 		] ,
@@ -70,14 +70,14 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/array-of-action-6f91380f-703f-471e-9be6-cf7499bf44f2> ;
 			sh:resultMessage "Value is not of Node Kind sh:IRI" ;
-			sh:resultPath action:action ;
+			sh:resultPath uco-action:action ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
 			sh:sourceShape [
-				sh:class action:Action ;
+				sh:class uco-action:Action ;
 				sh:minCount "1"^^xsd:integer ;
 				sh:nodeKind sh:IRI ;
-				sh:path action:action ;
+				sh:path uco-action:action ;
 			] ;
 			sh:value "kb:action-35fada9e-c807-4fa0-87b8-582473115eeb" ;
 		] ,
@@ -85,14 +85,14 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/array-of-action-6f91380f-703f-471e-9be6-cf7499bf44f2> ;
 			sh:resultMessage "Value is not of Node Kind sh:IRI" ;
-			sh:resultPath action:action ;
+			sh:resultPath uco-action:action ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
 			sh:sourceShape [
-				sh:class action:Action ;
+				sh:class uco-action:Action ;
 				sh:minCount "1"^^xsd:integer ;
 				sh:nodeKind sh:IRI ;
-				sh:path action:action ;
+				sh:path uco-action:action ;
 			] ;
 			sh:value "kb:action-dcb9c6a2-f7b9-454a-b185-44d63244ac1c" ;
 		] ,
@@ -100,14 +100,14 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/array-of-action-6f91380f-703f-471e-9be6-cf7499bf44f2> ;
 			sh:resultMessage "Value is not of Node Kind sh:IRI" ;
-			sh:resultPath action:action ;
+			sh:resultPath uco-action:action ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
 			sh:sourceShape [
-				sh:class action:Action ;
+				sh:class uco-action:Action ;
 				sh:minCount "1"^^xsd:integer ;
 				sh:nodeKind sh:IRI ;
-				sh:path action:action ;
+				sh:path uco-action:action ;
 			] ;
 			sh:value "kb:action-e1bb7bac-5655-48e3-8c62-843ffb7cc17f" ;
 		]

--- a/tests/examples/action_result_PASS.json
+++ b/tests/examples/action_result_PASS.json
@@ -1,17 +1,18 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "action": "https://ontology.unifiedcyberontology.org/uco/action/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-action": "https://ontology.unifiedcyberontology.org/uco/action/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:action-1-094d6f1a-eaaf-48b2-bbe8-1943aa77cff1",
-            "@type": "action:Action",
+            "@type": "uco-action:Action",
             "rdfs:comment": "This node is some action that has some ObservableObjects as results.  By the ontology, the results need to be some UcoObject or subclass of UcoObject.  They are serialized here as ObservableObjects, and are redundantly assigned types of some of their superclasses.  For completeness-tracking, let the id slug's number be a binary number tracking which superclasses are present, 2^0=core:UcoObject, 2^1=core:Item, 2^2=observable:Observable.",
-            "action:result": [
+            "uco-action:result": [
                 {
                     "@id": "kb:node-0-0cc5b4d4-e85f-4131-86ff-206a7ca9e8fc"
                 },
@@ -40,60 +41,60 @@
         },
         {
             "@id": "kb:node-0-0cc5b4d4-e85f-4131-86ff-206a7ca9e8fc",
-            "@type": "observable:ObservableObject"
+            "@type": "uco-observable:ObservableObject"
         },
         {
             "@id": "kb:node-1-21bea5ad-9fd3-4221-a839-4f0864c79fc3",
             "@type": [
-                "core:UcoObject",
-                "observable:ObservableObject"
+                "uco-core:UcoObject",
+                "uco-observable:ObservableObject"
             ]
         },
         {
             "@id": "kb:node-2-5e759182-ae22-4f73-9c55-215974f2a61b",
             "@type": [
-                "core:Item",
-                "observable:ObservableObject"
+                "uco-core:Item",
+                "uco-observable:ObservableObject"
             ]
         },
         {
             "@id": "kb:node-3-6c5d68fc-c869-4567-af65-8bfba49bd26d",
             "@type": [
-                "core:UcoObject",
-                "core:Item",
-                "observable:ObservableObject"
+                "uco-core:UcoObject",
+                "uco-core:Item",
+                "uco-observable:ObservableObject"
             ]
         },
         {
             "@id": "kb:node-4-90352b81-74f1-43aa-8cf1-a194442077a9",
             "@type": [
-                "observable:Observable",
-                "observable:ObservableObject"
+                "uco-observable:Observable",
+                "uco-observable:ObservableObject"
             ]
         },
         {
             "@id": "kb:node-5-ee7608ee-e372-4574-bc22-23ef74e5f882",
             "@type": [
-                "core:UcoObject",
-                "observable:Observable",
-                "observable:ObservableObject"
+                "uco-core:UcoObject",
+                "uco-observable:Observable",
+                "uco-observable:ObservableObject"
             ]
         },
         {
             "@id": "kb:node-6-f456dbf2-a2f4-4060-ad79-6a954c5d0140",
             "@type": [
-                "core:Item",
-                "observable:Observable",
-                "observable:ObservableObject"
+                "uco-core:Item",
+                "uco-observable:Observable",
+                "uco-observable:ObservableObject"
             ]
         },
         {
             "@id": "kb:node-7-fd15ec16-9eff-49f4-ba70-b315d90d72a8",
             "@type": [
-                "core:UcoObject",
-                "core:Item",
-                "observable:Observable",
-                "observable:ObservableObject"
+                "uco-core:UcoObject",
+                "uco-core:Item",
+                "uco-observable:Observable",
+                "uco-observable:ObservableObject"
             ]
         }
     ]

--- a/tests/examples/alternate_data_stream_PASS.json
+++ b/tests/examples/alternate_data_stream_PASS.json
@@ -1,20 +1,20 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/"
     },
     "@graph": [
         {
             "@id": "kb:AlternateDataStream-07b3c41a-080c-4916-8375-c18148763e13",
-            "@type": "observable:AlternateDataStream",
+            "@type": "uco-observable:AlternateDataStream",
             "rdfs:comment": "This node should trigger a sh:Warning from not being a observable:FileSystemObject"
         },
         {
             "@id": "kb:AlternateDataStream-b2d4968b-4490-4b44-a56b-832058834454",
             "@type": [
-                "observable:AlternateDataStream",
-                "observable:FileSystemObject"
+                "uco-observable:AlternateDataStream",
+                "uco-observable:FileSystemObject"
             ]
         }
     ]

--- a/tests/examples/alternate_data_stream_PASS_validation.ttl
+++ b/tests/examples/alternate_data_stream_PASS_validation.ttl
@@ -1,8 +1,8 @@
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -17,10 +17,10 @@
 		sh:sourceShape [
 			a sh:NodeShape ;
 			rdfs:comment "This anonymous shape is attached with rdfs:seeAlso in order to associate a warning-severity class constraint, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
-			sh:class observable:FileSystemObject ;
+			sh:class uco-observable:FileSystemObject ;
 			sh:message "In UCO 2.0.0, uco-observable:AlternateDataStream will be a subclass of uco-observable:FileSystemObject.  In preparation for UCO 2.0.0, the additional type uco-observable:FileSystemObject should be assigned to this node."@en ;
 			sh:severity sh:Warning ;
-			sh:targetClass observable:AlternateDataStream ;
+			sh:targetClass uco-observable:AlternateDataStream ;
 		] ;
 		sh:value <http://example.org/kb/AlternateDataStream-07b3c41a-080c-4916-8375-c18148763e13> ;
 	] ;

--- a/tests/examples/co_PASS.json
+++ b/tests/examples/co_PASS.json
@@ -1,8 +1,8 @@
 {
     "@context": {
         "co": "http://purl.org/co/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
@@ -176,15 +176,15 @@
         },
         {
             "@id": "kb:uco-object-eff7e490-8488-40f7-a3ed-469cf9628c7d",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:uco-object-f6df0854-bc98-4bf8-b658-cba328fc3a09",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:uco-object-fcfc829a-276f-4f0f-82b7-085ba1f668dc",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         }
     ]
 }

--- a/tests/examples/co_XFAIL.json
+++ b/tests/examples/co_XFAIL.json
@@ -1,19 +1,19 @@
 {
     "@context": {
         "co": "http://purl.org/co/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:uco-object-e398cbb9-a92e-4e8b-b3ba-b4149810775f",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:uco-object-f3592274-5af8-434a-90c7-14f286ce01c9",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:list-02de67a8-bfb9-4e00-a305-bae3daf6384b",

--- a/tests/examples/configuration_setting_PASS.json
+++ b/tests/examples/configuration_setting_PASS.json
@@ -1,9 +1,9 @@
 {
     "@context": {
-        "configuration": "https://ontology.unifiedcyberontology.org/uco/configuration/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "tool": "https://ontology.unifiedcyberontology.org/uco/tool/"
+        "uco-configuration": "https://ontology.unifiedcyberontology.org/uco/configuration/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-tool": "https://ontology.unifiedcyberontology.org/uco/tool/"
     },
     "@graph": [
         {
@@ -11,27 +11,27 @@
         },
         {
             "@id": "kb:tool-f12e10c5-daca-4bd1-8b49-ae728f309053",
-            "@type": "tool:Tool"
+            "@type": "uco-tool:Tool"
         },
         {
             "@id": "kb:configured-object-711b4e95-996e-461a-83a0-e0d6342bf028",
-            "@type": "tool:ConfiguredTool",
-            "configuration:isConfigurationOf": {
+            "@type": "uco-tool:ConfiguredTool",
+            "uco-configuration:isConfigurationOf": {
                 "@id": "kb:tool-f12e10c5-daca-4bd1-8b49-ae728f309053"
             },
-            "configuration:usesConfiguration": {
+            "uco-configuration:usesConfiguration": {
                 "@id": "kb:configuration-26760258-ffc7-4241-96f9-0056781eccff"
             }
         },
 
         {
             "@id": "kb:thing-b752452a-9f7a-4421-a9f3-9611a8cd216c",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:configuration-26760258-ffc7-4241-96f9-0056781eccff",
-            "@type": "configuration:Configuration",
-            "configuration:configurationEntry": [
+            "@type": "uco-configuration:Configuration",
+            "uco-configuration:configurationEntry": [
                 {
                     "@id": "kb:configuration-entry-317fc0bd-bc17-40af-85e0-5818ff4b823a"
                 },
@@ -45,22 +45,22 @@
         },
         {
             "@id": "kb:configuration-entry-317fc0bd-bc17-40af-85e0-5818ff4b823a",
-            "@type": "configuration:ConfigurationEntry",
-            "configuration:itemName": "--setting-0"
+            "@type": "uco-configuration:ConfigurationEntry",
+            "uco-configuration:itemName": "--setting-0"
         },
         {
             "@id": "kb:configuration-entry-38ca44a6-c72c-4ad7-b196-a65506eb467f",
-            "@type": "configuration:ConfigurationEntry",
-            "configuration:itemName": "--setting-1",
-            "configuration:itemObject": {
+            "@type": "uco-configuration:ConfigurationEntry",
+            "uco-configuration:itemName": "--setting-1",
+            "uco-configuration:itemObject": {
                 "@id": "kb:thing-b752452a-9f7a-4421-a9f3-9611a8cd216c"
             }
         },
         {
             "@id": "kb:configuration-entry-52a03c2a-ebc5-4695-b0b7-e04d5fc34e8c",
-            "@type": "configuration:ConfigurationEntry",
-            "configuration:itemName": "--setting-2",
-            "configuration:itemValue": "A value"
+            "@type": "uco-configuration:ConfigurationEntry",
+            "uco-configuration:itemName": "--setting-2",
+            "uco-configuration:itemValue": "A value"
         }
     ]
 }

--- a/tests/examples/configuration_setting_XFAIL.json
+++ b/tests/examples/configuration_setting_XFAIL.json
@@ -1,10 +1,10 @@
 {
     "@context": {
-        "configuration": "https://ontology.unifiedcyberontology.org/uco/configuration/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
-        "tool": "https://ontology.unifiedcyberontology.org/uco/tool/"
+        "uco-configuration": "https://ontology.unifiedcyberontology.org/uco/configuration/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-tool": "https://ontology.unifiedcyberontology.org/uco/tool/"
     },
     "@graph": [
         {
@@ -12,38 +12,38 @@
         },
         {
             "@id": "kb:thing-acd8e871-f63d-46d4-bf0e-61ee3107d416",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:software-9466a9f9-edf3-4ecd-bc48-a81a6c64ff81",
-            "@type": "observable:Software"
+            "@type": "uco-observable:Software"
         },
         {
             "@id": "kb:configured-object-7156bff0-b805-4190-83ee-230fae31e33a",
-            "@type": "tool:ConfiguredTool",
+            "@type": "uco-tool:ConfiguredTool",
             "rdfs:comment": "This will trigger an error, as kb:software-9466a9f9-edf3-4ecd-bc48-a81a6c64ff81 is not declared here to be a tool:Tool.  It can be, but it has not been declared here.",
-            "configuration:isConfigurationOf": {
+            "uco-configuration:isConfigurationOf": {
                 "@id": "kb:software-9466a9f9-edf3-4ecd-bc48-a81a6c64ff81"
             },
-            "configuration:usesConfiguration": {
+            "uco-configuration:usesConfiguration": {
                 "@id": "kb:configuration-3736e04e-5363-4359-a9f8-a3c95ca72411"
             }
         },
         {
             "@id": "kb:configuration-3736e04e-5363-4359-a9f8-a3c95ca72411",
-            "@type": "configuration:Configuration",
-            "configuration:configurationEntry": {
+            "@type": "uco-configuration:Configuration",
+            "uco-configuration:configurationEntry": {
                 "@id": "kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c"
             }
         },
         {
             "@id": "kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c",
-            "@type": "configuration:ConfigurationEntry",
-            "configuration:itemName": "--setting-3",
-            "configuration:itemObject": {
+            "@type": "uco-configuration:ConfigurationEntry",
+            "uco-configuration:itemName": "--setting-3",
+            "uco-configuration:itemObject": {
                 "@id": "kb:thing-acd8e871-f63d-46d4-bf0e-61ee3107d416"
             },
-            "configuration:itemValue": "A value"
+            "uco-configuration:itemValue": "A value"
         }
     ]
 }

--- a/tests/examples/configuration_setting_XFAIL_validation.ttl
+++ b/tests/examples/configuration_setting_XFAIL_validation.ttl
@@ -1,9 +1,9 @@
-@prefix configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix tool: <https://ontology.unifiedcyberontology.org/uco/tool/> .
+@prefix uco-configuration: <https://ontology.unifiedcyberontology.org/uco/configuration/> .
+@prefix uco-tool: <https://ontology.unifiedcyberontology.org/uco/tool/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -13,24 +13,24 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c> ;
-			sh:resultMessage 'Node kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c must conform to exactly one shape in [ sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemObject ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemValue ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemObject ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemValue ] ]' ;
+			sh:resultMessage 'Node kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c must conform to exactly one shape in [ sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path uco-configuration:itemObject ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path uco-configuration:itemValue ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path uco-configuration:itemObject ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path uco-configuration:itemValue ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
-			sh:sourceShape configuration:ConfigurationEntry ;
+			sh:sourceShape uco-configuration:ConfigurationEntry ;
 			sh:value <http://example.org/kb/configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/configured-object-7156bff0-b805-4190-83ee-230fae31e33a> ;
-			sh:resultMessage "Value does not have class tool:Tool" ;
-			sh:resultPath configuration:isConfigurationOf ;
+			sh:resultMessage "Value does not have class uco-tool:Tool" ;
+			sh:resultPath uco-configuration:isConfigurationOf ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class tool:Tool ;
+				sh:class uco-tool:Tool ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:BlankNodeOrIRI ;
-				sh:path configuration:isConfigurationOf ;
+				sh:path uco-configuration:isConfigurationOf ;
 			] ;
 			sh:value <http://example.org/kb/software-9466a9f9-edf3-4ecd-bc48-a81a6c64ff81> ;
 		]

--- a/tests/examples/database_records_PASS.json
+++ b/tests/examples/database_records_PASS.json
@@ -1,41 +1,41 @@
 {
     "@context": {
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:sqlite-record-102119a5-29f2-49fc-80a7-adbafd03aa46",
-            "@type": "observable:TableField",
-            "core:hasFacet": {
+            "@type": "uco-observable:TableField",
+            "uco-core:hasFacet": {
                 "@id": "kb:table-field-facet-25254866-21bd-441d-bf2a-3373f7d17df6",
-                "@type": "observable:TableFieldFacet",
+                "@type": "uco-observable:TableFieldFacet",
                 "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
-                "observable:recordRowID": 1
+                "uco-observable:recordRowID": 1
             }
         },
         {
             "@id": "kb:sqlite-record-63a3229a-a1bd-4c91-b45a-704fbf5e43d3",
-            "@type": "observable:TableField",
-            "core:hasFacet": {
+            "@type": "uco-observable:TableField",
+            "uco-core:hasFacet": {
                 "@id": "kb:table-field-facet-32c5e881-f6a7-4ac8-89ec-4ea2e53e6d56",
-                "@type": "observable:TableFieldFacet",
+                "@type": "uco-observable:TableFieldFacet",
                 "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
-                "observable:recordRowID": "A"
+                "uco-observable:recordRowID": "A"
             }
         },
         {
             "@id": "kb:sqlite-record-8186208e-a27a-4025-9fb7-e697d044786d",
-            "@type": "observable:TableField",
-            "core:hasFacet": {
+            "@type": "uco-observable:TableField",
+            "uco-core:hasFacet": {
                 "@id": "kb:table-field-facet-fbe52d33-7448-48de-9d1c-f6ab9e2757e0",
-                "@type": "observable:TableFieldFacet",
+                "@type": "uco-observable:TableFieldFacet",
                 "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
-                "observable:recordFieldIsNull": false,
-                "observable:recordFieldValue": {
+                "uco-observable:recordFieldIsNull": false,
+                "uco-observable:recordFieldValue": {
                     "@type": "xsd:decimal",
                     "@value": "87.65"
                 }
@@ -43,13 +43,13 @@
         },
         {
             "@id": "kb:sqlite-record-ff678274-ab0f-4671-9a9b-da1828326fb8",
-            "@type": "observable:TableField",
-            "core:hasFacet": {
+            "@type": "uco-observable:TableField",
+            "uco-core:hasFacet": {
                 "@id": "kb:table-field-facet-c30848ac-6c64-43eb-a081-cddf01c37085",
-                "@type": "observable:TableFieldFacet",
+                "@type": "uco-observable:TableFieldFacet",
                 "rdfs:comment": "This node is intended to not trigger any SHACL validation issues.",
-                "observable:recordFieldIsNull": false,
-                "observable:recordFieldValue": {
+                "uco-observable:recordFieldIsNull": false,
+                "uco-observable:recordFieldValue": {
                     "@type": "xsd:base64Binary",
                     "@value": "2jmj7l5rSw0yVb/vlWAYkK/YBwk="
                 }
@@ -57,10 +57,10 @@
         },
         {
             "@id": "kb:sqlite-record-2892f411-3bab-4998-8af1-b8a5dff92bac",
-            "@type": "observable:TableField",
-            "core:hasFacet": {
+            "@type": "uco-observable:TableField",
+            "uco-core:hasFacet": {
                 "@id": "kb:table-field-facet-44843015-9916-43e9-8f02-3e20874f461d",
-                "@type": "observable:TableFieldFacet",
+                "@type": "uco-observable:TableFieldFacet",
                 "rdfs:comment": "This node is intentionally sparse, to show that no SHACL validation issues are triggered."
             }
         }

--- a/tests/examples/database_records_XFAIL.json
+++ b/tests/examples/database_records_XFAIL.json
@@ -1,20 +1,20 @@
 {
     "@context": {
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:sqlite-record-c1d91148-754f-41b9-b3e8-000a31102205",
-            "@type": "observable:TableField",
-            "core:hasFacet": {
+            "@type": "uco-observable:TableField",
+            "uco-core:hasFacet": {
                 "@id": "kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314",
-                "@type": "observable:TableFieldFacet",
+                "@type": "uco-observable:TableFieldFacet",
                 "rdfs:comment": "This node is intended to trigger a SHACL validation issue, and will be migrated to a XFAIL test in UCO.",
-                "observable:recordFieldIsNull": [
+                "uco-observable:recordFieldIsNull": [
                     false,
                     true
                 ]
@@ -22,13 +22,13 @@
         },
         {
             "@id": "kb:sqlite-record-f150b810-503c-426b-b8f9-0c66325ea3b0",
-            "@type": "observable:TableField",
-            "core:hasFacet": {
+            "@type": "uco-observable:TableField",
+            "uco-core:hasFacet": {
                 "@id": "kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29",
-                "@type": "observable:TableFieldFacet",
+                "@type": "uco-observable:TableFieldFacet",
                 "rdfs:comment": "This node is intended to trigger a SHACL validation issue about a field being designated NULL and value-bearing.",
-                "observable:recordFieldIsNull": true,
-                "observable:recordFieldValue": 6789
+                "uco-observable:recordFieldIsNull": true,
+                "uco-observable:recordFieldValue": 6789
             }
         }
     ]

--- a/tests/examples/database_records_XFAIL_validation.ttl
+++ b/tests/examples/database_records_XFAIL_validation.ttl
@@ -1,8 +1,8 @@
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -12,33 +12,33 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29> ;
-			sh:resultMessage 'Node kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultMessage 'Node kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path uco-observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path uco-observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path uco-observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path uco-observable:recordFieldIsNull ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
-			sh:sourceShape observable:TableFieldFacet ;
+			sh:sourceShape uco-observable:TableFieldFacet ;
 			sh:value <http://example.org/kb/table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
-			sh:resultMessage "More than 1 values on kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314->observable:recordFieldIsNull" ;
-			sh:resultPath observable:recordFieldIsNull ;
+			sh:resultMessage "More than 1 values on kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314->uco-observable:recordFieldIsNull" ;
+			sh:resultPath uco-observable:recordFieldIsNull ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:boolean ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path observable:recordFieldIsNull ;
+				sh:path uco-observable:recordFieldIsNull ;
 			] ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
-			sh:resultMessage 'Node kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultMessage 'Node kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path uco-observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path uco-observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path uco-observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path uco-observable:recordFieldIsNull ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
-			sh:sourceShape observable:TableFieldFacet ;
+			sh:sourceShape uco-observable:TableFieldFacet ;
 			sh:value <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
 		]
 		;

--- a/tests/examples/dictionary_PASS.json
+++ b/tests/examples/dictionary_PASS.json
@@ -2,122 +2,122 @@
     "@context": {
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/"
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/"
     },
     "@graph": [
         {
             "@id": "kb:Dictionary-3bb38b3e-d47a-43c8-8a77-afc0e6655ce1",
-            "@type": "types:Dictionary",
-            "types:entry": [
+            "@type": "uco-types:Dictionary",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-b8a01d49-53c1-440f-a2d5-618b58801d37",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-6cac6c2c-5d4e-45f5-b784-c029c9f9fb6d",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "y",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "y",
+                    "uco-types:value": "2"
                 }
             ]
         },
         {
             "@id": "kb:ProperDictionary-eaded28e-0bf8-4df1-aee8-84d22c09702c",
-            "@type": "types:ProperDictionary",
-            "types:entry": [
+            "@type": "uco-types:ProperDictionary",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-314212eb-39c4-4bf3-be3a-f07c38f0eae8",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-9ec24a1a-7e99-41c9-ba7d-9d23f11babb4",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "y",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "y",
+                    "uco-types:value": "2"
                 }
             ]
         },
         {
             "@id": "kb:ImproperDictionary-a8e5e8e1-b3de-4ac4-99dd-e36f96beea4d",
-            "@type": "types:ImproperDictionary",
-            "types:repeatsKey": "x",
-            "types:entry": [
+            "@type": "uco-types:ImproperDictionary",
+            "uco-types:repeatsKey": "x",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-55786f64-534d-4e8c-8a64-616f708ea4d3",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-d1a83c3d-cbe6-40b0-bb26-3527c47a01d8",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "2"
                 }
             ]
         },
         {
             "@id": "kb:Dictionary-e9adf6c1-0287-4290-95a9-c94a128d7ff6",
-            "@type": "types:Dictionary",
+            "@type": "uco-types:Dictionary",
             "rdfs:comment": "This dictionary, not being typed as a ProperDictionary, will not trigger a warning from having two entries keyed with value 'x'.",
-            "types:entry": [
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-20431f00-64a3-4c0f-94a4-1eb09f8a6b6a",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-f187ee7f-12fb-4580-966d-47bf1afd4975",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 }
             ]
         },
         {
             "@id": "kb:ImproperDictionary-7fa3ea45-6426-4ad3-bb5f-7559e07adeb4",
-            "@type": "types:ImproperDictionary",
+            "@type": "uco-types:ImproperDictionary",
             "repeatsKey": "z"
         },
         {
             "@id": "kb:ImproperDictionary-14e28425-00c1-4f11-b2ed-21390fc0749a",
-            "@type": "types:ImproperDictionary",
-            "types:entry": [
+            "@type": "uco-types:ImproperDictionary",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-09f23642-389b-4553-b5be-283a6160f534",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-7a84a0d6-d1cd-4291-afb4-c834d611898d",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "2"
                 }
             ]
         },
         {
             "@id": "kb:ImproperDictionary-cbc1c80d-1bad-4947-8459-c53ff61e8bfa",
-            "@type": "types:ImproperDictionary",
+            "@type": "uco-types:ImproperDictionary",
             "rdfs:comment": "This improper dictionary has no repeated key or assertion of a repeated key.  This should not trigger a data error, because the information in the graph could merely be incomplete.",
-            "types:entry": [
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-ca1910ab-fa26-402a-86bb-229f490dd89a",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-2a13e674-5e95-4a7a-9fac-c90417dcd97c",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "y",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "y",
+                    "uco-types:value": "2"
                 }
             ]
         }

--- a/tests/examples/dictionary_PASS_validation.ttl
+++ b/tests/examples/dictionary_PASS_validation.ttl
@@ -2,7 +2,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -11,26 +11,26 @@
 	sh:result [
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/kb/Dictionary-e9adf6c1-0287-4290-95a9-c94a128d7ff6> ;
-		sh:resultMessage "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the types:ImproperDictionary class and types:repeatsKey property." ;
+		sh:resultMessage "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the uco-types:ImproperDictionary class and uco-types:repeatsKey property." ;
 		sh:resultSeverity sh:Warning ;
 		sh:sourceConstraint [
 			a sh:SPARQLConstraint ;
-			sh:message "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the types:ImproperDictionary class and types:repeatsKey property."@en ;
+			sh:message "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the uco-types:ImproperDictionary class and uco-types:repeatsKey property."@en ;
 			sh:select """
-			PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+			PREFIX uco-types: <https://ontology.unifiedcyberontology.org/uco/types/>
 			SELECT $this ?value
 			WHERE {
 				$this
-					types:entry/types:key ?value ;
+					uco-types:entry/uco-types:key ?value ;
 					.
 				FILTER NOT EXISTS {
 					$this
-						a types:ImproperDictionary ;
+						a uco-types:ImproperDictionary ;
 						.
 				}
 				FILTER NOT EXISTS {
 					$this
-						a types:ProperDictionary ;
+						a uco-types:ProperDictionary ;
 						.
 				}
 			}
@@ -39,7 +39,7 @@
 			""" ;
 		] ;
 		sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-		sh:sourceShape types:Dictionary-keyUniqueness-shape ;
+		sh:sourceShape uco-types:Dictionary-keyUniqueness-shape ;
 		sh:value "x" ;
 	] ;
 	.

--- a/tests/examples/dictionary_XFAIL.json
+++ b/tests/examples/dictionary_XFAIL.json
@@ -2,119 +2,119 @@
     "@context": {
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/"
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/"
     },
     "@graph": [
         {
             "@id": "kb:Dictionary-5bc55661-4808-48e6-9e02-80a153eee5d3",
             "@type": [
-                "types:ImproperDictionary",
-                "types:ProperDictionary"
+                "uco-types:ImproperDictionary",
+                "uco-types:ProperDictionary"
             ],
             "rdfs:comment": "This dictionary will trigger an error from being typed as both disjoint subclasses of types:Dictionary.",
-            "types:entry": {
+            "uco-types:entry": {
                 "@id": "kb:DictionaryEntry-fa139d6e-2b4d-49e5-8c7d-3cfc635d56e0",
-                "@type": "types:DictionaryEntry",
-                "types:key": "x",
-                "types:value": "1"
+                "@type": "uco-types:DictionaryEntry",
+                "uco-types:key": "x",
+                "uco-types:value": "1"
             }
         },
         {
             "@id": "kb:Dictionary-34ac0c49-1042-49c0-8fd6-c42a810e58da",
-            "@type": "types:Dictionary",
+            "@type": "uco-types:Dictionary",
             "rdfs:comment": "This dictionary will trigger an error from using repeatsKey while not also typing itself as a types:ImproperDictionary.",
-            "types:repeatsKey": "x",
-            "types:entry": [
+            "uco-types:repeatsKey": "x",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-322b718b-3869-48a3-a7bf-d97d5463563b",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-e51c7808-7fcb-423a-95e6-dcb431a3bade",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "2"
                 }
             ]
         },
         {
             "@id": "kb:ProperDictionary-b2baf8af-3d5d-4c4e-b442-49befefd147e",
-            "@type": "types:ProperDictionary",
+            "@type": "uco-types:ProperDictionary",
             "rdfs:comment": "This dictionary will trigger an error from having two entries keyed with value 'x'.",
-            "types:entry": [
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-203a8596-1439-4065-a99f-daf4d530bed7",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-40b9d75d-6a11-4a8f-9951-e96e2c1fe683",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "2"
                 }
             ]
         },
         {
             "@id": "kb:ProperDictionary-8114819f-d3c8-4e29-9e31-295d771f9db2",
-            "@type": "types:ProperDictionary",
+            "@type": "uco-types:ProperDictionary",
             "rdfs:comment": "This proper dictionary will trigger an error from using repeatsKey while not being an ImproperDictionary.",
-            "types:repeatsKey": "x",
-            "types:entry": [
+            "uco-types:repeatsKey": "x",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-1311a664-fce3-4174-ace1-539ac6d54a5f",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-8b149881-5adc-4020-b46f-2be1c60bab83",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "y",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "y",
+                    "uco-types:value": "2"
                 }
             ]
         },
         {
             "@id": "kb:ProperDictionary-f5ae2e6a-9b10-46f3-8441-30aada36aa1b",
-            "@type": "types:ProperDictionary",
+            "@type": "uco-types:ProperDictionary",
             "rdfs:comment": "This dictionary will trigger an error from having two entries keyed with value 'x'.",
-            "types:repeatsKey": "x",
-            "types:entry": [
+            "uco-types:repeatsKey": "x",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-0274c19c-89b9-42b6-a87e-f671cbd2c731",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-de108ec2-8ddd-4201-8267-5a04035ba88e",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 }
             ]
         },
         {
             "@id": "kb:Dictionary-e6dc9c2e-25bc-422f-8ae8-8457e29f5fde",
-            "@type": "types:Dictionary",
+            "@type": "uco-types:Dictionary",
             "rdfs:comment": "This dictionary will trigger an error from using repeatsKey while not also typing itself as a types:ImproperDictionary.",
-            "types:repeatsKey": "x",
-            "types:entry": [
+            "uco-types:repeatsKey": "x",
+            "uco-types:entry": [
                 {
                     "@id": "kb:DictionaryEntry-02edb446-1ad5-41ef-8877-fbee912189e7",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "x",
-                    "types:value": "1"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "x",
+                    "uco-types:value": "1"
                 },
                 {
                     "@id": "kb:DictionaryEntry-147908bb-ebba-42e8-854d-72352dc903a1",
-                    "@type": "types:DictionaryEntry",
-                    "types:key": "y",
-                    "types:value": "2"
+                    "@type": "uco-types:DictionaryEntry",
+                    "uco-types:key": "y",
+                    "uco-types:value": "2"
                 }
             ]
         }

--- a/tests/examples/dictionary_XFAIL_validation.ttl
+++ b/tests/examples/dictionary_XFAIL_validation.ttl
@@ -2,7 +2,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -12,26 +12,26 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/Dictionary-34ac0c49-1042-49c0-8fd6-c42a810e58da> ;
-			sh:resultMessage "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the types:ImproperDictionary class and types:repeatsKey property." ;
+			sh:resultMessage "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the uco-types:ImproperDictionary class and uco-types:repeatsKey property." ;
 			sh:resultSeverity sh:Warning ;
 			sh:sourceConstraint [
 				a sh:SPARQLConstraint ;
-				sh:message "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the types:ImproperDictionary class and types:repeatsKey property."@en ;
+				sh:message "A key in a dictionary should appear no more than once.  The value literal does.  Please consider using the uco-types:ImproperDictionary class and uco-types:repeatsKey property."@en ;
 				sh:select """
-			PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+			PREFIX uco-types: <https://ontology.unifiedcyberontology.org/uco/types/>
 			SELECT $this ?value
 			WHERE {
 				$this
-					types:entry/types:key ?value ;
+					uco-types:entry/uco-types:key ?value ;
 					.
 				FILTER NOT EXISTS {
 					$this
-						a types:ImproperDictionary ;
+						a uco-types:ImproperDictionary ;
 						.
 				}
 				FILTER NOT EXISTS {
 					$this
-						a types:ProperDictionary ;
+						a uco-types:ProperDictionary ;
 						.
 				}
 			}
@@ -40,43 +40,43 @@
 			""" ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape types:Dictionary-keyUniqueness-shape ;
+			sh:sourceShape uco-types:Dictionary-keyUniqueness-shape ;
 			sh:value "x" ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/Dictionary-34ac0c49-1042-49c0-8fd6-c42a810e58da> ;
-			sh:resultMessage "Value does not have class types:ImproperDictionary" ;
+			sh:resultMessage "Value does not have class uco-types:ImproperDictionary" ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
-			sh:sourceShape types:repeatsKey-subjects-shape ;
+			sh:sourceShape uco-types:repeatsKey-subjects-shape ;
 			sh:value <http://example.org/kb/Dictionary-34ac0c49-1042-49c0-8fd6-c42a810e58da> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/Dictionary-5bc55661-4808-48e6-9e02-80a153eee5d3> ;
-			sh:resultMessage "types:ImproperDictionary and types:ProperDictionary are disjoint classes."@en ;
+			sh:resultMessage "uco-types:ImproperDictionary and uco-types:ProperDictionary are disjoint classes."@en ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NotConstraintComponent ;
-			sh:sourceShape types:ImproperDictionary-disjointWith-ProperDictionary-shape ;
+			sh:sourceShape uco-types:ImproperDictionary-disjointWith-ProperDictionary-shape ;
 			sh:value <http://example.org/kb/Dictionary-5bc55661-4808-48e6-9e02-80a153eee5d3> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/Dictionary-e6dc9c2e-25bc-422f-8ae8-8457e29f5fde> ;
-			sh:resultMessage "Value does not have class types:ImproperDictionary" ;
+			sh:resultMessage "Value does not have class uco-types:ImproperDictionary" ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
-			sh:sourceShape types:repeatsKey-subjects-shape ;
+			sh:sourceShape uco-types:repeatsKey-subjects-shape ;
 			sh:value <http://example.org/kb/Dictionary-e6dc9c2e-25bc-422f-8ae8-8457e29f5fde> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/ProperDictionary-8114819f-d3c8-4e29-9e31-295d771f9db2> ;
-			sh:resultMessage "Value does not have class types:ImproperDictionary" ;
+			sh:resultMessage "Value does not have class uco-types:ImproperDictionary" ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
-			sh:sourceShape types:repeatsKey-subjects-shape ;
+			sh:sourceShape uco-types:repeatsKey-subjects-shape ;
 			sh:value <http://example.org/kb/ProperDictionary-8114819f-d3c8-4e29-9e31-295d771f9db2> ;
 		] ,
 		[
@@ -88,11 +88,11 @@
 				a sh:SPARQLConstraint ;
 				sh:message "A key in a proper dictionary can appear no more than once."@en ;
 				sh:select """
-			PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+			PREFIX uco-types: <https://ontology.unifiedcyberontology.org/uco/types/>
 			SELECT $this ?value
 			WHERE {
 				$this
-					types:entry/types:key ?value ;
+					uco-types:entry/uco-types:key ?value ;
 					.
 			}
 			GROUP BY ?value
@@ -100,7 +100,7 @@
 		""" ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape types:ProperDictionary ;
+			sh:sourceShape uco-types:ProperDictionary ;
 			sh:value "x" ;
 		] ,
 		[
@@ -112,11 +112,11 @@
 				a sh:SPARQLConstraint ;
 				sh:message "A key in a proper dictionary can appear no more than once."@en ;
 				sh:select """
-			PREFIX types: <https://ontology.unifiedcyberontology.org/uco/types/>
+			PREFIX uco-types: <https://ontology.unifiedcyberontology.org/uco/types/>
 			SELECT $this ?value
 			WHERE {
 				$this
-					types:entry/types:key ?value ;
+					uco-types:entry/uco-types:key ?value ;
 					.
 			}
 			GROUP BY ?value
@@ -124,16 +124,16 @@
 		""" ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape types:ProperDictionary ;
+			sh:sourceShape uco-types:ProperDictionary ;
 			sh:value "x" ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/ProperDictionary-f5ae2e6a-9b10-46f3-8441-30aada36aa1b> ;
-			sh:resultMessage "Value does not have class types:ImproperDictionary" ;
+			sh:resultMessage "Value does not have class uco-types:ImproperDictionary" ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
-			sh:sourceShape types:repeatsKey-subjects-shape ;
+			sh:sourceShape uco-types:repeatsKey-subjects-shape ;
 			sh:value <http://example.org/kb/ProperDictionary-f5ae2e6a-9b10-46f3-8441-30aada36aa1b> ;
 		]
 		;

--- a/tests/examples/disjointedness_PASS.json
+++ b/tests/examples/disjointedness_PASS.json
@@ -1,16 +1,15 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:File-33a25932-3a1a-4828-a90f-d31818b495ce",
             "@type": [
-                "observable:File",
-                "observable:FileFacet"
+                "uco-observable:File",
+                "uco-observable:FileFacet"
             ],
             "rdfs:comment": "This node will trigger a violation in UCO 2.0.0 for designating itself a File and FileFacet, which are disjoint due to File being a (eventual) subclass of UcoObject, and FileFacet being a (eventual) subclass of UcoInherentCharacterizationThing."
         }

--- a/tests/examples/disjointedness_PASS_validation.ttl
+++ b/tests/examples/disjointedness_PASS_validation.ttl
@@ -1,8 +1,8 @@
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -11,10 +11,10 @@
 	sh:result [
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/kb/File-33a25932-3a1a-4828-a90f-d31818b495ce> ;
-		sh:resultMessage "core:UcoInherentCharacterizationThing and core:UcoObject are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
+		sh:resultMessage "uco-core:UcoInherentCharacterizationThing and uco-core:UcoObject are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
 		sh:resultSeverity sh:Warning ;
 		sh:sourceConstraintComponent sh:NotConstraintComponent ;
-		sh:sourceShape core:UcoInherentCharacterizationThing-disjointWith-UcoObject-shape ;
+		sh:sourceShape uco-core:UcoInherentCharacterizationThing-disjointWith-UcoObject-shape ;
 		sh:value <http://example.org/kb/File-33a25932-3a1a-4828-a90f-d31818b495ce> ;
 	] ;
 	.

--- a/tests/examples/event_XFAIL.json
+++ b/tests/examples/event_XFAIL.json
@@ -1,22 +1,22 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "action": "https://ontology.unifiedcyberontology.org/uco/action/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-action": "https://ontology.unifiedcyberontology.org/uco/action/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:Action-0-03ee1fe6-12cf-4a35-b7dd-06d4e69369b5",
             "@type": [
-                "action:Action",
-                "core:Event"
+                "uco-action:Action",
+                "uco-core:Event"
             ],
             "rdfs:comment": "This node will trigger an XFAIL for designating itself an Action and Event, which are disjoint classes."
         },
         {
             "@id": "kb:Action-1-763c1ff2-d18d-427b-aa82-30d90701a644",
-            "@type": "action:Action",
+            "@type": "uco-action:Action",
             "rdfs:comment": "This node should pass validation."
         },
         {

--- a/tests/examples/event_XFAIL_validation.ttl
+++ b/tests/examples/event_XFAIL_validation.ttl
@@ -1,8 +1,8 @@
-@prefix action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -11,10 +11,10 @@
 	sh:result [
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/kb/Action-0-03ee1fe6-12cf-4a35-b7dd-06d4e69369b5> ;
-		sh:resultMessage "action:Action and core:Event are disjoint classes."@en ;
+		sh:resultMessage "uco-action:Action and uco-core:Event are disjoint classes."@en ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:NotConstraintComponent ;
-		sh:sourceShape action:Action-disjointWith-Event-shape ;
+		sh:sourceShape uco-action:Action-disjointWith-Event-shape ;
 		sh:value <http://example.org/kb/Action-0-03ee1fe6-12cf-4a35-b7dd-06d4e69369b5> ;
 	] ;
 	.

--- a/tests/examples/file_url_PASS.json
+++ b/tests/examples/file_url_PASS.json
@@ -1,15 +1,15 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:Thing-23a38d67-3432-458b-9651-955b418c2a77",
             "@type": [
-                "observable:File",
-                "observable:URL"
+                "uco-observable:File",
+                "uco-observable:URL"
             ],
             "rdfs:comment": "Should trigger sh:Warning from simultaneously being a member of two disjoint classes; will trigger sh:Violation in UCO 2.0.0."
         }

--- a/tests/examples/file_url_PASS_validation.ttl
+++ b/tests/examples/file_url_PASS_validation.ttl
@@ -1,8 +1,8 @@
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -11,10 +11,10 @@
 	sh:result [
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/kb/Thing-23a38d67-3432-458b-9651-955b418c2a77> ;
-		sh:resultMessage "observable:File and observable:URL are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
+		sh:resultMessage "uco-observable:File and uco-observable:URL are disjoint classes.  Assigning both types to a single node will be an error in UCO 2.0.0."@en ;
 		sh:resultSeverity sh:Warning ;
 		sh:sourceConstraintComponent sh:NotConstraintComponent ;
-		sh:sourceShape observable:File-disjointWith-URL-shape ;
+		sh:sourceShape uco-observable:File-disjointWith-URL-shape ;
 		sh:value <http://example.org/kb/Thing-23a38d67-3432-458b-9651-955b418c2a77> ;
 	] ;
 	.

--- a/tests/examples/has_facet_inverse_functional_PASS.json
+++ b/tests/examples/has_facet_inverse_functional_PASS.json
@@ -1,18 +1,18 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
-        "owl": "http://www.w3.org/2002/07/owl#"
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/"
     },
     "@graph": [
         {
             "@id": "kb:facet-356c486e-508b-418d-bafa-f5a899bb57eb",
-            "@type": "core:Facet"
+            "@type": "uco-core:Facet"
         },
         {
             "@id": "kb:object-57dd2e88-0714-4015-9f20-a4785c48ea6b",
-            "@type": "core:UcoObject",
-            "core:hasFacet": {
+            "@type": "uco-core:UcoObject",
+            "uco-core:hasFacet": {
                 "@id": "kb:facet-356c486e-508b-418d-bafa-f5a899bb57eb"
             },
             "owl:sameAs": {
@@ -21,8 +21,8 @@
         },
         {
             "@id": "kb:object-e7afc58a-17ca-49f3-822f-bb5a327a5cc8",
-            "@type": "core:UcoObject",
-            "core:hasFacet": {
+            "@type": "uco-core:UcoObject",
+            "uco-core:hasFacet": {
                 "@id": "kb:facet-356c486e-508b-418d-bafa-f5a899bb57eb"
             }
         }

--- a/tests/examples/has_facet_inverse_functional_XFAIL.json
+++ b/tests/examples/has_facet_inverse_functional_XFAIL.json
@@ -1,24 +1,24 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/"
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/"
     },
     "@graph": [
         {
             "@id": "kb:facet-b94b9cce-f11a-49f2-b5d4-9efff5e8ab2d",
-            "@type": "core:Facet"
+            "@type": "uco-core:Facet"
         },
         {
             "@id": "kb:object-dc5d338e-1067-4b83-b748-0ff189377a33",
-            "@type": "core:UcoObject",
-            "core:hasFacet": {
+            "@type": "uco-core:UcoObject",
+            "uco-core:hasFacet": {
                 "@id": "kb:facet-b94b9cce-f11a-49f2-b5d4-9efff5e8ab2d"
             }
         },
         {
             "@id": "kb:object-f7dad740-5f28-40d2-af46-70d0cedcb03b",
-            "@type": "core:UcoObject",
-            "core:hasFacet": {
+            "@type": "uco-core:UcoObject",
+            "uco-core:hasFacet": {
                 "@id": "kb:facet-b94b9cce-f11a-49f2-b5d4-9efff5e8ab2d"
             }
         }

--- a/tests/examples/has_facet_inverse_functional_XFAIL_validation.ttl
+++ b/tests/examples/has_facet_inverse_functional_XFAIL_validation.ttl
@@ -1,8 +1,8 @@
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -13,18 +13,18 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/facet-b94b9cce-f11a-49f2-b5d4-9efff5e8ab2d> ;
 			sh:resultMessage "hasFacet must not be used to link two objects to one Facet." ;
-			sh:resultPath core:hasFacet ;
+			sh:resultPath uco-core:hasFacet ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraint [
 				a sh:SPARQLConstraint ;
 				sh:message "hasFacet must not be used to link two objects to one Facet."@en ;
 				sh:select """
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this ?value
 			WHERE {
-				?value core:hasFacet $this .
-				?nOtherValue core:hasFacet $this .
+				?value uco-core:hasFacet $this .
+				?nOtherValue uco-core:hasFacet $this .
 				FILTER ( ?value != ?nOtherValue )
 				FILTER NOT EXISTS {
 					?value owl:sameAs|^owl:sameAs ?nOtherValue .
@@ -33,25 +33,25 @@
 			""" ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape core:hasFacet-shape ;
+			sh:sourceShape uco-core:hasFacet-shape ;
 			sh:value <http://example.org/kb/object-dc5d338e-1067-4b83-b748-0ff189377a33> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/facet-b94b9cce-f11a-49f2-b5d4-9efff5e8ab2d> ;
 			sh:resultMessage "hasFacet must not be used to link two objects to one Facet." ;
-			sh:resultPath core:hasFacet ;
+			sh:resultPath uco-core:hasFacet ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraint [
 				a sh:SPARQLConstraint ;
 				sh:message "hasFacet must not be used to link two objects to one Facet."@en ;
 				sh:select """
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			PREFIX owl: <http://www.w3.org/2002/07/owl#>
 			SELECT $this ?value
 			WHERE {
-				?value core:hasFacet $this .
-				?nOtherValue core:hasFacet $this .
+				?value uco-core:hasFacet $this .
+				?nOtherValue uco-core:hasFacet $this .
 				FILTER ( ?value != ?nOtherValue )
 				FILTER NOT EXISTS {
 					?value owl:sameAs|^owl:sameAs ?nOtherValue .
@@ -60,7 +60,7 @@
 			""" ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape core:hasFacet-shape ;
+			sh:sourceShape uco-core:hasFacet-shape ;
 			sh:value <http://example.org/kb/object-f7dad740-5f28-40d2-af46-70d0cedcb03b> ;
 		]
 		;

--- a/tests/examples/hash_PASS.json
+++ b/tests/examples/hash_PASS.json
@@ -2,50 +2,50 @@
     "@context": {
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/",
-        "vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:hash-04dcd1dc-6920-4977-a898-e242870249a4",
-            "@type": "types:Hash",
+            "@type": "uco-types:Hash",
             "rdfs:comment": "Should trigger sh:Info from the hashMethod literal not having its value be in the HashNameVocab vocabulary.",
-            "types:hashMethod": "CUSTOM_hash",
-            "types:hashValue": {
+            "uco-types:hashMethod": "CUSTOM_hash",
+            "uco-types:hashValue": {
                 "@type": "xsd:hexBinary",
                 "@value": "a39a3ee5e6b4b0d3255bfef95601890afd80709d"
             }
         },
         {
             "@id": "kb:hash-af4b0c85-b042-4e2d-a213-210b3d7f115c",
-            "@type": "types:Hash",
+            "@type": "uco-types:Hash",
             "rdfs:comment": "Should trigger sh:Info from the hashMethod literal not being a member of the vocabulary.  ('SHA1' is in the vocabulary; 'SHA-1' isn't.)",
-            "types:hashMethod": "SHA-1",
-            "types:hashValue": {
+            "uco-types:hashMethod": "SHA-1",
+            "uco-types:hashValue": {
                 "@type": "xsd:hexBinary",
                 "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
             }
         },
         {
             "@id": "kb:hash-b7eca8de-142d-4aa9-b546-0796a268afa4",
-            "@type": "types:Hash",
+            "@type": "uco-types:Hash",
             "rdfs:comment": "Should trigger an sh:Info from the hashMethod value not having its (literal-)value in the HashNameVocab vocabulary, and also a sh:Warning from not being an xsd:string.",
-            "types:hashMethod": {
-                "@type": "vocabulary:HashNameVocab",
+            "uco-types:hashMethod": {
+                "@type": "uco-vocabulary:HashNameVocab",
                 "@value": "SHA1"
             },
-            "types:hashValue": {
+            "uco-types:hashValue": {
                 "@type": "xsd:hexBinary",
                 "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
             }
         },
         {
             "@id": "kb:hash-f46c714f-559a-4325-bf8a-4ef60c92c771",
-            "@type": "types:Hash",
+            "@type": "uco-types:Hash",
             "rdfs:comment": "This should trigger an sh:Warning from the hashMethod value not being a string, and an sh:Info from not being in the HashNameVocab vocabulary.  (The warning from not being a string is a relaxation from an error, enacted between UCO 1.3.0 and 1.4.0.  It will again be an error in UCO 2.0.0.)",
-            "types:hashMethod": 1,
-            "types:hashValue": {
+            "uco-types:hashMethod": 1,
+            "uco-types:hashValue": {
                 "@type": "xsd:hexBinary",
                 "@value": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
             }

--- a/tests/examples/hash_PASS_validation.ttl
+++ b/tests/examples/hash_PASS_validation.ttl
@@ -2,8 +2,8 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -14,58 +14,58 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-04dcd1dc-6920-4977-a898-e242870249a4> ;
 			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
-			sh:resultPath types:hashMethod ;
+			sh:resultPath uco-types:hashMethod ;
 			sh:resultSeverity sh:Info ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;
-			sh:sourceShape types:Hash-hashMethod-in-shape ;
+			sh:sourceShape uco-types:Hash-hashMethod-in-shape ;
 			sh:value "CUSTOM_hash" ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-af4b0c85-b042-4e2d-a213-210b3d7f115c> ;
 			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
-			sh:resultPath types:hashMethod ;
+			sh:resultPath uco-types:hashMethod ;
 			sh:resultSeverity sh:Info ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;
-			sh:sourceShape types:Hash-hashMethod-in-shape ;
+			sh:sourceShape uco-types:Hash-hashMethod-in-shape ;
 			sh:value "SHA-1" ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4> ;
-			sh:resultMessage "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:resultPath types:hashMethod ;
+			sh:resultMessage "As of UCO 1.4.0, the datatype to use for uco-types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:resultPath uco-types:hashMethod ;
 			sh:resultSeverity sh:Warning ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
-				sh:message "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-				sh:path types:hashMethod ;
+				sh:message "As of UCO 1.4.0, the datatype to use for uco-types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+				sh:path uco-types:hashMethod ;
 				sh:severity sh:Warning ;
 			] ;
-			sh:value "SHA1"^^vocabulary:HashNameVocab ;
+			sh:value "SHA1"^^uco-vocabulary:HashNameVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-b7eca8de-142d-4aa9-b546-0796a268afa4> ;
 			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
-			sh:resultPath types:hashMethod ;
+			sh:resultPath uco-types:hashMethod ;
 			sh:resultSeverity sh:Info ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;
-			sh:sourceShape types:Hash-hashMethod-in-shape ;
-			sh:value "SHA1"^^vocabulary:HashNameVocab ;
+			sh:sourceShape uco-types:Hash-hashMethod-in-shape ;
+			sh:value "SHA1"^^uco-vocabulary:HashNameVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
-			sh:resultMessage "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-			sh:resultPath types:hashMethod ;
+			sh:resultMessage "As of UCO 1.4.0, the datatype to use for uco-types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+			sh:resultPath uco-types:hashMethod ;
 			sh:resultSeverity sh:Warning ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
-				sh:message "As of UCO 1.4.0, the datatype to use for types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
-				sh:path types:hashMethod ;
+				sh:message "As of UCO 1.4.0, the datatype to use for uco-types:hashMethod should be xsd:string.  Not using xsd:string will be an error in UCO 2.0.0." ;
+				sh:path uco-types:hashMethod ;
 				sh:severity sh:Warning ;
 			] ;
 			sh:value "1"^^xsd:integer ;
@@ -74,10 +74,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
 			sh:resultMessage "Value is not member of the vocabulary HashNameVocab." ;
-			sh:resultPath types:hashMethod ;
+			sh:resultPath uco-types:hashMethod ;
 			sh:resultSeverity sh:Info ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;
-			sh:sourceShape types:Hash-hashMethod-in-shape ;
+			sh:sourceShape uco-types:Hash-hashMethod-in-shape ;
 			sh:value "1"^^xsd:integer ;
 		]
 		;

--- a/tests/examples/hash_XFAIL.json
+++ b/tests/examples/hash_XFAIL.json
@@ -1,17 +1,16 @@
 {
     "@context": {
         "kb": "http://example.org/kb/",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/",
-        "vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:hash-66954988-aa9a-4f0d-8ad1-380700c830fc",
-            "@type": "types:Hash",
+            "@type": "uco-types:Hash",
             "rdfs:comment": "This should trigger sh:Violation from the hash value not being hexBinary.",
-            "types:hashMethod": "SHA1",
-            "types:hashValue": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            "uco-types:hashMethod": "SHA1",
+            "uco-types:hashValue": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
         }
     ]
 }

--- a/tests/examples/hash_XFAIL_validation.ttl
+++ b/tests/examples/hash_XFAIL_validation.ttl
@@ -2,7 +2,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -12,7 +12,7 @@
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/kb/hash-66954988-aa9a-4f0d-8ad1-380700c830fc> ;
 		sh:resultMessage "Value is not Literal with datatype xsd:hexBinary" ;
-		sh:resultPath types:hashValue ;
+		sh:resultPath uco-types:hashValue ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 		sh:sourceShape [
@@ -20,7 +20,7 @@
 			sh:maxCount "1"^^xsd:integer ;
 			sh:minCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:path types:hashValue ;
+			sh:path uco-types:hashValue ;
 		] ;
 		sh:value "da39a3ee5e6b4b0d3255bfef95601890afd80709" ;
 	] ;

--- a/tests/examples/location_PASS.json
+++ b/tests/examples/location_PASS.json
@@ -1,30 +1,30 @@
 {
     "@context": {
         "acme": "http://example.org/ontology/acme/core/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "location": "https://ontology.unifiedcyberontology.org/uco/location/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-location": "https://ontology.unifiedcyberontology.org/uco/location/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:location-027d88c2-9c8f-424c-8793-957c4db1aad3",
-            "@type": "location:Location",
-            "core:description": "First of two locations in example.",
-            "core:hasFacet": [
+            "@type": "uco-location:Location",
+            "uco-core:description": "First of two locations in example.",
+            "uco-core:hasFacet": [
                 {
                     "@id": "kb:simple-address-facet-5f0054b7-a597-4c76-ad6c-6098d8f33281",
-                    "@type": "location:SimpleAddressFacet",
-                    "location:locality": "Seattle",
-                    "location:region": "WA",
-                    "location:postalCode": "98052",
-                    "location:street": "20341 Whitworth Institute 405 N. Whitworth"
+                    "@type": "uco-location:SimpleAddressFacet",
+                    "uco-location:locality": "Seattle",
+                    "uco-location:region": "WA",
+                    "uco-location:postalCode": "98052",
+                    "uco-location:street": "20341 Whitworth Institute 405 N. Whitworth"
                 },
                 {
                     "@id": "kb:internal-location-facet-7fd377a1-3e0a-40a8-a934-edf81cc7ecf3",
                     "@type": [
                         "acme:InternalLocationFacet",
-                        "core:Facet"
+                        "uco-core:Facet"
                     ],
                     "acme:floor": 3,
                     "acme:roomNumber": 345
@@ -33,27 +33,27 @@
         },
         {
             "@id": "kb:location-4aa228c5-239a-468f-b668-21d413dc9159",
-            "@type": "location:Location",
-            "core:description": "Second of two locations in example.",
-            "core:hasFacet": [
+            "@type": "uco-location:Location",
+            "uco-core:description": "Second of two locations in example.",
+            "uco-core:hasFacet": [
                 {
 
                     "@id": "kb:simple-address-facet-829caf86-0d19-48f4-b115-0edb10182a7a",
-                    "@type": "location:SimpleAddressFacet",
-                    "location:locality": "Paris",
-                    "location:country": "France",
-                    "location:postalCode": "F-75002",
-                    "location:street": "38 Bad Guy Headquarters st."
+                    "@type": "uco-location:SimpleAddressFacet",
+                    "uco-location:locality": "Paris",
+                    "uco-location:country": "France",
+                    "uco-location:postalCode": "F-75002",
+                    "uco-location:street": "38 Bad Guy Headquarters st."
                 },
                 {
 
                     "@id": "kb:lat-long-coordinates-facet-9558479d-eecf-4e8d-9721-9e1a835352ba",
-                    "@type": "location:LatLongCoordinatesFacet",
-                    "location:latitude": {
+                    "@type": "uco-location:LatLongCoordinatesFacet",
+                    "uco-location:latitude": {
                         "@type": "xsd:decimal",
                         "@value": "48.860346"
                     },
-                    "location:longitude": {
+                    "uco-location:longitude": {
                         "@type": "xsd:decimal",
                         "@value": "2.331199"
                     }

--- a/tests/examples/location_XFAIL.json
+++ b/tests/examples/location_XFAIL.json
@@ -1,24 +1,24 @@
 {
     "@context": {
         "acme": "http://example.org/ontology/acme/core/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "location": "https://ontology.unifiedcyberontology.org/uco/location/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-location": "https://ontology.unifiedcyberontology.org/uco/location/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:location-264c3f5f-680c-4c44-917f-624b9928088e",
-            "@type": "location:Location",
-            "core:description": "First of two locations in example.",
-            "core:hasFacet": [
+            "@type": "uco-location:Location",
+            "uco-core:description": "First of two locations in example.",
+            "uco-core:hasFacet": [
                 {
                     "@id": "kb:simple-address-facet-511873a2-31cb-44dc-bd59-3ec72ddb6b5f",
-                    "@type": "location:SimpleAddressFacet",
-                    "location:locality": "Seattle",
-                    "location:region": "WA",
-                    "location:postalCode": 98052,
-                    "location:street": "20341 Whitworth Institute 405 N. Whitworth"
+                    "@type": "uco-location:SimpleAddressFacet",
+                    "uco-location:locality": "Seattle",
+                    "uco-location:region": "WA",
+                    "uco-location:postalCode": 98052,
+                    "uco-location:street": "20341 Whitworth Institute 405 N. Whitworth"
                 },
                 {
                     "@id": "kb:internal-location-facet-8b89f634-4616-4ef6-af2c-23ca9fc673bd",
@@ -30,25 +30,25 @@
         },
         {
             "@id": "kb:location-e01d13b0-23b5-45ff-8ac5-b21562f66973",
-            "@type": "location:Location",
-            "core:descriptionButWrongName": "Second of two locations in example.",
-            "core:hasFacet": [
+            "@type": "uco-location:Location",
+            "uco-core:descriptionButWrongName": "Second of two locations in example.",
+            "uco-core:hasFacet": [
                 {
                     "@id": "kb:simple-address-facet-62feb577-b9e0-45b6-986d-aa13d698f12e",
-                    "@type": "location:SimpleAddressFacet",
-                    "location:locality": "Paris",
-                    "location:country": "France",
-                    "location:postalCode": "F-75002",
-                    "location:street": "38 Bad Guy Headquarters st."
+                    "@type": "uco-location:SimpleAddressFacet",
+                    "uco-location:locality": "Paris",
+                    "uco-location:country": "France",
+                    "uco-location:postalCode": "F-75002",
+                    "uco-location:street": "38 Bad Guy Headquarters st."
                 },
                 {
                     "@id": "kb:lat-long-coordinates-facet-cdb448fd-a7e2-4ec3-8c02-0135ee794835",
-                    "@type": "location:LatLongCoordinates",
-                    "location:latitude": {
+                    "@type": "uco-location:LatLongCoordinates",
+                    "uco-location:latitude": {
                         "@type": "xsd:decimal",
                         "@value": "48.860346"
                     },
-                    "location:longitude": {
+                    "uco-location:longitude": {
                         "@type": "xsd:decimal",
                         "@value": "2.331199"
                     }

--- a/tests/examples/location_XFAIL_validation.ttl
+++ b/tests/examples/location_XFAIL_validation.ttl
@@ -1,9 +1,9 @@
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
-@prefix location: <https://ontology.unifiedcyberontology.org/uco/location/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-location: <https://ontology.unifiedcyberontology.org/uco/location/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -13,28 +13,28 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/location-264c3f5f-680c-4c44-917f-624b9928088e> ;
-			sh:resultMessage "Value does not have class core:Facet" ;
-			sh:resultPath core:hasFacet ;
+			sh:resultMessage "Value does not have class uco-core:Facet" ;
+			sh:resultPath uco-core:hasFacet ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class core:Facet ;
+				sh:class uco-core:Facet ;
 				sh:nodeKind sh:IRI ;
-				sh:path core:hasFacet ;
+				sh:path uco-core:hasFacet ;
 			] ;
 			sh:value <http://example.org/kb/internal-location-facet-8b89f634-4616-4ef6-af2c-23ca9fc673bd> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/location-e01d13b0-23b5-45ff-8ac5-b21562f66973> ;
-			sh:resultMessage "Value does not have class core:Facet" ;
-			sh:resultPath core:hasFacet ;
+			sh:resultMessage "Value does not have class uco-core:Facet" ;
+			sh:resultPath uco-core:hasFacet ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class core:Facet ;
+				sh:class uco-core:Facet ;
 				sh:nodeKind sh:IRI ;
-				sh:path core:hasFacet ;
+				sh:path uco-core:hasFacet ;
 			] ;
 			sh:value <http://example.org/kb/lat-long-coordinates-facet-cdb448fd-a7e2-4ec3-8c02-0135ee794835> ;
 		] ,
@@ -42,14 +42,14 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/simple-address-facet-511873a2-31cb-44dc-bd59-3ec72ddb6b5f> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath location:postalCode ;
+			sh:resultPath uco-location:postalCode ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path location:postalCode ;
+				sh:path uco-location:postalCode ;
 			] ;
 			sh:value "98052"^^xsd:integer ;
 		]

--- a/tests/examples/message_thread_PASS.json
+++ b/tests/examples/message_thread_PASS.json
@@ -3,53 +3,53 @@
         "co": "http://purl.org/co/",
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:message-1-01a38f9a-d91b-4f7a-b446-308829b0b6c3",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-2-2e770ebe-cc83-46cd-b340-9c2ba081c002",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-3-3ec6dff5-edcc-4b64-ad51-aa8a262dcef1",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-4-51392250-533d-4a04-89d7-6db6340d09c3",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-5-53d04ec1-ce54-407f-93ef-95730c88a09a",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-6-7e4f6696-13cb-443b-bccf-ac1bd1c90300",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-7-8071dceb-a946-496b-8771-8f9bfc230cb0",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-thread-86bef664-c9c2-470b-847b-18510ffbaa73",
-            "@type": "observable:MessageThread",
+            "@type": "uco-observable:MessageThread",
             "core:hasFacet": {
                 "@id": "kb:message-thread-facet-ac98fdc4-e7ac-4d15-b6d2-2180b4d0f407",
-                "@type": "observable:MessageThreadFacet",
-                "observable:messageThread": {
+                "@type": "uco-observable:MessageThreadFacet",
+                "uco-observable:messageThread": {
                     "@id": "kb:thread-f5c6285f-70ee-405d-9acd-0d74c005fecc"
                 }
             }
         },
         {
             "@id": "kb:thread-f5c6285f-70ee-405d-9acd-0d74c005fecc",
-            "@type": "types:Thread",
+            "@type": "uco-types:Thread",
             "co:element": [
                 {
                     "@id": "kb:message-1-01a38f9a-d91b-4f7a-b446-308829b0b6c3"
@@ -94,7 +94,7 @@
                     "@id": "kb:message-thread-item-e27b2c77-6bf4-49fe-be9e-d7958a1ecfb2"
                 }
             ],
-            "types:threadOriginItem": [
+            "uco-types:threadOriginItem": [
                 {
                     "@id": "kb:message-thread-item-9707179c-3a1a-49e8-838e-0ec95cb8b8b2"
                 },
@@ -102,7 +102,7 @@
                     "@id": "kb:message-thread-item-dd9fa256-5e0f-49a1-9bf3-fa34afb7d326"
                 }
             ],
-            "types:threadTerminalItem": [
+            "uco-types:threadTerminalItem": [
                 {
                     "@id": "kb:message-thread-item-ad4c64f2-aff4-4322-aff4-29b12fcf4f9e"
                 },
@@ -116,11 +116,11 @@
         },
         {
             "@id": "kb:message-thread-item-9707179c-3a1a-49e8-838e-0ec95cb8b8b2",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-1-01a38f9a-d91b-4f7a-b446-308829b0b6c3"
             },
-            "types:threadNextItem": [
+            "uco-types:threadNextItem": [
                 {
                     "@id": "kb:message-thread-item-a6ad1873-c843-4f29-bc79-7d881c3261c5"
                 },
@@ -131,11 +131,11 @@
         },
         {
             "@id": "kb:message-thread-item-a6ad1873-c843-4f29-bc79-7d881c3261c5",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-2-2e770ebe-cc83-46cd-b340-9c2ba081c002"
             },
-            "types:threadNextItem": [
+            "uco-types:threadNextItem": [
                 {
                     "@id": "kb:message-thread-item-ad4c64f2-aff4-4322-aff4-29b12fcf4f9e"
                 },
@@ -143,47 +143,47 @@
                     "@id": "kb:message-thread-item-be503989-4185-40c1-bb3f-b2b8745b8a58"
                 }
             ],
-            "types:threadPreviousItem": {
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:message-thread-item-9707179c-3a1a-49e8-838e-0ec95cb8b8b2"
             }
         },
         {
             "@id": "kb:message-thread-item-ad4c64f2-aff4-4322-aff4-29b12fcf4f9e",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-3-3ec6dff5-edcc-4b64-ad51-aa8a262dcef1"
             },
-            "types:threadPreviousItem": {
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:message-thread-item-a6ad1873-c843-4f29-bc79-7d881c3261c5"
             }
         },
         {
             "@id": "kb:message-thread-item-be503989-4185-40c1-bb3f-b2b8745b8a58",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-4-51392250-533d-4a04-89d7-6db6340d09c3"
             },
-            "types:threadPreviousItem": {
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:message-thread-item-a6ad1873-c843-4f29-bc79-7d881c3261c5"
             }
         },
         {
             "@id": "kb:message-thread-item-dd9fa256-5e0f-49a1-9bf3-fa34afb7d326",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-5-53d04ec1-ce54-407f-93ef-95730c88a09a"
             },
-            "types:threadNextItem": {
+            "uco-types:threadNextItem": {
                 "@id": "kb:message-thread-item-e27b2c77-6bf4-49fe-be9e-d7958a1ecfb2"
             }
         },
         {
             "@id": "kb:message-thread-item-e27b2c77-6bf4-49fe-be9e-d7958a1ecfb2",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-6-7e4f6696-13cb-443b-bccf-ac1bd1c90300"
             },
-            "types:threadPreviousItem": [
+            "uco-types:threadPreviousItem": [
                 {
                     "@id": "kb:message-thread-item-9707179c-3a1a-49e8-838e-0ec95cb8b8b2"
                 },

--- a/tests/examples/message_thread_XFAIL.json
+++ b/tests/examples/message_thread_XFAIL.json
@@ -3,55 +3,55 @@
         "co": "http://purl.org/co/",
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:message-04169db8-68a0-4448-8ffc-583a85ade550",
-            "@type": "observable:ObservableObject",
+            "@type": "uco-observable:ObservableObject",
             "rdfs:comment": "The non-Message class will trigger errors pertaining to co:element, co:itemContent and types:threadOriginItem."
         },
         {
             "@id": "kb:message-095cb794-e4cd-4c45-8f7a-aff2e8dfb2d7",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-0b8eb566-2bca-49ce-b668-db138df6e62f",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-0f7064f5-8dbb-440e-8741-17045805e916",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-1dc2a575-549c-4e6f-95e2-7f478135a65a",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-5620d71b-5f8f-4e88-b6d6-99123abbaf7d",
-            "@type": "observable:ObservableObject",
+            "@type": "uco-observable:ObservableObject",
             "rdfs:comment": "The non-Message class will trigger errors pertaining to co:element, co:itemContent and types:threadTerminalItem."
         },
         {
             "@id": "kb:message-67b42e78-332d-497e-9665-efa2cb968e38",
-            "@type": "observable:Message"
+            "@type": "uco-observable:Message"
         },
         {
             "@id": "kb:message-thread-716ad469-5767-4306-abaa-3918ba1cea6e",
-            "@type": "observable:MessageThread",
-            "core:hasFacet": {
+            "@type": "uco-observable:MessageThread",
+            "uco-core:hasFacet": {
                 "@id": "kb:message-thread-facet-5be8604b-49ad-4432-a560-d529f998807b",
-                "@type": "observable:MessageThreadFacet",
-                "observable:messageThread": {
+                "@type": "uco-observable:MessageThreadFacet",
+                "uco-observable:messageThread": {
                     "@id": "kb:thread-f708d033-c49a-4e2c-bc41-c84a1a7bdb62"
                 }
             }
         },
         {
             "@id": "kb:thread-f708d033-c49a-4e2c-bc41-c84a1a7bdb62",
-            "@type": "types:Thread",
+            "@type": "uco-types:Thread",
             "co:size": {
                 "@type": "xsd:nonNegativeInteger",
                 "@value": "6"
@@ -96,7 +96,7 @@
                     "@id": "kb:message-thread-item-e83bb0ca-c342-42bb-973d-347a145dfd75"
                 }
             ],
-            "types:threadOriginItem": [
+            "uco-types:threadOriginItem": [
                 {
                     "@id": "kb:message-thread-item-7fdca660-1c4e-46a8-ba37-0445a2115cc5"
                 },
@@ -104,7 +104,7 @@
                     "@id": "kb:message-thread-item-e0766f69-a415-4be6-91f7-4ef0d1fc3c27"
                 }
             ],
-            "types:threadTerminalItem": [
+            "uco-types:threadTerminalItem": [
                 {
                     "@id": "kb:message-thread-item-c47bd92e-b26b-49c3-b580-00c8a6b271c5"
                 },
@@ -118,11 +118,11 @@
         },
         {
             "@id": "kb:message-thread-item-7fdca660-1c4e-46a8-ba37-0445a2115cc5",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-04169db8-68a0-4448-8ffc-583a85ade550"
             },
-            "types:threadNextItem": [
+            "uco-types:threadNextItem": [
                 {
                     "@id": "kb:message-thread-item-9f1a731e-2de6-4952-913d-afa729dc145a"
                 },
@@ -133,11 +133,11 @@
         },
         {
             "@id": "kb:message-thread-item-9f1a731e-2de6-4952-913d-afa729dc145a",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-095cb794-e4cd-4c45-8f7a-aff2e8dfb2d7"
             },
-            "types:threadNextItem": [
+            "uco-types:threadNextItem": [
                 {
                     "@id": "kb:message-thread-item-c47bd92e-b26b-49c3-b580-00c8a6b271c5"
                 },
@@ -145,47 +145,47 @@
                     "@id": "kb:message-thread-item-d747c262-4684-4e03-a08c-80e1093c43eb"
                 }
             ],
-            "types:threadPreviousItem": {
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:message-thread-item-7fdca660-1c4e-46a8-ba37-0445a2115cc5"
             }
         },
         {
             "@id": "kb:message-thread-item-c47bd92e-b26b-49c3-b580-00c8a6b271c5",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-0b8eb566-2bca-49ce-b668-db138df6e62f"
             },
-            "types:threadPreviousItem": {
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:message-thread-item-9f1a731e-2de6-4952-913d-afa729dc145a"
             }
         },
         {
             "@id": "kb:message-thread-item-d747c262-4684-4e03-a08c-80e1093c43eb",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-0f7064f5-8dbb-440e-8741-17045805e916"
             },
-            "types:threadPreviousItem": {
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:message-thread-item-9f1a731e-2de6-4952-913d-afa729dc145a"
             }
         },
         {
             "@id": "kb:message-thread-item-e0766f69-a415-4be6-91f7-4ef0d1fc3c27",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-1dc2a575-549c-4e6f-95e2-7f478135a65a"
             },
-            "types:threadNextItem": {
+            "uco-types:threadNextItem": {
                 "@id": "kb:message-thread-item-e83bb0ca-c342-42bb-973d-347a145dfd75"
             }
         },
         {
             "@id": "kb:message-thread-item-e83bb0ca-c342-42bb-973d-347a145dfd75",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:message-5620d71b-5f8f-4e88-b6d6-99123abbaf7d"
             },
-            "types:threadPreviousItem": [
+            "uco-types:threadPreviousItem": [
                 {
                     "@id": "kb:message-thread-item-7fdca660-1c4e-46a8-ba37-0445a2115cc5"
                 },

--- a/tests/examples/message_thread_XFAIL_validation.ttl
+++ b/tests/examples/message_thread_XFAIL_validation.ttl
@@ -1,10 +1,10 @@
 @prefix co: <http://purl.org/co/> .
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -14,18 +14,18 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/message-thread-facet-5be8604b-49ad-4432-a560-d529f998807b> ;
-			sh:resultMessage "Value does not have class observable:Message" ;
+			sh:resultMessage "Value does not have class uco-observable:Message" ;
 			sh:resultPath (
-				observable:messageThread
+				uco-observable:messageThread
 				co:element
 			) ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class observable:Message ;
+				sh:class uco-observable:Message ;
 				sh:description "The contents of unordered items in the Thread linked by messageThread must be Message objects."@en ;
 				sh:path (
-					observable:messageThread
+					uco-observable:messageThread
 					co:element
 				) ;
 			] ;
@@ -34,18 +34,18 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/message-thread-facet-5be8604b-49ad-4432-a560-d529f998807b> ;
-			sh:resultMessage "Value does not have class observable:Message" ;
+			sh:resultMessage "Value does not have class uco-observable:Message" ;
 			sh:resultPath (
-				observable:messageThread
+				uco-observable:messageThread
 				co:element
 			) ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class observable:Message ;
+				sh:class uco-observable:Message ;
 				sh:description "The contents of unordered items in the Thread linked by messageThread must be Message objects."@en ;
 				sh:path (
-					observable:messageThread
+					uco-observable:messageThread
 					co:element
 				) ;
 			] ;
@@ -54,19 +54,19 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/message-thread-facet-5be8604b-49ad-4432-a560-d529f998807b> ;
-			sh:resultMessage "Value does not have class observable:Message" ;
+			sh:resultMessage "Value does not have class uco-observable:Message" ;
 			sh:resultPath (
-				observable:messageThread
+				uco-observable:messageThread
 				co:item
 				co:itemContent
 			) ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class observable:Message ;
+				sh:class uco-observable:Message ;
 				sh:description "The contents of ordered items in the Thread linked by messageThread must be Message objects."@en ;
 				sh:path (
-					observable:messageThread
+					uco-observable:messageThread
 					co:item
 					co:itemContent
 				) ;
@@ -76,19 +76,19 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/message-thread-facet-5be8604b-49ad-4432-a560-d529f998807b> ;
-			sh:resultMessage "Value does not have class observable:Message" ;
+			sh:resultMessage "Value does not have class uco-observable:Message" ;
 			sh:resultPath (
-				observable:messageThread
+				uco-observable:messageThread
 				co:item
 				co:itemContent
 			) ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class observable:Message ;
+				sh:class uco-observable:Message ;
 				sh:description "The contents of ordered items in the Thread linked by messageThread must be Message objects."@en ;
 				sh:path (
-					observable:messageThread
+					uco-observable:messageThread
 					co:item
 					co:itemContent
 				) ;
@@ -98,20 +98,20 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/message-thread-facet-5be8604b-49ad-4432-a560-d529f998807b> ;
-			sh:resultMessage "Value does not have class observable:Message" ;
+			sh:resultMessage "Value does not have class uco-observable:Message" ;
 			sh:resultPath (
-				observable:messageThread
-				types:threadOriginItem
+				uco-observable:messageThread
+				uco-types:threadOriginItem
 				co:itemContent
 			) ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class observable:Message ;
+				sh:class uco-observable:Message ;
 				sh:description "The contents of origin items in the Thread linked by messageThread must be Message objects."@en ;
 				sh:path (
-					observable:messageThread
-					types:threadOriginItem
+					uco-observable:messageThread
+					uco-types:threadOriginItem
 					co:itemContent
 				) ;
 			] ;
@@ -120,20 +120,20 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/message-thread-facet-5be8604b-49ad-4432-a560-d529f998807b> ;
-			sh:resultMessage "Value does not have class observable:Message" ;
+			sh:resultMessage "Value does not have class uco-observable:Message" ;
 			sh:resultPath (
-				observable:messageThread
-				types:threadTerminalItem
+				uco-observable:messageThread
+				uco-types:threadTerminalItem
 				co:itemContent
 			) ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class observable:Message ;
+				sh:class uco-observable:Message ;
 				sh:description "The contents of terminal items in the Thread linked by messageThread must be Message objects."@en ;
 				sh:path (
-					observable:messageThread
-					types:threadTerminalItem
+					uco-observable:messageThread
+					uco-types:threadTerminalItem
 					co:itemContent
 				) ;
 			] ;

--- a/tests/examples/object_status_PASS.json
+++ b/tests/examples/object_status_PASS.json
@@ -1,13 +1,13 @@
 {
     "@context": {
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
-        "kb": "http://example.org/kb/"
+        "kb": "http://example.org/kb/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/"
     },
     "@graph": [
         {
             "@id": "kb:UcoObject-f86c567d-374a-4873-b9bc-a746ca2bf360",
-            "@type": "core:UcoObject",
-            "core:objectStatus": "Draft"
+            "@type": "uco-core:UcoObject",
+            "uco-core:objectStatus": "Draft"
         }
     ]
 }

--- a/tests/examples/object_status_XFAIL.json
+++ b/tests/examples/object_status_XFAIL.json
@@ -1,25 +1,26 @@
 {
     "@context": {
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/"
     },
     "@graph": [
         {
             "@id": "kb:UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351",
-            "@type": "core:UcoObject",
+            "@type": "uco-core:UcoObject",
             "rdfs:comment": "This will trigger an error from using a value outside of the required vocabulary.",
-            "core:objectStatus": "Initial draft"
+            "uco-core:objectStatus": "Initial draft"
         },
         {
             "@id": "kb:File-c9c36379-8eca-4a85-887c-b51f7721edfd",
-            "@type": "observable:File",
-            "core:hasFacet": {
+            "@type": "uco-observable:File",
+            "uco-core:hasFacet": {
                 "@id": "kb:ArchiveFileFacet-5884ca1c-2f5e-4e66-bdc6-7d48606f9fbc",
-                "@type": "observable:ArchiveFileFacet",
+                "@type": "uco-observable:ArchiveFileFacet",
                 "rdfs:comment": "This will trigger an error from using objectStatus on a non-UcoObject thing.",
-                "core:objectStatus": "Draft",
-                "observable:archiveType": "Currently-unknown compressing-and-encrypting type seen multiple places, further research needed"
+                "uco-core:objectStatus": "Draft",
+                "uco-observable:archiveType": "Currently-unknown compressing-and-encrypting type seen multiple places, further research needed"
             }
         }
     ]

--- a/tests/examples/object_status_XFAIL_validation.ttl
+++ b/tests/examples/object_status_XFAIL_validation.ttl
@@ -1,8 +1,8 @@
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -12,17 +12,17 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/ArchiveFileFacet-5884ca1c-2f5e-4e66-bdc6-7d48606f9fbc> ;
-			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultMessage "Value does not have class uco-core:UcoObject" ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
-			sh:sourceShape core:objectStatus-subjects-shape ;
+			sh:sourceShape uco-core:objectStatus-subjects-shape ;
 			sh:value <http://example.org/kb/ArchiveFileFacet-5884ca1c-2f5e-4e66-bdc6-7d48606f9fbc> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/UcoObject-6ae2b245-a8cd-45dc-9f40-5b2738879351> ;
 			sh:resultMessage "Value Literal(\"Initial draft\") not in list ['Literal(\"Draft\")', 'Literal(\"Final\")', 'Literal(\"Deprecated\")']" ;
-			sh:resultPath core:objectStatus ;
+			sh:resultPath uco-core:objectStatus ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:InConstraintComponent ;
 			sh:sourceShape [
@@ -34,7 +34,7 @@
 				) ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:objectStatus ;
+				sh:path uco-core:objectStatus ;
 			] ;
 			sh:value "Initial draft" ;
 		]

--- a/tests/examples/observable_creation_time_PASS.json
+++ b/tests/examples/observable_creation_time_PASS.json
@@ -1,20 +1,20 @@
 {
     "@context": {
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:windows-thread-da52a01e-41cc-42d5-85be-ca14bfa10fd6",
-            "@type": "observable:WindowsThread",
-            "core:hasFacet": {
+            "@type": "uco-observable:WindowsThread",
+            "uco-core:hasFacet": {
                 "@id": "kb:windows-thread-facet-4967ae35-f00b-49c8-9dd2-38e3bdf851e1",
-                "@type": "observable:WindowsThreadFacet",
+                "@type": "uco-observable:WindowsThreadFacet",
                 "rdfs:comment": "In UCO 1.2.0, this will raise a warning.  In UCO 2.0.0, this will raise an error.",
-                "observable:creationTime": {
+                "uco-observable:creationTime": {
                     "@type": "xsd:dateTime",
                     "@value": "2023-01-01T01:23:45Z"
                 }

--- a/tests/examples/observable_creation_time_PASS_validation.ttl
+++ b/tests/examples/observable_creation_time_PASS_validation.ttl
@@ -1,8 +1,8 @@
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -11,15 +11,15 @@
 	sh:result [
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/kb/windows-thread-facet-4967ae35-f00b-49c8-9dd2-38e3bdf851e1> ;
-		sh:resultMessage "observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  observable:observableCreatedTime should be used instead."@en ;
-		sh:resultPath observable:creationTime ;
+		sh:resultMessage "uco-observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  uco-observable:observableCreatedTime should be used instead."@en ;
+		sh:resultPath uco-observable:creationTime ;
 		sh:resultSeverity sh:Warning ;
 		sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
 		sh:sourceShape [
 			a sh:PropertyShape ;
 			sh:maxCount "0"^^xsd:integer ;
-			sh:message "observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  observable:observableCreatedTime should be used instead."@en ;
-			sh:path observable:creationTime ;
+			sh:message "uco-observable:creationTime is deprecated, and will be an error to use in UCO 2.0.0.  uco-observable:observableCreatedTime should be used instead."@en ;
+			sh:path uco-observable:creationTime ;
 			sh:severity sh:Warning ;
 		] ;
 	] ;

--- a/tests/examples/operating_system_PASS.json
+++ b/tests/examples/operating_system_PASS.json
@@ -1,46 +1,46 @@
 {
     "@context": {
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
-        "identity": "https://ontology.unifiedcyberontology.org/uco/identity/",
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-identity": "https://ontology.unifiedcyberontology.org/uco/identity/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:Organization-4ea8a5bf-60ea-43ba-9ba6-f852ce8f8b54",
-            "@type": "identity:Organization",
-            "core:name": "Example OS Company"
+            "@type": "uco-identity:Organization",
+            "uco-core:name": "Example OS Company"
         },
         {
             "@id": "kb:OperatingSystem-427dd103-2553-4ccc-ad57-1df4e88b174d",
-            "@type": "observable:OperatingSystem",
-            "core:description": "The Example Operating System instance deployed on workstation B-203-22",
-            "core:hasFacet": [
+            "@type": "uco-observable:OperatingSystem",
+            "uco-core:description": "The Example Operating System instance deployed on workstation B-203-22",
+            "uco-core:hasFacet": [
                 {
                     "@id": "kb:SoftwareFacet-1bde46c5-4648-493c-b9dc-56477191d5c6",
-                    "@type": "observable:SoftwareFacet",
-                    "observable:cpeid": "cpe:2.3:o:exampleosco:exampleos:40:*:*:*:*:*:*:*",
-                    "observable:language": "en-us",
-                    "observable:manufacturer": {
+                    "@type": "uco-observable:SoftwareFacet",
+                    "uco-observable:cpeid": "cpe:2.3:o:exampleosco:exampleos:40:*:*:*:*:*:*:*",
+                    "uco-observable:language": "en-us",
+                    "uco-observable:manufacturer": {
                         "@id": "kb:Organization-4ea8a5bf-60ea-43ba-9ba6-f852ce8f8b54"
                     },
-                    "observable:version": "40"
+                    "uco-observable:version": "40"
                 },
                 {
                     "@id": "kb:OperatingSystemFacet-35047ef2-ffd6-45e8-8b3c-2e8e4bfe7c2b",
-                    "@type": "observable:OperatingSystemFacet",
+                    "@type": "uco-observable:OperatingSystemFacet",
                     "rdfs:comment": "This node will trigger a warning for housing the manufacturer and version properties, meant to be moved to SoftwareFacet.",
-                    "observable:bitness": "64",
-                    "observable:installDate": {
+                    "uco-observable:bitness": "64",
+                    "uco-observable:installDate": {
                         "@type": "xsd:dateTime",
                         "@value": "2024-09-13T09:00:00-04:00"
                     },
-                    "observable:manufacturer": {
+                    "uco-observable:manufacturer": {
                         "@id": "kb:Organization-4ea8a5bf-60ea-43ba-9ba6-f852ce8f8b54"
                     },
-                    "observable:version": "40"
+                    "uco-observable:version": "40"
                 }
             ]
         }

--- a/tests/examples/operating_system_PASS_validation.ttl
+++ b/tests/examples/operating_system_PASS_validation.ttl
@@ -1,8 +1,8 @@
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -18,10 +18,10 @@
 			sh:sourceShape [
 				a sh:NodeShape ;
 				rdfs:comment "This anonymous shape is attached with rdfs:seeAlso in order to associate a warning-severity class constraint, that will only be necessary as an independent shape until UCO 2.0.0."@en ;
-				sh:class observable:Software ;
+				sh:class uco-observable:Software ;
 				sh:message "In UCO 2.0.0, uco-observable:OperatingSystem will be a subclass of uco-observable:Software.  In preparation for UCO 2.0.0, the additional type uco-observable:Software should be assigned to this node."@en ;
 				sh:severity sh:Warning ;
-				sh:targetClass observable:OperatingSystem ;
+				sh:targetClass uco-observable:OperatingSystem ;
 			] ;
 			sh:value <http://example.org/kb/OperatingSystem-427dd103-2553-4ccc-ad57-1df4e88b174d> ;
 		] ,
@@ -29,13 +29,13 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/OperatingSystemFacet-35047ef2-ffd6-45e8-8b3c-2e8e4bfe7c2b> ;
 			sh:resultMessage "In UCO 2.0.0, uco-observable:manufacturer will not be associated with uco-observable:OperatingSystemFacet.  Please place this on a uco-observable:SoftwareFacet instead."@en ;
-			sh:resultPath observable:manufacturer ;
+			sh:resultPath uco-observable:manufacturer ;
 			sh:resultSeverity sh:Warning ;
 			sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
 			sh:sourceShape [
 				sh:maxCount "0"^^xsd:integer ;
 				sh:message "In UCO 2.0.0, uco-observable:manufacturer will not be associated with uco-observable:OperatingSystemFacet.  Please place this on a uco-observable:SoftwareFacet instead."@en ;
-				sh:path observable:manufacturer ;
+				sh:path uco-observable:manufacturer ;
 				sh:severity sh:Warning ;
 			] ;
 		] ,
@@ -43,13 +43,13 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/OperatingSystemFacet-35047ef2-ffd6-45e8-8b3c-2e8e4bfe7c2b> ;
 			sh:resultMessage "In UCO 2.0.0, uco-observable:version will not be associated with uco-observable:OperatingSystemFacet.  Please place this on a uco-observable:SoftwareFacet instead."@en ;
-			sh:resultPath observable:version ;
+			sh:resultPath uco-observable:version ;
 			sh:resultSeverity sh:Warning ;
 			sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
 			sh:sourceShape [
 				sh:maxCount "0"^^xsd:integer ;
 				sh:message "In UCO 2.0.0, uco-observable:version will not be associated with uco-observable:OperatingSystemFacet.  Please place this on a uco-observable:SoftwareFacet instead."@en ;
-				sh:path observable:version ;
+				sh:path uco-observable:version ;
 				sh:severity sh:Warning ;
 			] ;
 		]

--- a/tests/examples/relationship_PASS.json
+++ b/tests/examples/relationship_PASS.json
@@ -1,100 +1,99 @@
 {
     "@context": {
-        "action": "https://ontology.unifiedcyberontology.org/uco/action/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
-        "vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "uco-action": "https://ontology.unifiedcyberontology.org/uco/action/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:relationship-1-1-1-7273698b-34ef-4d04-8cbf-99bdcad7a336",
-            "@type": "core:Relationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": "CUSTOM_Influenced",
-            "core:source": {
+            "@type": "uco-core:Relationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": "CUSTOM_Influenced",
+            "uco-core:source": {
                 "@id": "kb:file-6aea6ec2-2524-437f-8a1f-762d2dfe6dd0"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-f1ebf584-6abd-472d-bb0e-03d13f50830d"
             }
         },
         {
             "@id": "kb:relationship-1-2-1-87a18d97-1bd2-4b02-9438-96ddbcba9372",
-            "@type": "core:Relationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": "Initiated",
-            "core:source": {
+            "@type": "uco-core:Relationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": "Initiated",
+            "uco-core:source": {
                 "@id": "kb:action-5525f37b-41ea-4710-ba33-c0a80faa72c3"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:action-6a4d31e8-353f-4fd0-8056-fed390553542"
             }
         },
         {
             "@id": "kb:relationship-1-3-1-9b94518f-4415-4869-ae49-af66e99d0250",
-            "@type": "core:Relationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": "Contained_Within",
-            "core:source": {
+            "@type": "uco-core:Relationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": "Contained_Within",
+            "uco-core:source": {
                 "@id": "kb:file-6aea6ec2-2524-437f-8a1f-762d2dfe6dd0"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-f1ebf584-6abd-472d-bb0e-03d13f50830d"
             }
         },
         {
             "@id": "kb:relationship-2-1-1-a6ba4ba1-00b2-436e-b64a-4475355560cd",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": "CUSTOM_Influenced",
-            "core:source": {
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": "CUSTOM_Influenced",
+            "uco-core:source": {
                 "@id": "kb:file-6aea6ec2-2524-437f-8a1f-762d2dfe6dd0"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-f1ebf584-6abd-472d-bb0e-03d13f50830d"
             }
         },
         {
             "@id": "kb:relationship-2-2-1-a8e6100b-4e1c-4ec8-a6a4-a4db8ecb8233",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": "Initiated",
-            "core:source": {
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": "Initiated",
+            "uco-core:source": {
                 "@id": "kb:file-6aea6ec2-2524-437f-8a1f-762d2dfe6dd0"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-f1ebf584-6abd-472d-bb0e-03d13f50830d"
             }
         },
         {
             "@id": "kb:relationship-2-3-1-b8d01d00-5a32-4c8f-8a30-11a69b8c5420",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": "Contained_Within",
-            "core:source": {
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": "Contained_Within",
+            "uco-core:source": {
                 "@id": "kb:file-6aea6ec2-2524-437f-8a1f-762d2dfe6dd0"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-f1ebf584-6abd-472d-bb0e-03d13f50830d"
             }
         },
         {
             "@id": "kb:action-5525f37b-41ea-4710-ba33-c0a80faa72c3",
-            "@type": "action:Action"
+            "@type": "uco-action:Action"
         },
         {
             "@id": "kb:action-6a4d31e8-353f-4fd0-8056-fed390553542",
-            "@type": "action:Action"
+            "@type": "uco-action:Action"
         },
         {
             "@id": "kb:file-6aea6ec2-2524-437f-8a1f-762d2dfe6dd0",
-            "@type": "observable:File"
+            "@type": "uco-observable:File"
         },
         {
             "@id": "kb:zipfile-f1ebf584-6abd-472d-bb0e-03d13f50830d",
-            "@type": "observable:ArchiveFile"
+            "@type": "uco-observable:ArchiveFile"
         }
     ]
 }

--- a/tests/examples/relationship_XFAIL.json
+++ b/tests/examples/relationship_XFAIL.json
@@ -1,211 +1,211 @@
 {
     "@context": {
-        "action": "https://ontology.unifiedcyberontology.org/uco/action/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
-        "vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "uco-action": "https://ontology.unifiedcyberontology.org/uco/action/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:relationship-1-1-2-2e668923-bfb7-4f54-afb6-66074ab5b9b0",
-            "@type": "core:Relationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ActionRelationshipTypeVocab",
+            "@type": "uco-core:Relationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ActionRelationshipTypeVocab",
                 "@value": "CUSTOM_Influenced"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-1-1-3-35598cb0-1770-49af-a417-51e91774df89",
-            "@type": "core:Relationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ObservableObjectRelationshipVocab",
+            "@type": "uco-core:Relationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "CUSTOM_Influenced"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-1-2-2-3ee0cc25-5923-40df-ba8f-0cce5f18f724",
-            "@type": "core:Relationship",
+            "@type": "uco-core:Relationship",
             "rdfs:comment": "Note - this might be moved back to the PASS set after re-design of semi-open vocabularies.",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ActionRelationshipTypeVocab",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ActionRelationshipTypeVocab",
                 "@value": "Initiated"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:action-00ae4a34-6114-4e9a-867f-4d81393dfd58"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:action-1a5d1fe5-4fd0-4a80-912a-125b2130c099"
             }
         },
         {
             "@id": "kb:relationship-1-2-3-46da302e-cff3-4634-bcf8-6f52649e2496",
-            "@type": "core:Relationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ObservableObjectRelationshipVocab",
+            "@type": "uco-core:Relationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "Initiated"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:action-00ae4a34-6114-4e9a-867f-4d81393dfd58"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:action-1a5d1fe5-4fd0-4a80-912a-125b2130c099"
             }
         },
         {
             "@id": "kb:relationship-1-3-2-746aeee5-c857-4afb-8dba-85d5d60be279",
-            "@type": "core:Relationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ActionRelationshipTypeVocab",
+            "@type": "uco-core:Relationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ActionRelationshipTypeVocab",
                 "@value": "Contained_Within"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-1-3-3-779c2646-dd1d-4fac-9e22-5a14bd78c6ea",
-            "@type": "core:Relationship",
+            "@type": "uco-core:Relationship",
             "rdfs:comment": "Note - this might be moved back to the PASS set after re-design of semi-open vocabularies.",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ObservableObjectRelationshipVocab",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "Contained_Within"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-2-1-2-800dd373-2916-4104-a2bb-2715cbc80804",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ActionRelationshipTypeVocab",
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ActionRelationshipTypeVocab",
                 "@value": "CUSTOM_Influenced"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-2-1-3-803a8e5c-f09a-403d-9c8d-91b08a3c0bbd",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ObservableObjectRelationshipVocab",
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "CUSTOM_Influenced"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-2-2-2-851c5f1a-1f1e-4315-b7b8-6d7f4a602e98",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ActionRelationshipTypeVocab",
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ActionRelationshipTypeVocab",
                 "@value": "Initiated"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-2-2-3-90046c36-98f7-4f69-8566-2541eaad1dce",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ObservableObjectRelationshipVocab",
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "Initiated"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-2-3-2-c1e3518a-b808-49ee-9d68-73aaa6ec2ea7",
-            "@type": "observable:ObservableRelationship",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ActionRelationshipTypeVocab",
+            "@type": "uco-observable:ObservableRelationship",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ActionRelationshipTypeVocab",
                 "@value": "Contained_Within"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:relationship-2-3-3-cee42e22-3f76-465f-b737-62f2786eadfc",
-            "@type": "observable:ObservableRelationship",
+            "@type": "uco-observable:ObservableRelationship",
             "rdfs:comment": "Note - this will be moved back to the PASS set after re-design of semi-open vocabularies.",
-            "core:isDirectional": true,
-            "core:kindOfRelationship": {
-                "@type": "vocabulary:ObservableObjectRelationshipVocab",
+            "uco-core:isDirectional": true,
+            "uco-core:kindOfRelationship": {
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "Contained_Within"
             },
-            "core:source": {
+            "uco-core:source": {
                 "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361"
             },
-            "core:target": {
+            "uco-core:target": {
                 "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c"
             }
         },
         {
             "@id": "kb:action-00ae4a34-6114-4e9a-867f-4d81393dfd58",
-            "@type": "action:Action"
+            "@type": "uco-action:Action"
         },
         {
             "@id": "kb:action-1a5d1fe5-4fd0-4a80-912a-125b2130c099",
-            "@type": "action:Action"
+            "@type": "uco-action:Action"
         },
         {
             "@id": "kb:file-25c16531-7121-45b0-b520-54d721183361",
-            "@type": "observable:File"
+            "@type": "uco-observable:File"
         },
         {
             "@id": "kb:zipfile-edfbfe0f-3551-4009-91f6-5ebc1aa7766c",
-            "@type": "observable:ArchiveFile"
+            "@type": "uco-observable:ArchiveFile"
         }
     ]
 }

--- a/tests/examples/relationship_XFAIL_validation.ttl
+++ b/tests/examples/relationship_XFAIL_validation.ttl
@@ -1,9 +1,9 @@
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-vocabulary: <https://ontology.unifiedcyberontology.org/uco/vocabulary/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -14,181 +14,181 @@
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-1-1-2-2e668923-bfb7-4f54-afb6-66074ab5b9b0> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "CUSTOM_Influenced"^^vocabulary:ActionRelationshipTypeVocab ;
+			sh:value "CUSTOM_Influenced"^^uco-vocabulary:ActionRelationshipTypeVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-1-1-3-35598cb0-1770-49af-a417-51e91774df89> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "CUSTOM_Influenced"^^vocabulary:ObservableObjectRelationshipVocab ;
+			sh:value "CUSTOM_Influenced"^^uco-vocabulary:ObservableObjectRelationshipVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-1-2-2-3ee0cc25-5923-40df-ba8f-0cce5f18f724> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Initiated"^^vocabulary:ActionRelationshipTypeVocab ;
+			sh:value "Initiated"^^uco-vocabulary:ActionRelationshipTypeVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-1-2-3-46da302e-cff3-4634-bcf8-6f52649e2496> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Initiated"^^vocabulary:ObservableObjectRelationshipVocab ;
+			sh:value "Initiated"^^uco-vocabulary:ObservableObjectRelationshipVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-1-3-2-746aeee5-c857-4afb-8dba-85d5d60be279> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Contained_Within"^^vocabulary:ActionRelationshipTypeVocab ;
+			sh:value "Contained_Within"^^uco-vocabulary:ActionRelationshipTypeVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-1-3-3-779c2646-dd1d-4fac-9e22-5a14bd78c6ea> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Contained_Within"^^vocabulary:ObservableObjectRelationshipVocab ;
+			sh:value "Contained_Within"^^uco-vocabulary:ObservableObjectRelationshipVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-2-1-2-800dd373-2916-4104-a2bb-2715cbc80804> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "CUSTOM_Influenced"^^vocabulary:ActionRelationshipTypeVocab ;
+			sh:value "CUSTOM_Influenced"^^uco-vocabulary:ActionRelationshipTypeVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-2-1-3-803a8e5c-f09a-403d-9c8d-91b08a3c0bbd> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "CUSTOM_Influenced"^^vocabulary:ObservableObjectRelationshipVocab ;
+			sh:value "CUSTOM_Influenced"^^uco-vocabulary:ObservableObjectRelationshipVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-2-2-2-851c5f1a-1f1e-4315-b7b8-6d7f4a602e98> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Initiated"^^vocabulary:ActionRelationshipTypeVocab ;
+			sh:value "Initiated"^^uco-vocabulary:ActionRelationshipTypeVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-2-2-3-90046c36-98f7-4f69-8566-2541eaad1dce> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Initiated"^^vocabulary:ObservableObjectRelationshipVocab ;
+			sh:value "Initiated"^^uco-vocabulary:ObservableObjectRelationshipVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-2-3-2-c1e3518a-b808-49ee-9d68-73aaa6ec2ea7> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Contained_Within"^^vocabulary:ActionRelationshipTypeVocab ;
+			sh:value "Contained_Within"^^uco-vocabulary:ActionRelationshipTypeVocab ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/relationship-2-3-3-cee42e22-3f76-465f-b737-62f2786eadfc> ;
 			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
-			sh:resultPath core:kindOfRelationship ;
+			sh:resultPath uco-core:kindOfRelationship ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 			sh:sourceShape [
 				sh:datatype xsd:string ;
 				sh:maxCount "1"^^xsd:integer ;
 				sh:nodeKind sh:Literal ;
-				sh:path core:kindOfRelationship ;
+				sh:path uco-core:kindOfRelationship ;
 			] ;
-			sh:value "Contained_Within"^^vocabulary:ObservableObjectRelationshipVocab ;
+			sh:value "Contained_Within"^^uco-vocabulary:ObservableObjectRelationshipVocab ;
 		]
 		;
 	.

--- a/tests/examples/thread_PASS.json
+++ b/tests/examples/thread_PASS.json
@@ -3,13 +3,13 @@
         "co": "http://purl.org/co/",
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:thread-1c94da2d-0a8d-4ae9-95e1-d3977466f4dd",
-            "@type": "types:Thread",
+            "@type": "uco-types:Thread",
             "co:item": [
                 {
                     "@id": "kb:thread-item-85b644e5-da20-43af-b899-1d55c249def8"
@@ -24,8 +24,8 @@
         },
         {
             "@id": "kb:thread-item-85b644e5-da20-43af-b899-1d55c249def8",
-            "@type": "types:ThreadItem",
-            "types:threadNextItem": [
+            "@type": "uco-types:ThreadItem",
+            "uco-types:threadNextItem": [
                 {
                     "@id": "kb:thread-item-a8c06685-1d5e-4f60-866e-16af567cf218"
                 },
@@ -36,15 +36,15 @@
         },
         {
             "@id": "kb:thread-item-a8c06685-1d5e-4f60-866e-16af567cf218",
-            "@type": "types:ThreadItem",
-            "types:threadPreviousItem": {
+            "@type": "uco-types:ThreadItem",
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:thread-item-85b644e5-da20-43af-b899-1d55c249def8"
             }
         },
         {
             "@id": "kb:thread-item-e9c2219b-9881-47ef-bc73-fb9240c69238",
-            "@type": "types:ThreadItem",
-            "types:threadPreviousItem": {
+            "@type": "uco-types:ThreadItem",
+            "uco-types:threadPreviousItem": {
                 "@id": "kb:thread-item-85b644e5-da20-43af-b899-1d55c249def8"
             }
         }

--- a/tests/examples/thread_XFAIL.json
+++ b/tests/examples/thread_XFAIL.json
@@ -1,25 +1,25 @@
 {
     "@context": {
         "co": "http://purl.org/co/",
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {
             "@id": "kb:uco-object-d99d4ad8-a6b4-4aa6-a609-4d01808845b7",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:uco-object-f53c2b09-cf45-494a-b587-936e7b550cac",
-            "@type": "core:UcoObject"
+            "@type": "uco-core:UcoObject"
         },
         {
             "@id": "kb:thread-1c73bebd-798e-4ea2-a1be-553db145e7b5",
-            "@type": "types:Thread",
-            "types:threadOriginItem": {
+            "@type": "uco-types:Thread",
+            "uco-types:threadOriginItem": {
                 "@id": "kb:uco-object-d99d4ad8-a6b4-4aa6-a609-4d01808845b7"
             },
             "co:item": {
@@ -32,7 +32,7 @@
         },
         {
             "@id": "kb:thread-1c73bebd-798e-4ea2-a1be-553db145e7b556fdd7c-6e02-45ee-8bb1-d6b1bad2840f",
-            "@type": "types:Thread",
+            "@type": "uco-types:Thread",
             "co:item": [
                 {
                     "@id": "kb:thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987"
@@ -44,7 +44,7 @@
         },
         {
             "@id": "kb:thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": {
                 "@id": "kb:thread-item-461295a0-d50d-42e7-8011-656db5762ff6"
             },
@@ -54,7 +54,7 @@
         },
         {
             "@id": "kb:thread-item-461295a0-d50d-42e7-8011-656db5762ff6",
-            "@type": "types:ThreadItem",
+            "@type": "uco-types:ThreadItem",
             "co:itemContent": [
                 {
                     "@id": "kb:uco-object-d99d4ad8-a6b4-4aa6-a609-4d01808845b7"
@@ -69,7 +69,7 @@
         },
         {
             "@id": "kb:thread-857a1b51-a93d-4202-80c3-83408249474f",
-            "@type": "types:Thread",
+            "@type": "uco-types:Thread",
             "co:item": [
                 {
                     "@id": "kb:thread-item-a921e6f5-6920-4868-8634-451010d4164c"
@@ -85,22 +85,22 @@
         },
         {
             "@id": "kb:thread-item-a921e6f5-6920-4868-8634-451010d4164c",
-            "@type": "types:ThreadItem",
-            "types:threadNextItem": {
+            "@type": "uco-types:ThreadItem",
+            "uco-types:threadNextItem": {
                 "@id": "kb:thread-item-cac63c40-fce8-4e63-950f-a62a2df36f1d"
             }
         },
         {
             "@id": "kb:thread-item-b78a0387-3a63-49ab-8439-173be968b2d2",
-            "@type": "types:ThreadItem",
-            "types:threadNextItem": {
+            "@type": "uco-types:ThreadItem",
+            "uco-types:threadNextItem": {
                 "@id": "kb:thread-item-cac63c40-fce8-4e63-950f-a62a2df36f1d"
             }
         },
         {
             "@id": "kb:thread-item-cac63c40-fce8-4e63-950f-a62a2df36f1d",
-            "@type": "types:ThreadItem",
-            "types:threadPreviousItem": [
+            "@type": "uco-types:ThreadItem",
+            "uco-types:threadPreviousItem": [
                 {
                     "@id": "kb:thread-item-a921e6f5-6920-4868-8634-451010d4164c"
                 },

--- a/tests/examples/thread_XFAIL_validation.ttl
+++ b/tests/examples/thread_XFAIL_validation.ttl
@@ -1,11 +1,11 @@
 @prefix co: <http://purl.org/co/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix uco-co: <https://ontology.unifiedcyberontology.org/co/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -25,12 +25,12 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/thread-1c73bebd-798e-4ea2-a1be-553db145e7b5> ;
-			sh:resultMessage "Value does not have class types:ThreadItem" ;
+			sh:resultMessage "Value does not have class uco-types:ThreadItem" ;
 			sh:resultPath co:item ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class types:ThreadItem ;
+				sh:class uco-types:ThreadItem ;
 				sh:path co:item ;
 			] ;
 			sh:value <http://example.org/kb/uco-object-d99d4ad8-a6b4-4aa6-a609-4d01808845b7> ;
@@ -38,11 +38,11 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/thread-1c73bebd-798e-4ea2-a1be-553db145e7b5> ;
-			sh:resultMessage "Value does not have class types:ThreadItem" ;
-			sh:resultPath types:threadOriginItem ;
+			sh:resultMessage "Value does not have class uco-types:ThreadItem" ;
+			sh:resultPath uco-types:threadOriginItem ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
-			sh:sourceShape types:threadOriginItem-subjects-shape ;
+			sh:sourceShape uco-types:threadOriginItem-subjects-shape ;
 			sh:value <http://example.org/kb/uco-object-d99d4ad8-a6b4-4aa6-a609-4d01808845b7> ;
 		] ,
 		[
@@ -57,12 +57,12 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987> ;
-			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultMessage "Value does not have class uco-core:UcoObject" ;
 			sh:resultPath co:itemContent ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
 			sh:sourceShape [
-				sh:class core:UcoObject ;
+				sh:class uco-core:UcoObject ;
 				sh:path co:itemContent ;
 			] ;
 			sh:value <http://example.org/kb/thread-item-461295a0-d50d-42e7-8011-656db5762ff6> ;

--- a/tests/examples/uco_thing_XFAIL.json
+++ b/tests/examples/uco_thing_XFAIL.json
@@ -1,22 +1,22 @@
 {
     "@context": {
-        "core": "https://ontology.unifiedcyberontology.org/uco/core/",
         "kb": "http://example.org/kb/",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/"
     },
     "@graph": [
         {
-            "@type": "core:UcoThing",
+            "@type": "uco-core:UcoThing",
             "rdfs:comment": "Triggers Violation-severity violation of node being a blank node."
         },
         {
             "@id": "kb:uco-thing-x",
-            "@type": "core:UcoThing",
+            "@type": "uco-core:UcoThing",
             "rdfs:comment": "Triggers Info-severity violation of IRI not ending with UUID."
         },
         {
             "@id": "kb:uco-thing-eb10f281-566c-a946-b360-c228d74a493b",
-            "@type": "core:UcoThing",
+            "@type": "uco-core:UcoThing",
             "rdfs:comment": "Triggers Info-severity violation of IRI not ending with UUID - more subtly, the version field is incorrect.",
             "rdfs:seeAlso": {
                 "@id": "https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.3"

--- a/tests/examples/uco_thing_XFAIL_validation.ttl
+++ b/tests/examples/uco_thing_XFAIL_validation.ttl
@@ -1,8 +1,8 @@
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 []
@@ -20,10 +20,10 @@
 				sh:message "UcoThings are suggested to end with a UUID."@en ;
 				sh:select '''
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			SELECT $this
 			WHERE {
-			        $this a/rdfs:subClassOf* core:UcoThing .
+			        $this a/rdfs:subClassOf* uco-core:UcoThing .
 			        FILTER (
 			                ! REGEX (
 			                        STR($this),
@@ -35,7 +35,7 @@
 		''' ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape core:UcoThing-identifier-regex-shape ;
+			sh:sourceShape uco-core:UcoThing-identifier-regex-shape ;
 			sh:value <http://example.org/kb/uco-thing-eb10f281-566c-a946-b360-c228d74a493b> ;
 		] ,
 		[
@@ -49,10 +49,10 @@
 				sh:message "UcoThings are suggested to end with a UUID."@en ;
 				sh:select '''
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			SELECT $this
 			WHERE {
-			        $this a/rdfs:subClassOf* core:UcoThing .
+			        $this a/rdfs:subClassOf* uco-core:UcoThing .
 			        FILTER (
 			                ! REGEX (
 			                        STR($this),
@@ -64,13 +64,13 @@
 		''' ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape core:UcoThing-identifier-regex-shape ;
+			sh:sourceShape uco-core:UcoThing-identifier-regex-shape ;
 			sh:value <http://example.org/kb/uco-thing-x> ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode [
-				a core:UcoThing ;
+				a uco-core:UcoThing ;
 				rdfs:comment "Triggers Violation-severity violation of node being a blank node." ;
 			] ;
 			sh:resultMessage "UcoThings are required to not be blank nodes." ;
@@ -80,25 +80,25 @@
 				sh:message "UcoThings are required to not be blank nodes."@en ;
 				sh:select """
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			SELECT $this
 			WHERE {
-			        $this a/rdfs:subClassOf* core:UcoThing .
+			        $this a/rdfs:subClassOf* uco-core:UcoThing .
 			        FILTER isBlank ($this)
 			}
 		""" ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape core:UcoThing ;
+			sh:sourceShape uco-core:UcoThing ;
 			sh:value [
-				a core:UcoThing ;
+				a uco-core:UcoThing ;
 				rdfs:comment "Triggers Violation-severity violation of node being a blank node." ;
 			] ;
 		] ,
 		[
 			a sh:ValidationResult ;
 			sh:focusNode [
-				a core:UcoThing ;
+				a uco-core:UcoThing ;
 				rdfs:comment "Triggers Violation-severity violation of node being a blank node." ;
 			] ;
 			sh:resultMessage "UcoThings are suggested to end with a UUID." ;
@@ -109,10 +109,10 @@
 				sh:message "UcoThings are suggested to end with a UUID."@en ;
 				sh:select '''
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			SELECT $this
 			WHERE {
-			        $this a/rdfs:subClassOf* core:UcoThing .
+			        $this a/rdfs:subClassOf* uco-core:UcoThing .
 			        FILTER (
 			                ! REGEX (
 			                        STR($this),
@@ -124,9 +124,9 @@
 		''' ;
 			] ;
 			sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
-			sh:sourceShape core:UcoThing-identifier-regex-shape ;
+			sh:sourceShape uco-core:UcoThing-identifier-regex-shape ;
 			sh:value [
-				a core:UcoThing ;
+				a uco-core:UcoThing ;
 				rdfs:comment "Triggers Violation-severity violation of node being a blank node." ;
 			] ;
 		]

--- a/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL.ttl
+++ b/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL.ttl
@@ -1,18 +1,18 @@
 @prefix co: <http://purl.org/co/> .
-@prefix core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix ex: <http://example.org/ontology/> .
-@prefix observable: <https://ontology.unifiedcyberontology.org/uco/obserable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/obserable/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:IPAddressRoute
 	a owl:Class ;
-	rdfs:comment "This is expected to trigger a disjointed-classes violation, once subclass expansion occurs.  This example copies subclass axioms from co:, core:, and observable:."@en ;
+	rdfs:comment "This is expected to trigger a disjointed-classes violation, once subclass expansion occurs.  This example copies subclass axioms from co:, uco-core:, and uco-observable:."@en ;
 	rdfs:subClassOf
 		co:List ,
-		observable:ObservableObject
+		uco-observable:ObservableObject
 		;
 	.
 
@@ -37,21 +37,21 @@ co:List
 	] ;
 	.
 
-core:Item
+uco-core:Item
 	a owl:Class ;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	.
 
-observable:ObservableObject
+uco-observable:ObservableObject
 	a owl:Class ;
 	rdfs:subClassOf
-		core:Item ,
-		observable:Observable
+		uco-core:Item ,
+		uco-observable:Observable
 		;
 	.
 
-observable:Observable
+uco-observable:Observable
 	a owl:Class ;
-	rdfs:subClassOf core:UcoObject ;
+	rdfs:subClassOf uco-core:UcoObject ;
 	.
 

--- a/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL_validation.ttl
+++ b/tests/shapes/examples_uco_qc/co_Collection_core_UcoObject_XFAIL_validation.ttl
@@ -11,21 +11,21 @@
 	sh:result [
 		a sh:ValidationResult ;
 		sh:focusNode <http://example.org/ontology/IPAddressRoute> ;
-		sh:resultMessage "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and core:UcoObject.  See Issue 509 for suggested implementation alterations." ;
+		sh:resultMessage "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and uco-core:UcoObject.  See Issue 509 for suggested implementation alterations." ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraint [
 			a sh:SPARQLConstraint ;
 			rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/509> ;
-			sh:message "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and core:UcoObject.  See Issue 509 for suggested implementation alterations."@en ;
+			sh:message "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and uco-core:UcoObject.  See Issue 509 for suggested implementation alterations."@en ;
 			sh:select """
 			PREFIX co: <http://purl.org/co/>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 			SELECT $this
 			WHERE {
 				$this
 					rdfs:subClassOf*/(owl:intersectionOf/rdf:rest*/rdf:first)?/rdfs:subClassOf* co:Collection ;
-					rdfs:subClassOf* core:UcoObject ;
+					rdfs:subClassOf* uco-core:UcoObject ;
 					.
 			}
 		""" ;

--- a/tests/shapes/uco-qc.ttl
+++ b/tests/shapes/uco-qc.ttl
@@ -15,16 +15,16 @@ uco-qc:disjointedness-co-collection-core-uco-object
 	sh:sparql [
 		a sh:SPARQLConstraint ;
 		rdfs:seeAlso <https://github.com/ucoProject/UCO/issues/509> ;
-		sh:message "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and core:UcoObject.  See Issue 509 for suggested implementation alterations."@en ;
+		sh:message "The focus node is defined as a subclass of two classes intended to be disjoint, co:Collection and uco-core:UcoObject.  See Issue 509 for suggested implementation alterations."@en ;
 		sh:select """
 			PREFIX co: <http://purl.org/co/>
-			PREFIX core: <https://ontology.unifiedcyberontology.org/uco/core/>
+			PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 			SELECT $this
 			WHERE {
 				$this
 					rdfs:subClassOf*/(owl:intersectionOf/rdf:rest*/rdf:first)?/rdfs:subClassOf* co:Collection ;
-					rdfs:subClassOf* core:UcoObject ;
+					rdfs:subClassOf* uco-core:UcoObject ;
 					.
 			}
 		""" ;


### PR DESCRIPTION
This Pull Request will resolve all backwards-compatible requirements of Issue #651 .

The total changes for Issue 651 will be part of this PR.  However, for review purposes, the changes specific to adding support for the time relations (properties, SHACL shapes, tests, etc.) are going into a separate PR.  The initial needed change is adapting all prefixes to start with `uco-` for disambiguating from OWL-Time (e.g., `core:UcoObject` will now read `uco-core:UcoObject`), and that turns out to be thousands of changed lines.

For the sake of easing review on GitHub, see [this tab on PR #658](https://github.com/ucoProject/UCO/pull/658/files), which shows the diffs that aren't just prefix-change effects.  PR 658 will be merged into this PR after the Solutions Approval vote.

This PR will still track the testing progress.


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed
- [x] CI passes in UCO feature branch against `develop`
- [ ] CI passes in UCO current `unstable` branch ([merge-commit](#TODO-commit))
- [ ] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([merge-commit](#TODO-commit))
- [ ] Impact on SHACL validation [reviewed](#TODO-commit) for CASE-Corpora
- [ ] Impact on SHACL validation [remediated](#TODO-commit) for CASE-Corpora
- [ ] Impact on SHACL validation [reviewed](#TODO-commit) for CASE-Examples
- [ ] Impact on SHACL validation [remediated](#TODO-commit) for CASE-Examples
- [ ] Impact on SHACL validation [reviewed](#TODO-commit) for casework.github.io
- [ ] Impact on SHACL validation [remediated](#TODO-commit) for casework.github.io
- [x] Milestone linked
- [ ] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status)