### PR TITLE
catalog-v001.xml still names 1.4.0 after versionIRI 1.5.0

### DIFF
--- a/ontology/uco/action/catalog-v001.xml
+++ b/ontology/uco/action/catalog-v001.xml
@@ -2,11 +2,11 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
     <uri id="User Entered Import Resolution" uri="../../../dependencies/collections-ontology/collections.owl" name="http://purl.org/co"/>
     <uri id="User Entered Import Resolution" uri="../../../dependencies/error/docs/current/error.ttl" name="http://purl.org/spar/error"/>
-    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action"/>
 </catalog>

--- a/ontology/uco/analysis/catalog-v001.xml
+++ b/ontology/uco/analysis/catalog-v001.xml
@@ -2,12 +2,12 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
     <uri id="User Entered Import Resolution" uri="../../../dependencies/collections-ontology/collections.owl" name="http://purl.org/co"/>
     <uri id="User Entered Import Resolution" uri="../../../dependencies/error/docs/current/error.ttl" name="http://purl.org/spar/error"/>
-    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../action/action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../action/action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="analysis.ttl" name="https://ontology.unifiedcyberontology.org/uco/analysis"/>
 </catalog>

--- a/ontology/uco/configuration/catalog-v001.xml
+++ b/ontology/uco/configuration/catalog-v001.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="configuration.ttl" name="https://ontology.unifiedcyberontology.org/uco/configuration"/>
 </catalog>

--- a/ontology/uco/identity/catalog-v001.xml
+++ b/ontology/uco/identity/catalog-v001.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity"/>
 </catalog>

--- a/ontology/uco/location/catalog-v001.xml
+++ b/ontology/uco/location/catalog-v001.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location"/>
 </catalog>

--- a/ontology/uco/marking/catalog-v001.xml
+++ b/ontology/uco/marking/catalog-v001.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="marking.ttl" name="https://ontology.unifiedcyberontology.org/uco/marking"/>
 </catalog>

--- a/ontology/uco/master/catalog-v001.xml
+++ b/ontology/uco/master/catalog-v001.xml
@@ -2,22 +2,22 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
     <uri id="User Entered Import Resolution" uri="../../../dependencies/collections-ontology/collections.owl" name="http://purl.org/co"/>
     <uri id="User Entered Import Resolution" uri="../../../dependencies/error/docs/current/error.ttl" name="http://purl.org/spar/error"/>
-    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../../owl/owl.ttl" name="https://ontology.unifiedcyberontology.org/owl/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../action/action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../analysis/analysis.ttl" name="https://ontology.unifiedcyberontology.org/uco/analysis/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../configuration/configuration.ttl" name="https://ontology.unifiedcyberontology.org/uco/configuration/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../identity/identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../marking/marking.ttl" name="https://ontology.unifiedcyberontology.org/uco/marking/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../observable/observable.ttl" name="https://ontology.unifiedcyberontology.org/uco/observable/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../role/role.ttl" name="https://ontology.unifiedcyberontology.org/uco/role/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../time/time.ttl" name="https://ontology.unifiedcyberontology.org/uco/time/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../tool/tool.ttl" name="https://ontology.unifiedcyberontology.org/uco/tool/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../victim/victim.ttl" name="https://ontology.unifiedcyberontology.org/uco/victim/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../../owl/owl.ttl" name="https://ontology.unifiedcyberontology.org/owl/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../action/action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../analysis/analysis.ttl" name="https://ontology.unifiedcyberontology.org/uco/analysis/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../configuration/configuration.ttl" name="https://ontology.unifiedcyberontology.org/uco/configuration/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../identity/identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../marking/marking.ttl" name="https://ontology.unifiedcyberontology.org/uco/marking/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../observable/observable.ttl" name="https://ontology.unifiedcyberontology.org/uco/observable/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../role/role.ttl" name="https://ontology.unifiedcyberontology.org/uco/role/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../time/time.ttl" name="https://ontology.unifiedcyberontology.org/uco/time/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../tool/tool.ttl" name="https://ontology.unifiedcyberontology.org/uco/tool/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../victim/victim.ttl" name="https://ontology.unifiedcyberontology.org/uco/victim/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="uco.ttl" name="https://ontology.unifiedcyberontology.org/uco/uco"/>
 </catalog>

--- a/ontology/uco/observable/catalog-v001.xml
+++ b/ontology/uco/observable/catalog-v001.xml
@@ -2,14 +2,14 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
     <uri id="User Entered Import Resolution" uri="../../../dependencies/collections-ontology/collections.owl" name="http://purl.org/co"/>
     <uri id="User Entered Import Resolution" uri="../../../dependencies/error/docs/current/error.ttl" name="http://purl.org/spar/error"/>
-    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../action/action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../configuration/configuration.ttl" name="https://ontology.unifiedcyberontology.org/uco/configuration/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../identity/identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../action/action.ttl" name="https://ontology.unifiedcyberontology.org/uco/action/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../configuration/configuration.ttl" name="https://ontology.unifiedcyberontology.org/uco/configuration/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../identity/identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../pattern/pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../types/types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="observable.ttl" name="https://ontology.unifiedcyberontology.org/uco/observable"/>
 </catalog>

--- a/ontology/uco/pattern/catalog-v001.xml
+++ b/ontology/uco/pattern/catalog-v001.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="pattern.ttl" name="https://ontology.unifiedcyberontology.org/uco/pattern"/>
 </catalog>

--- a/ontology/uco/role/catalog-v001.xml
+++ b/ontology/uco/role/catalog-v001.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="role.ttl" name="https://ontology.unifiedcyberontology.org/uco/role"/>
 </catalog>

--- a/ontology/uco/time/catalog-v001.xml
+++ b/ontology/uco/time/catalog-v001.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="time.ttl" name="https://ontology.unifiedcyberontology.org/uco/time"/>
 </catalog>

--- a/ontology/uco/tool/catalog-v001.xml
+++ b/ontology/uco/tool/catalog-v001.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../configuration/configuration.ttl" name="https://ontology.unifiedcyberontology.org/uco/configuration/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../identity/identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../configuration/configuration.ttl" name="https://ontology.unifiedcyberontology.org/uco/configuration/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../identity/identity.ttl" name="https://ontology.unifiedcyberontology.org/uco/identity/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../location/location.ttl" name="https://ontology.unifiedcyberontology.org/uco/location/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="tool.ttl" name="https://ontology.unifiedcyberontology.org/uco/tool"/>
 </catalog>

--- a/ontology/uco/types/catalog-v001.xml
+++ b/ontology/uco/types/catalog-v001.xml
@@ -2,8 +2,8 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
     <uri id="User Entered Import Resolution" uri="../../../dependencies/collections-ontology/collections.owl" name="http://purl.org/co"/>
     <uri id="User Entered Import Resolution" uri="../../../dependencies/error/docs/current/error.ttl" name="http://purl.org/spar/error"/>
-    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../../co/co.ttl" name="https://ontology.unifiedcyberontology.org/co/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../vocabulary/vocabulary.ttl" name="https://ontology.unifiedcyberontology.org/uco/vocabulary/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="types.ttl" name="https://ontology.unifiedcyberontology.org/uco/types"/>
 </catalog>

--- a/ontology/uco/victim/catalog-v001.xml
+++ b/ontology/uco/victim/catalog-v001.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
-    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.4.0"/>
-    <uri id="User Entered Import Resolution" uri="../role/role.ttl" name="https://ontology.unifiedcyberontology.org/uco/role/1.4.0"/>
+    <uri id="User Entered Import Resolution" uri="../core/core.ttl" name="https://ontology.unifiedcyberontology.org/uco/core/1.5.0"/>
+    <uri id="User Entered Import Resolution" uri="../role/role.ttl" name="https://ontology.unifiedcyberontology.org/uco/role/1.5.0"/>
     <uri id="User Entered Import Resolution" uri="victim.ttl" name="https://ontology.unifiedcyberontology.org/uco/victim"/>
 </catalog>


### PR DESCRIPTION
# catalog-v001.xml still names 1.4.0 after versionIRI 1.5.0

Committed Protégé catalogs still map imports to `…/1.4.0` while the sibling TTL already declares `owl:versionIRI` / `owl:versionInfo` 1.5.0. `ontology/uco/master/catalog-v001.xml` is 17× `/1.4.0`, 0× `/1.5.0`. The same stale `name=` values sit in the per-module catalogs. `src/create-catalog-v001.xml.py` walks `versionIRI`s, so a fresh generate would emit 1.5.0 names. CI is `make clean && make check`. `src/review.mk` generates catalogs then diffs Turtle only; `clean` deletes the catalogs. Generated catalogs are never diffed against the committed files.

This packet restamps those `name=` attributes to 1.5.0. Catalogs only. `uri=` paths stay. No `.ttl` file is in the diff.

## Files

Exact catalog paths in `PATCH.diff` (no glob). Each `name="…/1.4.0"` becomes `name="…/1.5.0"` (56 attributes):

1. `ontology/uco/master/catalog-v001.xml`
2. `ontology/uco/action/catalog-v001.xml`
3. `ontology/uco/analysis/catalog-v001.xml`
4. `ontology/uco/configuration/catalog-v001.xml`
5. `ontology/uco/identity/catalog-v001.xml`
6. `ontology/uco/location/catalog-v001.xml`
7. `ontology/uco/marking/catalog-v001.xml`
8. `ontology/uco/observable/catalog-v001.xml`
9. `ontology/uco/pattern/catalog-v001.xml`
10. `ontology/uco/role/catalog-v001.xml`
11. `ontology/uco/time/catalog-v001.xml`
12. `ontology/uco/tool/catalog-v001.xml`
13. `ontology/uco/types/catalog-v001.xml`
14. `ontology/uco/victim/catalog-v001.xml`

## Out of scope

- `ontology/uco/analysis/analysis.ttl`
- `ontology/uco/configuration/configuration.ttl`
- Compilation / `uco-core:object` shapes
- #695 #696 #697
- A `make` regen of Turtle, tests, or monolithic
- New UCO terms / 2.0

## How to review

The dest is the `name=` restamp. Open `ontology/uco/master/catalog-v001.xml` next to `ontology/uco/master/uco.ttl` L49 `owl:versionIRI …/uco/uco/1.5.0`. Every catalog `name=` that was 1.4.0 should now be 1.5.0. No analysis / configuration / Compilation TTL change.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.
