### PR TITLE
Require IRI nodeKind on configuration:itemObject

### DIFF
--- a/ontology/uco/configuration/configuration.ttl
+++ b/ontology/uco/configuration/configuration.ttl
@@ -59,7 +59,7 @@ configuration:ConfigurationEntry
 	sh:property
 		[
 			sh:class core:UcoObject ;
-			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:nodeKind sh:IRI ;
 			sh:path configuration:itemObject ;
 		] ,
 		[


### PR DESCRIPTION
This Pull Request is a bug-fix change proposal, believed to be of low risk to the ontology and its downstream resources.

`configuration:ConfigurationEntry` currently lets `itemObject` be a blank node (`sh:BlankNodeOrIRI`). The range is `core:UcoObject`, which must be IRI-identified. The shape becomes `sh:IRI`.

`configurationEntry` and `dependencies` stay `sh:BlankNodeOrIRI`. The `sh:xone` itemObject vs itemValue split is untouched.

Closes #663.

## Out of scope

- UCO #694 / #662
- Other `BlankNodeOrIRI` shapes on `Configuration` (`configurationEntry`, `dependencies`)
- The `sh:xone` itemObject vs itemValue split
- New terms

One token. Alex named this shape in #663. I am a volunteer; if blank-node objects are intentional, I will stand down.

## Validation

- [x] `make check` (UCO CI)
- [x] `make --directory ontology/uco/configuration --file ../../../src/review.mk check`

Boxes match commands actually run after the one token.

Box run 2026-08-22 11:19–11:36 PM AKDT on `/workspace/checkouts/UCO` develop `586ac690d9c9ca02ad3b9d94faf0b0a9dc91a615` (`586ac69 Merge pull request #688 from ucoProject/release-1.5.0`). Working tree at run time: one token in `ontology/uco/configuration/configuration.ttl` only (`itemObject` `BlankNodeOrIRI` → `IRI`). `analysis.ttl` was reset to HEAD so this is not bundled with #694. Catalogs not in this packet. Python 3.13.5.

A first `make check` started on this same tree at 11:21 PM AKDT exited 2 (`rm: cannot remove '__uco_monolithic.ttl': No such file or directory` / `Makefile:104`) because it raced another `make check` in the same checkout. That failed run is not the checked box. The checked `make check` is the completed independent run below (started 11:19 PM AKDT, EXIT:0, elapsed 1003192 ms, ended 2026-08-23T07:36:34Z = 11:36 PM AKDT).

### `make --directory ontology/uco/configuration --file ../../../src/review.mk check`

```
make: Entering directory '/workspace/checkouts/UCO/ontology/uco/configuration'
diff configuration.ttl .check-configuration.ttl	\
  || (echo "ERROR:src/review.mk:The local configuration.ttl does not match the normalized version. If the above reported changes look fine, run 'cp .check-configuration.ttl configuration.ttl' while in the sub-folder ontology/$(basename configuration.ttl .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
make: Leaving directory '/workspace/checkouts/UCO/ontology/uco/configuration'
EXIT:0
```

### `make check`

Exact lines from the completed 663-only run. `git status --short` at start printed ` M ontology/uco/configuration/configuration.ttl`.

```
make \
  --directory configuration \
  --file /workspace/checkouts/UCO/src/review.mk \
  check
make[3]: Entering directory '/workspace/checkouts/UCO/ontology/uco/configuration'
java -jar /workspace/checkouts/UCO/lib/rdf-toolkit.jar \
  --inline-blank-nodes \
  --source configuration.ttl \
  --source-format turtle \
  --target .check-configuration.ttl_ \
  --target-format turtle
mv .check-configuration.ttl_ .check-configuration.ttl
diff configuration.ttl .check-configuration.ttl	\
  || (echo "ERROR:src/review.mk:The local configuration.ttl does not match the normalized version. If the above reported changes look fine, run 'cp .check-configuration.ttl configuration.ttl' while in the sub-folder ontology/$(basename configuration.ttl .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
make[3]: Leaving directory '/workspace/checkouts/UCO/ontology/uco/configuration'
```

`tests/inheritance_review.ttl` after `case_shacl_inheritance_reviewer --strict`:

```
[] a shir:InheritanceValidationReport ;
    sh:conforms true .
```

Four `pyshacl` reports on the monolithic (closure-qc, metashacl, uco-qc, owl.ttl) each printed:

```
[] a sh:ValidationReport ;
    sh:conforms true .
```

```
source /workspace/checkouts/UCO/venv/bin/activate \
  && pytest \
    --ignore examples \
    --ignore shapes \
    --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace/checkouts/UCO/tests
collected 4 items

test_uco_monolithic.py ....                                              [100%]

============================== 4 passed in 0.76s ===============================
```

`configuration_setting_PASS.json` / `configuration_setting_XFAIL.json` ran in `tests/examples` (PASS fixture already uses an IRI `itemObject`). Final examples pytest:

```
source /workspace/checkouts/UCO/venv/bin/activate \
  && pytest \
    --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace/checkouts/UCO/tests/examples
collected 41 items

test_validation.py .....................x..............x.x..             [100%]

=============================== warnings summary ===============================
test_validation.py::test_message_thread
  /workspace/checkouts/UCO/venv/lib/python3.13/site-packages/rdflib/plugins/parsers/jsonld.py:159: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    conj_sink = ConjunctiveGraph(store=sink.store, identifier=sink.identifier)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 38 passed, 3 xfailed, 1 warning in 1.01s ===================
make[2]: Leaving directory '/workspace/checkouts/UCO/tests/examples'
make[1]: Leaving directory '/workspace/checkouts/UCO/tests'
EXIT:0
```

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes, or close it.