### PR TITLE
Share Compilation object PropertyShape with both children

### DIFF
--- a/ontology/uco/core/core.ttl
+++ b/ontology/uco/core/core.ttl
@@ -90,6 +90,11 @@ core:Compilation
 	rdfs:subClassOf core:UcoObject ;
 	rdfs:label "Compilation"@en ;
 	rdfs:comment "A compilation is a grouping of things."@en ;
+	sh:property [
+		sh:class core:UcoObject ;
+		sh:nodeKind sh:IRI ;
+		sh:path core:object ;
+	] ;
 	sh:targetClass core:Compilation ;
 	.
 


### PR DESCRIPTION
This Pull Request resolves all requirements of Issue #662.

Closes #662.

`ContextualCompilation` and `EnclosingCompilation` both constrain `uco-core:object` to an IRI `UcoObject`. `Compilation` has no property shapes. This adds that shared shape on `Compilation`:

- `sh:class core:UcoObject`
- `sh:nodeKind sh:IRI`
- `sh:path core:object`

`EnclosingCompilation`'s extra `sh:minCount 1` stays on the child. Child shapes stay so SHACL still binds without RDFS subclass inference.

## Files

1. `ontology/uco/core/core.ttl` (`core:Compilation` only)

## Out of scope

- UCO #694 / #663
- Removing the child `object` shapes
- Moving `minCount 1` onto `Compilation`
- New terms

## Validation

- [x] `make --directory ontology/uco/core --file ../../../src/review.mk check`
- [x] `make check` (UCO CI)

Boxes match commands actually run after this Compilation-only cut.

Run 2026-08-23 2:01–2:18 PM AKDT on a local `develop` checkout @ `586ac69` (`586ac690d9c9ca02ad3b9d94faf0b0a9dc91a615`, Merge pull request #688 from ucoProject/release-1.5.0) plus this change only (`ontology/uco/core/core.ttl`: shared three constraints on `core:Compilation`). Not bundled with #694 / #663. Children and `EnclosingCompilation` `minCount 1` left in place. Python 3.13.5.

### file-level (`make --directory ontology/uco/core --file ../../../src/review.mk check`)

Started 2026-08-23T22:01:07Z = 2:01 PM AKDT. Exact lines from the run:

```
make: Entering directory '/workspace/checkouts/UCO/ontology/uco/core'
java -jar /workspace/checkouts/UCO/lib/rdf-toolkit.jar \
  --inline-blank-nodes \
  --source core.ttl \
  --source-format turtle \
  --target .check-core.ttl_ \
  --target-format turtle
mv .check-core.ttl_ .check-core.ttl
diff core.ttl .check-core.ttl	\
  || (echo "ERROR:src/review.mk:The local core.ttl does not match the normalized version. If the above reported changes look fine, run 'cp .check-core.ttl core.ttl' while in the sub-folder ontology/$(basename core.ttl .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
make: Leaving directory '/workspace/checkouts/UCO/ontology/uco/core'
EXIT:0
```

### `make check`

Started 2026-08-23T22:01:14Z = 2:01 PM AKDT. Ended 2026-08-23T22:18:46Z = 2:18 PM AKDT. Exact lines from the run:

```
make \
  --directory core \
  --file /workspace/checkouts/UCO/src/review.mk \
  check
make[3]: Entering directory '/workspace/checkouts/UCO/ontology/uco/core'
diff core.ttl .check-core.ttl	\
  || (echo "ERROR:src/review.mk:The local core.ttl does not match the normalized version. If the above reported changes look fine, run 'cp .check-core.ttl core.ttl' while in the sub-folder ontology/$(basename core.ttl .ttl)/ to get a file ready to commit to Git." >&2 ; exit 1)
make[3]: Leaving directory '/workspace/checkouts/UCO/ontology/uco/core'
```

`tests/inheritance_review.ttl` after `case_shacl_inheritance_reviewer --strict`:

```
[] a shir:InheritanceValidationReport ;
    sh:conforms true .
```

Four `pyshacl` reports on the monolithic (closure-qc, metashacl, uco-qc, owl.ttl) each printed:

```
[] a sh:ValidationReport ;
    sh:conforms true .
```

```
source /workspace/checkouts/UCO/venv/bin/activate \
  && pytest \
    --ignore examples \
    --ignore shapes \
    --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace/checkouts/UCO/tests
collected 4 items

test_uco_monolithic.py ....                                              [100%]

============================== 4 passed in 0.83s ===============================
```

```
source /workspace/checkouts/UCO/venv/bin/activate \
  && pytest \
    --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace/checkouts/UCO/tests/examples
collected 41 items

test_validation.py .....................x..............x.x..             [100%]

=============================== warnings summary ===============================
test_validation.py::test_message_thread
  /workspace/checkouts/UCO/venv/lib/python3.13/site-packages/rdflib/plugins/parsers/jsonld.py:159: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    conj_sink = ConjunctiveGraph(store=sink.store, identifier=sink.identifier)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 38 passed, 3 xfailed, 1 warning in 1.08s ===================
make[2]: Leaving directory '/workspace/checkouts/UCO/tests/examples'
make[1]: Leaving directory '/workspace/checkouts/UCO/tests'
EXIT:0
```

## Maintainer question

Is the committee issue-reference form the right first screen, and is the shared Compilation shape the cut you want?

This uses the official issue-reference sentence, not the Bug-fix sentence, because adding a shared `sh:PropertyShape` is committee-shaped.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.
