### PR TITLE
Fix two dead sh:targetClass IRIs in analysis.ttl

### DIFF
--- a/ontology/uco/analysis/analysis.ttl
+++ b/ontology/uco/analysis/analysis.ttl
@@ -28,7 +28,7 @@ analysis:Analysis
 	rdfs:subClassOf action:Action ;
 	rdfs:label "Analysis"@en ;
 	rdfs:comment "An analysis is an action of detailed examination of something in order to understand its nature, context or essential features."@en ;
-	sh:targetClass action:Analysis ;
+	sh:targetClass analysis:Analysis ;
 	.
 
 analysis:AnalyticResult
@@ -52,7 +52,7 @@ analysis:AnalyticResult
 			sh:path analysis:resultContent ;
 		]
 		;
-	sh:targetClass analysis:AnalysicResult ;
+	sh:targetClass analysis:AnalyticResult ;
 	.
 
 analysis:AnalyticResultFacet


### PR DESCRIPTION
This Pull Request is a bug-fix change proposal, believed to be of low risk to the ontology and its downstream resources.

`ontology/uco/analysis/analysis.ttl` aims two node shapes at IRIs that are not the class (confirmed on #694):

1. `analysis:Analysis` currently has `sh:targetClass action:Analysis` (wrong namespace).
2. `analysis:AnalyticResult` currently has `sh:targetClass analysis:AnalysicResult` (typo).

Both targets become the class IRI already defined in this file. Diff is two tokens (L31 and L55).

Closes #694.

## Out of scope

- UCO #663 / #662
- `catalog-v001.xml` 1.4.0 version stamps
- New terms

I am a volunteer. If either line is intentional, please say so and I will stand down.

## Validation

- [x] `make check` (UCO CI)
- [x] `make --directory ontology/uco/analysis --file ../../../src/review.mk check`

Boxes match commands actually run after the two tokens.

Box run 2026-08-22 11:00–11:18 PM AKDT on `/workspace/checkouts/UCO` `develop` @ `586ac69` (`Merge pull request #688 from ucoProject/release-1.5.0`) plus this two-token patch only. Not bundled with #663 / #662. Python 3.13.5.

### file-level (after `rm -f .check-analysis.ttl`)

```
java -jar /workspace/checkouts/UCO/lib/rdf-toolkit.jar \
  --inline-blank-nodes \
  --source analysis.ttl \
  --source-format turtle \
  --target .check-analysis.ttl_ \
  --target-format turtle
mv .check-analysis.ttl_ .check-analysis.ttl
diff analysis.ttl .check-analysis.ttl	\
  || (echo "ERROR:src/review.mk:The local analysis.ttl does not match the normalized version. If the above reported changes look fine, run 'cp .check-analysis.ttl analysis.ttl' while in the sub-folder ontology/$(basename analysis.ttl .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
EXIT:0
```

### `make check`

Elapsed 1078559 ms, ended 2026-08-23T07:18:55Z = 11:18 PM AKDT. Exact lines from the run:

```
make \
  --directory analysis \
  --file /workspace/checkouts/UCO/src/review.mk \
  check
make[3]: Entering directory '/workspace/checkouts/UCO/ontology/uco/analysis'
diff analysis.ttl .check-analysis.ttl	\
  || (echo "ERROR:src/review.mk:The local analysis.ttl does not match the normalized version. If the above reported changes look fine, run 'cp .check-analysis.ttl analysis.ttl' while in the sub-folder ontology/$(basename analysis.ttl .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
make[3]: Leaving directory '/workspace/checkouts/UCO/ontology/uco/analysis'
```

Four `pyshacl` reports on the monolithic (closure-qc, metashacl, uco-qc, owl.ttl) each printed:

```
[] a sh:ValidationReport ;
    sh:conforms true .
```

```
source /workspace/checkouts/UCO/venv/bin/activate \
  && pytest \
    --ignore examples \
    --ignore shapes \
    --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace/checkouts/UCO/tests
collected 4 items

test_uco_monolithic.py ....                                              [100%]

============================== 4 passed in 0.77s ===============================
```

```
source /workspace/checkouts/UCO/venv/bin/activate \
  && pytest \
    --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace/checkouts/UCO/tests/examples
collected 41 items

test_validation.py .....................x..............x.x..             [100%]

=============================== warnings summary ===============================
test_validation.py::test_message_thread
  /workspace/checkouts/UCO/venv/lib/python3.13/site-packages/rdflib/plugins/parsers/jsonld.py:159: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    conj_sink = ConjunctiveGraph(store=sink.store, identifier=sink.identifier)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 38 passed, 3 xfailed, 1 warning in 0.96s ===================
make[2]: Leaving directory '/workspace/checkouts/UCO/tests/examples'
make[1]: Leaving directory '/workspace/checkouts/UCO/tests'
EXIT:0
```

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes, or close it.